### PR TITLE
Add bulk + search protos and bazel to compile

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,7 @@
+# Enable proto3 optional fields
+build --proto_compiler=@com_google_protobuf//:protoc
+build --protocopt=--experimental_allow_proto3_optional
+
+# Set C++ standard to C++14
+build --cxxopt=-std=c++14
+build --host_cxxopt=-std=c++14

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,31 @@
+# protos/BUILD.bazel
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@rules_java//java:defs.bzl", "java_proto_library")
+load("@io_grpc_grpc_java//:java_grpc_library.bzl", "java_grpc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+proto_library(
+    name = "document_service_proto",
+    srcs = ["document_service.proto"],
+    deps = [
+        "//protos/schemas:document_proto",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+proto_library(
+    name = "search_service_proto",
+    srcs = ["search_service.proto"],
+    deps = [
+        "//protos/schemas:search_proto",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+# Java proto library
+java_proto_library(
+    name = "protos_java",
+    deps = [":document_service_proto", ":search_service_proto"],
+    visibility = ["//visibility:public"],
+)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 
 ### Added
+- Add bulk + search protos and bazel to compile ([#5](https://github.com/opensearch-project/opensearch-protobufs/pull/5))
 
 ### Removed
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,62 @@
+workspace(name = "proto_workspace")
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+# Protocol Buffers dependencies
+http_archive(
+    name = "com_google_protobuf",
+    sha256 = "4356e78744dfb2df3890282386c8568c85868116317d9b3ad80eb11c2aecf2ff",
+    strip_prefix = "protobuf-3.25.5",
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.25.5.tar.gz"],
+)
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+protobuf_deps()
+
+# Java rules
+http_archive(
+    name = "rules_java",
+    sha256 = "220b87d8cfabd22d1c6d8e3cdb4249abd4c93dcc152e0667db061fb1b957ee68",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/0.1.1/rules_java-0.1.1.tar.gz"],
+)
+
+load("@rules_java//java:repositories.bzl", "rules_java_dependencies")
+rules_java_dependencies()
+
+# Proto rules
+http_archive(
+    name = "rules_proto",
+    sha256 = "66bfdf8782796239d3875d37e7de19b1d94301e8972b3cbd2446b332429b4df1",
+    strip_prefix = "rules_proto-4.0.0",
+    urls = ["https://github.com/bazelbuild/rules_proto/archive/refs/tags/4.0.0.zip"],
+)
+
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+rules_proto_dependencies()
+rules_proto_toolchains()
+
+# gRPC dependencies
+http_archive(
+    name = "io_grpc_grpc_java",
+    sha256 = "c454e068bfb5d0b5bdb5e3d7e32cd1fc34aaf22202855e29e048f3ad338e57b2",
+    strip_prefix = "grpc-java-1.38.0",
+    urls = ["https://github.com/grpc/grpc-java/archive/v1.38.0.tar.gz"],
+)
+
+load("@io_grpc_grpc_java//:repositories.bzl", "grpc_java_repositories")
+grpc_java_repositories()
+
+# Additional dependencies for gRPC Java
+http_archive(
+    name = "com_google_code_findbugs_jsr305",
+    build_file = "@io_grpc_grpc_java//third_party:jsr305.BUILD",
+    sha256 = "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
+    urls = ["https://repo1.maven.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar"],
+)
+
+http_archive(
+    name = "com_google_guava_guava",
+    build_file = "@io_grpc_grpc_java//third_party:guava.BUILD",
+    sha256 = "36a666e3b71ae7f0f0dca23654b67e086e6c93d192f60ba5dfd5519db6c288c8",
+    urls = ["https://repo1.maven.org/maven2/com/google/guava/guava/31.0.1-jre/guava-31.0.1-jre.jar"],
+)

--- a/document_service.proto
+++ b/document_service.proto
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+syntax = "proto3";
+package org.opensearch.protobuf.services;
+
+option java_multiple_files = true;
+option java_package = "org.opensearch.protobuf.services";
+option java_outer_classname = "DocumentServiceProto";
+
+import "protos/schemas/document.proto";
+
+service DocumentService {
+  rpc Bulk(BulkRequest) returns (BulkResponse) {}
+}

--- a/protos/schemas/BUILD.bazel
+++ b/protos/schemas/BUILD.bazel
@@ -1,0 +1,46 @@
+# protos/schemas/BUILD.bazel
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@rules_java//java:defs.bzl", "java_proto_library")
+package(default_visibility = ["//visibility:public"])
+
+proto_library(
+    name = "common_proto",
+    srcs = ["common.proto"],
+    deps = [
+        "@com_google_protobuf//:struct_proto",
+    ],
+)
+
+proto_library(
+    name = "document_proto",
+    srcs = ["document.proto"],
+    deps = [
+        ":common_proto",
+        "@com_google_protobuf//:struct_proto",
+    ],
+)
+
+proto_library(
+    name = "search_proto",
+    srcs = ["search.proto"],
+    deps = [
+        ":common_proto",
+        "@com_google_protobuf//:struct_proto",
+        ],
+)
+
+# Java proto libraries
+java_proto_library(
+    name = "common_java_proto",
+    deps = [":common_proto"],
+)
+
+java_proto_library(
+    name = "document_java_proto",
+    deps = [":document_proto"],
+)
+
+java_proto_library(
+    name = "search_java_proto",
+    deps = [":search_proto"],
+)

--- a/protos/schemas/common.proto
+++ b/protos/schemas/common.proto
@@ -1,0 +1,2748 @@
+/**
+This is generated from the spec. DO NOT manually modify.
+*/
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "org.opensearch.protobuf";
+option java_outer_classname = "CommonProto";
+option go_package = "opensearchpb";
+
+import "google/protobuf/struct.proto";
+
+message WaitForActiveShards {
+
+  enum WaitForActiveShardOptions {
+    WAIT_FOR_ACTIVE_SHARD_OPTIONS_UNSPECIFIED = 0;
+    WAIT_FOR_ACTIVE_SHARD_OPTIONS_ALL = 1;
+  }
+
+  oneof wait_for_active_shards {
+    int32 int32_value = 1;
+    WaitForActiveShardOptions wait_for_active_shard_options = 2;
+  }
+
+}
+
+message Script {
+  oneof script {
+    // Defines an inline script to execute as part of a query.
+    InlineScript inline_script = 1;
+    // References a stored script by its ID for use in a query.
+    StoredScriptId stored_script_id = 2;
+  }
+}
+
+message InlineScript {
+  // [optional]
+  // The parameters that can be passed to the script.
+  ObjectMap params = 1;
+
+  // [optional]
+  // The script's language. Default is painless.
+  ScriptLanguage lang = 2;
+
+  map<string, string> options = 3;
+
+  // [required]
+  // The script source.
+  string source = 4;
+}
+
+message ScriptLanguage {
+  enum BuiltinScriptLanguage {
+    BUILTIN_SCRIPT_LANGUAGE_UNSPECIFIED = 0;
+    BUILTIN_SCRIPT_LANGUAGE_EXPRESSION = 1;
+    BUILTIN_SCRIPT_LANGUAGE_JAVA = 2;
+    BUILTIN_SCRIPT_LANGUAGE_MUSTACHE = 3;
+    BUILTIN_SCRIPT_LANGUAGE_PAINLESS = 4;
+  }
+  BuiltinScriptLanguage builtin_script_language = 1;
+  string string_value = 2;
+}
+
+message StoredScriptId {
+  // [optional]
+  // The parameters that can be passed to the script.
+  ObjectMap params = 1;
+  // [required]
+  // The ID of a stored script previously created using the Create Stored Script API.
+  string id = 2;
+}
+
+message ObjectMap {
+  map<string, Value> fields = 1;
+
+  message Value {
+    // The kind of value.
+    oneof value {
+      // Represents a null value.
+      NullValue null_value = 1;
+      // Represents a double value.
+      GeneralNumber general_number = 2;
+      // Represents a string value.
+      string string_value = 3;
+      // Represents a boolean value.
+      bool bool_value = 4;
+      // Represents a structured value.
+      ObjectMap object_map = 5;
+      // Represents a repeated `Value`.
+      ListValue list_value = 6;
+    }
+
+  }
+
+  // `ListValue` is a wrapper around a repeated field of values.
+  // The JSON representation for `ListValue` is JSON array.
+  message ListValue {
+    // Repeated field of dynamically typed values.
+    repeated ValueWithoutWrappers value_without_wrappers = 1;
+  }
+
+  message ValueWithoutWrappers {
+    oneof value_without_wrappers {
+      NullValue null_value = 1;
+      int32 int32 = 2;
+      int64 int64 = 3;
+      float float = 4;
+      double double = 5;
+      string string = 6;
+      bool bool = 7;
+      ObjectMap object_map = 8;
+      ListValue list_value = 9;
+    }
+  }
+}
+
+enum NullValue {
+  NULL_VALUE_UNSPECIFIED = 0;
+  NULL_VALUE_NULL = 1;
+}
+
+// [optional] Controls how document source fields are returned in the response.
+// - If not set, source is returned as bytes (default, recommended for better performance)
+// - If set to SOURCE_TYPE_STRUCT: source is returned as a structured protobuf message
+enum SourceType {
+  SOURCE_TYPE_UNSPECIFIED = 0;
+  SOURCE_TYPE_STRUCT = 1;
+}
+
+message GeoLocation {
+
+  oneof geo_location {
+    LatLonGeoLocation lat_lon_geo_location = 1;
+    GeoHashLocation geo_hash_location = 2;
+    NumberArray number_array = 3;
+  }
+
+}
+
+message NumberArray {
+
+  repeated double number_array = 1;
+
+}
+
+message LatLonGeoLocation {
+  // Latitude
+  double lat = 1;
+
+  // Longitude
+  double lon = 2;
+
+}
+
+message GeoHashLocation {
+
+  string geohash = 1;
+
+}
+
+message GeneralNumber {
+  oneof value{
+    int32 int32_value = 1;
+    int64 int64_value = 2;
+    float float_value = 3;
+    double double_value = 4;
+  }
+}
+
+message SourceConfigParam {
+
+  oneof source_config_param {
+    // `true` or `false` to return the `_source` field or not
+    bool bool_value = 1;
+    // list of fields to be retrieved from `_source`
+    StringArray string_array = 2;
+  }
+
+}
+
+message StringArray{
+  repeated string string_array = 1;
+}
+
+message StringOrStringArray {
+  oneof string_or_string_array{
+    string string_value = 1;
+    StringArray string_array = 2;
+  }
+}
+
+message SourceConfig {
+
+  oneof source_config{
+    // [optional] if the source_config is bool value. true: The entire document source is returned. false: The document source is not returned.
+    bool fetch = 1;
+    // [optional] Array of patterns containing source fields to return.
+    StringArray includes = 2;
+    // [optional] source_filter type containing a list of source fields to include or exclude.
+    SourceFilter filter = 3;
+  }
+
+}
+
+message RuntimeField {
+
+  // For type `lookup`
+  repeated RuntimeFieldFetchFields fetch_fields = 1;
+
+  // A custom format for `date` type runtime fields.
+  string format = 2;
+
+  // Path to field or array of paths. Some API's support wildcards in the path to select multiple fields.
+  string input_field = 3;
+
+  // Path to field or array of paths. Some API's support wildcards in the path to select multiple fields.
+  string target_field = 4;
+
+  string target_index = 5;
+
+  Script script = 6;
+
+  enum RuntimeFieldType {
+    RUNTIME_FIELD_TYPE_UNSPECIFIED = 0;
+    RUNTIME_FIELD_TYPE_BOOLEAN = 1;
+    RUNTIME_FIELD_TYPE_DATE = 2;
+    RUNTIME_FIELD_TYPE_DOUBLE = 3;
+    RUNTIME_FIELD_TYPE_GEO_POINT = 4;
+    RUNTIME_FIELD_TYPE_IP = 5;
+    RUNTIME_FIELD_TYPE_KEYWORD = 6;
+    RUNTIME_FIELD_TYPE_LONG = 7;
+    RUNTIME_FIELD_TYPE_LOOKUP = 8;
+  }
+
+  RuntimeFieldType type = 7;
+
+}
+
+message RuntimeFieldFetchFields {
+
+  // Path to field or array of paths. Some API's support wildcards in the path to select multiple fields.
+  string field = 1;
+
+  string format = 2;
+
+}
+
+message SourceFilter {
+  // [optional] Wildcard (*) patterns are supported as array elements to specify source fields to exclude from the response.
+  repeated string excludes = 1;
+  // [optional] Wildcard (*) patterns are supported as array elements to specify source fields to return.
+  repeated string includes = 2;
+}
+
+message ErrorCause {
+
+  // The type of error
+  optional string type = 1;
+
+  // A human-readable explanation of the error, in english
+  optional string reason = 2;
+
+  // The server stack trace. Present only if the `error_trace=true` parameter was sent with the request.
+  optional string stack_trace = 3;
+
+  optional ErrorCause caused_by = 4;
+
+  repeated ErrorCause root_cause = 5;
+
+  repeated ErrorCause suppressed = 6;
+
+  optional string index = 7;
+
+  optional string shard = 8;
+
+  optional string index_uuid = 9;
+
+  .google.protobuf.Struct additional_details = 10;
+
+}
+message ShardStatistics {
+  // [required] Number of shards that failed to execute the request. Note that shards that are not allocated will be considered neither successful nor failed. Having failed+successful less than total is thus an indication that some of the shards were not allocated.
+  int32 failed = 1;
+
+  // [required] Number of shards that executed the request successfully.
+  int32 successful = 2;
+
+  // [required] Total number of shards that require querying, including unallocated shards.
+  int32 total = 3;
+
+  // [optional] An array of any shard-specific failures that occurred during the search operation.
+  repeated ShardFailure failures = 4;
+
+  // [optional] Number of shards that skipped the request because a lightweight check helped realize that no documents could possibly match on this shard. This typically happens when a search request includes a range filter and the shard only has values that fall outside of that range.
+  int32 skipped = 5;
+
+}
+
+message ShardInfo {
+  // [required] Number of shards that failed to execute the request. Note that shards that are not allocated will be considered neither successful nor failed. Having failed+successful less than total is thus an indication that some of the shards were not allocated.
+  int32 failed = 1;
+
+  // [required] Number of shards that executed the request successfully.
+  int32 successful = 2;
+
+  // [required] Total number of shards that require querying, including unallocated shards.
+  int32 total = 3;
+
+  // [optional] An array of any shard-specific failures that occurred during the search operation.
+  repeated ShardFailure failures = 4;
+
+}
+
+message ShardFailure {
+
+  // [optional] Name of the index in which the shard failure occurred.
+  optional string index = 1;
+
+  // [optional] ID of the node where the shard is located.
+  optional string node = 2;
+
+  // [required] Provides details about the error that caused the shard failure.
+  ErrorCause reason = 3;
+
+  // [required] The shard number where the failure occurred.
+  int32 shard = 4;
+
+  // [optional] Error status.
+  optional string status = 5;
+
+  // [required]
+  bool primary = 6;
+
+}
+
+message ShardSearchFailure {
+
+  // [optional] Name of the index in which the shard failure occurred.
+  optional string index = 1;
+
+  // [optional] ID of the node where the shard is located.
+  optional string node = 2;
+
+  // [required] Provides details about the error that caused the shard failure.
+  ErrorCause reason = 3;
+
+  // [required] The shard number where the failure occurred.
+  int32 shard = 4;
+
+  // [optional] Error status.
+  optional string status = 5;
+}
+
+// The fields in this message are effectively oneOf
+message QueryContainer {
+
+  // [optional]
+  // A Boolean (bool) query can combine several query clauses into one advanced query. The clauses are combined with Boolean logic to find matching documents returned in the results.
+  // If provided, no other fields should be provided inside QueryContainer
+  optional BoolQuery bool = 1;
+
+  // [optional]
+  // A boosting query returns documents that match a positive query. Among those documents, the ones that also match the negative query are scored lower in relevance (their relevance score is multiplied by the negative boosting factor).
+  // If provided, no other fields should be provided inside QueryContainer
+  optional BoostingQuery boosting = 2;
+
+  // [optional]
+  // A constant_score query wraps a filter query and assigns all documents in the results a relevance score equal to the value of the boost parameter.
+  // If provided, no other fields should be provided inside QueryContainer
+  optional ConstantScoreQuery constant_score = 3;
+
+  // [optional]
+  // A disjunction max (dis_max) query returns any document that matches one or more query clauses. For documents that match multiple query clauses, the relevance score is set to the highest relevance score from all matching query clauses.
+  // If provided, no other fields should be provided inside QueryContainer
+  optional DisMaxQuery dis_max = 4;
+
+  // [optional]
+  // Use a function_score query if you need to alter the relevance scores of documents returned in the results. A function_score query defines a query and one or more functions that can be applied to all results or subsets of the results to recalculate their relevance scores.
+  // If provided, no other fields should be provided inside QueryContainer
+  FunctionScoreQuery function_score = 5;
+
+  // [optional]
+  // Use the exists query to search for documents that contain a specific field.
+  // If provided, no other fields should be provided inside QueryContainer
+  optional ExistsQuery exists = 6;
+
+  // [optional]
+  // Fuzzy query is to searches for documents containing terms that are similar to the search term within the maximum allowed Damerau–Levenshtein distance. The Damerau–Levenshtein distance measures the number of one-character changes needed to change one term to another term.
+  // If provided, no other fields should be provided inside QueryContainer
+  // Only 1 entry can be provided in the map
+  map<string, FuzzyQuery> fuzzy = 7;
+
+  // [optional]
+  // Use the ids query to search for documents with one or more specific document ID values in the _id field. For example, the following query requests documents with the IDs 34229 and 91296.
+  // If provided, no other fields should be provided inside QueryContainer
+  optional IdsQuery ids = 8;
+
+  // [optional]
+  // Prefix query is to search for terms that begin with a specific prefix.
+  // If provided, no other fields should be provided inside QueryContainer
+  // Only 1 entry can be provided in the map
+  map<string, PrefixQuery> prefix = 9;
+
+  // [optional]
+  // Returns documents that contain terms within a provided range.
+  // If provided, no other fields should be provided inside QueryContainer
+  // Only 1 entry can be provided in the map
+  map<string, RangeQuery> range = 10;
+
+  // [optional]
+  // Returns documents that contain terms matching a regular expression.
+  // If provided, no other fields should be provided inside QueryContainer
+  // Only 1 entry can be provided in the map
+  map<string, RegexpQuery> regexp = 11;
+
+  // [optional]
+  // Term query is to search for an exact term in a field. The term query does not analyze the search term. The term query only searches for the exact term you provide.
+  // If provided, no other fields should be provided inside QueryContainer
+  // Only 1 entry can be provided in the map
+  map<string, TermQueryFieldValue> term = 12;
+
+  // [optional]
+  // Terms query field is to search for documents containing one or more terms in a specific field. Use the terms query to search for multiple terms in the same field.
+  // If provided, no other fields should be provided inside QueryContainer
+  optional TermsQueryField terms = 13;
+
+  // [optional]
+  // terms set query is to search for documents that match a minimum number of exact terms in a specified field. A terms_set query is similar to a terms query, except that you can specify the minimum number of matching terms that are required in order to return a document. You can specify this number either in a field in the index or with a script.
+  // If provided, no other fields should be provided inside QueryContainer
+  // Only 1 entry can be provided in the map
+  map<string, TermsSetQuery> terms_set = 14;
+
+  // [optional]
+  // Returns documents that contain terms matching a wildcard pattern.
+  // If provided, no other fields should be provided inside QueryContainer
+  // Only 1 entry can be provided in the map
+  map<string, WildcardQuery> wildcard = 15;
+
+  // [optional]
+  // Use the match query for full-text search on a specific document field. If you run a match query on a text field, the match query analyzes the provided search string and returns documents that match any of the string's terms. If you run a match query on an exact-value field, it returns documents that match the exact value. The preferred way to search exact-value fields is to use a filter because, unlike a query, a filter is cached.
+  // If provided, no other fields should be provided inside QueryContainer
+  // Only 1 entry can be provided in the map
+  map<string, MatchQueryTypeless> match = 16;
+
+  // [optional]
+  // The match_bool_prefix query analyzes the provided search string and creates a Boolean query from the string's terms. It uses every term except the last term as a whole word for matching. The last term is used as a prefix. The match_bool_prefix query returns documents that contain either the whole-word terms or terms that start with the prefix term, in any order.
+  // If provided, no other fields should be provided inside QueryContainer
+  // Only 1 entry can be provided in the map
+  map<string, MatchBoolPrefixQuery> match_bool_prefix = 17;
+
+  // [optional]
+  // Use the match_phrase query to match documents that contain an exact phrase in a specified order. You can add flexibility to phrase matching by providing the slop parameter.
+  // If provided, no other fields should be provided inside QueryContainer
+  // Only 1 entry can be provided in the map
+  map<string, MatchPhraseQuery> match_phrase = 18;
+
+  // [optional]
+  // Use the match_phrase_prefix query to specify a phrase to match in order. The documents that contain the phrase you specify will be returned. The last partial term in the phrase is interpreted as a prefix, so any documents that contain phrases that begin with the phrase and prefix of the last term will be returned.
+  // If provided, no other fields should be provided inside QueryContainer
+  // Only 1 entry can be provided in the map
+  map<string, MatchPhrasePrefixQuery> match_phrase_prefix = 19;
+
+  // [optional]
+  // A multi-match operation functions similarly to the match operation. You can use a multi_match query to search multiple fields.
+  // If provided, no other fields should be provided inside QueryContainer
+  MultiMatchQuery multi_match = 20;
+
+  // [optional]
+  // A query_string query parses the query string based on the query string syntax. It provides for creating powerful yet concise queries that can incorporate wildcards and search multiple fields.
+  // If provided, no other fields should be provided inside QueryContainer
+  optional QueryStringQuery query_string = 21;
+
+  // [optional]
+  // Use the simple_query_string type to specify multiple arguments delineated by regular expressions directly in the query string. Simple query string has a less strict syntax than query string because it discards any invalid portions of the string and does not return errors for invalid syntax.
+  // If provided, no other fields should be provided inside QueryContainer
+  optional SimpleQueryStringQuery simple_query_string = 22;
+
+  // [optional]
+  // Returns documents based on the order and proximity of matching terms.
+  // If provided, no other fields should be provided inside QueryContainer
+  // Only 1 entry can be provided in the map
+  map<string, IntervalsQuery> intervals = 23;
+
+  // [optional]
+  // Knn query is to search for the k-nearest neighbors to a query point across an index of vectors. To determine the neighbors, you can specify the space (the distance function) you want to use to measure the distance between points.
+  // If provided, no other fields should be provided inside QueryContainer
+  // Only 1 entry can be provided in the map
+  map<string, KnnField> knn = 24;
+
+  // [optional]
+  // The match all query returns all documents. This query can be useful in testing large document sets if you need to return the entire set.
+  // If provided, no other fields should be provided inside QueryContainer
+  optional MatchAllQuery match_all = 25;
+
+  // [optional]
+  // This is the inverse of the match_all query, which matches no documents.
+  // If provided, no other fields should be provided inside QueryContainer
+  optional MatchNoneQuery match_none = 26;
+
+  // [optional]
+  // Use a script_score query to customize the score calculation by using a script. For an expensive scoring function, you can use a script_score query to calculate the score only for the returned documents that have been filtered.
+  // If provided, no other fields should be provided inside QueryContainer
+  optional ScriptScoreQuery script_score = 27;
+
+  // [optional]
+  // The nested query acts as a wrapper for other queries to search nested fields. The nested field objects are searched as though they were indexed as separate documents. If an object matches the search, the nested query returns the parent document at the root level.
+  // If provided, no other fields should be provided inside QueryContainer
+  optional NestedQuery nested = 28;
+
+}
+
+message NestedQuery {
+
+  // Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
+  float boost = 1;
+
+  string name = 2 [json_name = "_name"];
+
+  // Set to `true` to ignore an unmapped field and not match any documents for this query. Set to `false` to throw an exception if the field is not mapped.
+  bool ignore_unmapped = 3;
+
+  InnerHits inner_hits = 4;
+
+  // The path to a field or an array of paths. Some APIs support wildcards in the path, which allows you to select multiple fields.
+  string path = 5;
+
+  QueryContainer query = 6;
+
+  enum ChildScoreMode {
+    CHILD_SCORE_MODE_UNSPECIFIED = 0;
+    CHILD_SCORE_MODE_AVG = 1;
+    CHILD_SCORE_MODE_MAX = 2;
+    CHILD_SCORE_MODE_MIN = 3;
+    CHILD_SCORE_MODE_NONE = 4;
+    CHILD_SCORE_MODE_SUM = 5;
+  }
+  ChildScoreMode score_mode = 7;
+
+}
+
+message InnerHits {
+
+  // [optional] The name to be used for the particular inner hit definition in the response. Useful when multiple inner hits have been defined in a single search request.
+  optional string name = 1;
+
+  // [optional] The maximum number of hits to return per `inner_hits`.
+  optional int32 size = 2;
+
+  // [optional] Inner hit starting document offset.
+  optional int32 from = 3;
+
+  // [optional] The collapse parameter groups search results by a particular field value. This returns only the top document within each group, which helps reduce redundancy by eliminating duplicates.
+  optional FieldCollapse collapse = 4;
+
+  // [optional] The fields that OpenSearch should return using their docvalue forms. Specify a format to return results in a certain format, such as date and time.
+  repeated FieldAndFormat docvalue_fields = 5;
+
+  // [optional] Whether to return details about how OpenSearch computed the document's score. Default is false.
+  bool explain = 6;
+
+  // [optional] Highlighting emphasizes the search term(s) in the results so you can emphasize the query matches.
+  optional Highlight highlight = 7;
+
+  // [optional] Specifies how to treat an unmapped field. Set ignore_unmapped to true to ignore unmapped fields. Default is false
+  optional bool ignore_unmapped = 8;
+
+  // [optional] The script_fields parameter allows you to include custom fields whose values are computed using scripts in your search results. This can be useful for calculating values dynamically based on the document data. You can also retrieve derived fields by using a similar approach.
+  map<string, ScriptField> script_fields = 9;
+
+  // [optional] Whether to return sequence number and primary term of the last operation of each document hit.
+  optional bool seq_no_primary_term = 10;
+
+  // [optional] Retrieve selected fields from a search
+  repeated string fields = 11;
+
+  // [optional] How the inner hits should be sorted per inner_hits. By default the hits are sorted by the score.
+  repeated SortCombinations sort = 12;
+
+  // [optional] Select what fields of the source are returned
+  optional SourceConfig source = 13 [json_name = "_source"];
+
+  // [optional] A list of stored fields to return as part of a hit. If no fields are specified, no stored fields are included in the response. If this option is specified, the _source parameter defaults to false. You can pass _source: true to return both source fields and stored fields in the search response.
+  repeated string stored_fields = 14;
+
+  // [optional] Whether to return document scores. Default is false.
+  optional bool track_scores = 15;
+
+  // [optional] Whether to include the document version as a match.
+  optional bool version = 16;
+
+}
+
+message ScriptField {
+  Script script = 1;
+  bool ignore_failure = 2;
+}
+
+message Highlight {
+
+  enum HighlighterType {
+    HIGHLIGHTER_TYPE_UNSPECIFIED = 0;
+    // The fvh highlighter uses the Lucene Fast Vector highlighter. This highlighter can be used on fields with term_vector set to with_positions_offsets in the mapping.
+    HIGHLIGHTER_TYPE_FVH = 1;
+    // The plain highlighter uses the standard Lucene highlighter. It attempts to reflect the query matching logic in terms of understanding word importance and any word positioning criteria in phrase queries.
+    HIGHLIGHTER_TYPE_PLAIN = 2;
+    // The unified highlighter uses the Lucene Unified Highlighter. This highlighter breaks the text into sentences and uses the BM25 algorithm to score individual sentences as if they were documents in the corpus. It also supports accurate phrase and multi-term (fuzzy, prefix, regex) highlighting. The unified highlighter can combine matches from multiple fields into one result (see matched_fields). This is the default highlighter.
+    HIGHLIGHTER_TYPE_UNIFIED = 3;
+  }
+
+  // [optional] Specifies the highlighter to use. Default is unified.
+  optional HighlighterType type = 1;
+
+  // [optional] All boundary characters combined in a string. Default is ".,!? \t\n".
+  optional string boundary_chars = 2;
+
+  // [optional] Controls how far to scan for boundary characters when the boundary_scanner parameter for the fvh highlighter is set to chars. Default is 20.
+  optional int32 boundary_max_scan = 3;
+
+  enum BoundaryScanner {
+    BOUNDARY_SCANNER_UNSPECIFIED = 0;
+    // Split highlighted fragments at any character listed in boundary_chars. Valid only for the fvh highlighter.
+    BOUNDARY_SCANNER_CHARS = 1;
+    // Split highlighted fragments at sentence boundaries, as defined by the BreakIterator. You can specify the BreakIterator's locale in the boundary_scanner_locale option.
+    BOUNDARY_SCANNER_SENTENCE = 2;
+    // Split highlighted fragments at word boundaries, as defined by the BreakIterator. You can specify the BreakIterator's locale in the boundary_scanner_locale option.
+    BOUNDARY_SCANNER_WORD = 3;
+  }
+
+  // [optional] Specifies whether to split the highlighted fragments into sentences, words, or characters.
+  optional BoundaryScanner boundary_scanner = 4;
+
+  // [optional] Provides a locale for the boundary_scanner. Valid values are language tags (for example, "en-US"). Default is Locale.ROOT.
+  optional string boundary_scanner_locale = 5;
+
+  // [x-deprecated]
+  optional bool force_source = 6;
+
+  enum HighlighterFragmenter {
+    HIGHLIGHTER_FRAGMENTER_UNSPECIFIED = 0;
+    // Splits text into fragments of the same size.
+    HIGHLIGHTER_FRAGMENTER_SIMPLE = 1;
+    // Splits text into fragments of the same size but tries not to split text between highlighted terms.
+    HIGHLIGHTER_FRAGMENTER_SPAN = 2;
+  }
+
+  // [optional] Specifies how to split text into highlighted fragments. Valid only for the plain highlighter. Default HIGHLIGHTER_FRAGMENTER_SPAN.
+  optional HighlighterFragmenter fragmenter = 7;
+
+  // [optional] The size of a highlighted fragment, specified as the number of characters. If number_of_fragments is set to 0, fragment_size is ignored. Default is 100.
+  optional int32 fragment_size = 8;
+
+  bool highlight_filter = 9;
+
+  // [optional] Specifies that matches for a query other than the search query should be highlighted. The highlight_query option is useful when you use a faster query to get document matches and a slower query (for example, rescore_query) to refine the results. We recommend to include the search query as part of the highlight_query.
+  optional QueryContainer highlight_query = 10;
+
+  int32 max_fragment_length = 11;
+
+  // [optional] If set to a non-negative value, highlighting stops at this defined maximum limit. The rest of the text is not processed, thus not highlighted and no error is returned The `max_analyzed_offset` query setting does not override the `index.highlight.max_analyzed_offset` setting, which prevails when it's set to lower value than the query setting.
+  optional int32 max_analyzed_offset = 12;
+
+  // [optional] Specifies the number of characters, starting from the beginning of the field, to return if there are no matching fragments to highlight. Default is 0.
+  optional int32 no_match_size = 13;
+
+  // [optional] The maximum number of returned fragments. If number_of_fragments is set to 0, OpenSearch returns the highlighted contents of the entire field. Default is 5.
+  optional int32 number_of_fragments = 14;
+
+  optional ObjectMap options = 15;
+
+  enum HighlighterOrder {
+    HIGHLIGHTER_ORDER_UNSPECIFIED = 0;
+    // Sort fragments by relevance.
+    HIGHLIGHTER_ORDER_SCORE = 1;
+  }
+
+  // [optional] The sort order for the highlighted fragments. Each highlighter has a different algorithm for calculating relevance scores. Default is none.
+  optional HighlighterOrder order = 16;
+
+  // [optional] The number of matching phrases in a document that are considered. Limits the number of phrases to analyze by the fvh highlighter to avoid consuming a lot of memory. If matched_fields are used, phrase_limit specifies the number of phrases for each matched field. A higher phrase_limit leads to increased query time and more memory consumption. Valid only for the fvh highlighter. Default is 256.
+  optional int32 phrase_limit = 17;
+
+  // [optional] Specifies the HTML end tags for the highlighted text as an array of strings.
+  repeated string post_tags = 18;
+
+  // [optional] Specifies the HTML start tags for the highlighted text as an array of strings.
+  repeated string pre_tags = 19;
+
+  // [optional] Specifies whether to highlight only fields that contain a search query match. Default is true. To highlight all fields, set this option to false.
+  optional bool require_field_match = 20;
+
+  enum HighlighterTagsSchema {
+    HIGHLIGHTER_TAGS_SCHEMA_UNSPECIFIED = 0;
+    // Defines the following pre_tags and defines post_tags as </em>.
+    HIGHLIGHTER_TAGS_SCHEMA_STYLED = 1;
+  }
+
+  // [optional] If you set this option to styled, OpenSearch uses the built-in tag schema. In this schema, the pre_tags are <em class="hlt1">, <em class="hlt2">, <em class="hlt3">, <em class="hlt4">, <em class="hlt5">, <em class="hlt6">, <em class="hlt7">, <em class="hlt8">, <em class="hlt9">, and <em class="hlt10">, and the post_tags is </em>.
+  optional HighlighterTagsSchema tags_schema = 21;
+
+  enum HighlighterEncoder {
+    HIGHLIGHTER_ENCODER_UNSPECIFIED = 0;
+    // No encoding
+    HIGHLIGHTER_ENCODER_DEFAULT = 1;
+    // First escape the HTML text and then insert the highlighting tags
+    HIGHLIGHTER_ENCODER_HTML = 2;
+  }
+
+  // [optional] Specifies whether the highlighted fragment should be HTML encoded before it is returned.
+  optional HighlighterEncoder encoder = 22;
+
+  // [required] Specifies the fields to search for text to be highlighted. Supports wildcard expressions. If you use wildcards, only text and keyword fields are highlighted. For example, you can set fields to my_field* to include all text and keyword fields that start with the prefix my_field.
+  map<string, HighlightField> fields = 23;
+
+}
+
+message HighlightField {
+
+  enum HighlighterType {
+    HIGHLIGHTER_TYPE_UNSPECIFIED = 0;
+    // The fvh highlighter uses the Lucene Fast Vector highlighter. This highlighter can be used on fields with term_vector set to with_positions_offsets in the mapping.
+    HIGHLIGHTER_TYPE_FVH = 1;
+    // The plain highlighter uses the standard Lucene highlighter. It attempts to reflect the query matching logic in terms of understanding word importance and any word positioning criteria in phrase queries.
+    HIGHLIGHTER_TYPE_PLAIN = 2;
+    // The unified highlighter uses the Lucene Unified Highlighter. This highlighter breaks the text into sentences and uses the BM25 algorithm to score individual sentences as if they were documents in the corpus. It also supports accurate phrase and multi-term (fuzzy, prefix, regex) highlighting. The unified highlighter can combine matches from multiple fields into one result (see matched_fields). This is the default highlighter.
+    HIGHLIGHTER_TYPE_UNIFIED = 3;
+  }
+
+  // [optional] Specifies the highlighter to use. Default is unified.
+  optional HighlighterType type = 1;
+
+  // [optional] All boundary characters combined in a string. Default is ".,!? \t\n".
+  optional string boundary_chars = 2;
+
+  // [optional] Controls how far to scan for boundary characters when the boundary_scanner parameter for the fvh highlighter is set to chars. Default is 20.
+  optional int32 boundary_max_scan = 3;
+
+  enum BoundaryScanner {
+    BOUNDARY_SCANNER_UNSPECIFIED = 0;
+    // Split highlighted fragments at any character listed in boundary_chars. Valid only for the fvh highlighter.
+    BOUNDARY_SCANNER_CHARS = 1;
+    // Split highlighted fragments at sentence boundaries, as defined by the BreakIterator. You can specify the BreakIterator's locale in the boundary_scanner_locale option.
+    BOUNDARY_SCANNER_SENTENCE = 2;
+    // Split highlighted fragments at word boundaries, as defined by the BreakIterator. You can specify the BreakIterator's locale in the boundary_scanner_locale option.
+    BOUNDARY_SCANNER_WORD = 3;
+  }
+
+  // [optional] Specifies whether to split the highlighted fragments into sentences, words, or characters.
+  optional BoundaryScanner boundary_scanner = 4;
+
+  // [optional] Provides a locale for the boundary_scanner. Valid values are language tags (for example, "en-US"). Default is Locale.ROOT.
+  optional string boundary_scanner_locale = 5;
+
+  // [x-deprecated]
+  bool force_source = 6;
+
+  enum HighlighterFragmenter {
+    HIGHLIGHTER_FRAGMENTER_UNSPECIFIED = 0;
+    // Splits text into fragments of the same size.
+    HIGHLIGHTER_FRAGMENTER_SIMPLE = 1;
+    // Splits text into fragments of the same size but tries not to split text between highlighted terms.
+    HIGHLIGHTER_FRAGMENTER_SPAN = 2;
+  }
+
+  // [optional] Specifies how to split text into highlighted fragments. Valid only for the plain highlighter. Default HIGHLIGHTER_FRAGMENTER_SPAN.
+  optional HighlighterFragmenter fragmenter = 7;
+
+  // [optional] The size of a highlighted fragment, specified as the number of characters. If number_of_fragments is set to 0, fragment_size is ignored. Default is 100.
+  optional int32 fragment_size = 8;
+
+  bool highlight_filter = 9;
+
+  // [optional] Specifies that matches for a query other than the search query should be highlighted. The highlight_query option is useful when you use a faster query to get document matches and a slower query (for example, rescore_query) to refine the results. We recommend to include the search query as part of the highlight_query.
+  optional QueryContainer highlight_query = 10;
+
+  int32 max_fragment_length = 11;
+
+  // [optional] If set to a non-negative value, highlighting stops at this defined maximum limit. The rest of the text is not processed, thus not highlighted and no error is returned The `max_analyzed_offset` query setting does not override the `index.highlight.max_analyzed_offset` setting, which prevails when it's set to lower value than the query setting.
+  optional int32 max_analyzed_offset = 12;
+
+  // [optional] Specifies the number of characters, starting from the beginning of the field, to return if there are no matching fragments to highlight. Default is 0.
+  optional int32 no_match_size = 13;
+
+  // [optional] The maximum number of returned fragments. If number_of_fragments is set to 0, OpenSearch returns the highlighted contents of the entire field. Default is 5.
+  optional int32 number_of_fragments = 14;
+
+  ObjectMap options = 15;
+
+  enum HighlighterOrder {
+    HIGHLIGHTER_ORDER_UNSPECIFIED = 0;
+    // Sort fragments by relevance.
+    HIGHLIGHTER_ORDER_SCORE = 1;
+  }
+
+  // [optional] The sort order for the highlighted fragments. Each highlighter has a different algorithm for calculating relevance scores. Default is none.
+  optional HighlighterOrder order = 16;
+
+  // [optional] The number of matching phrases in a document that are considered. Limits the number of phrases to analyze by the fvh highlighter to avoid consuming a lot of memory. If matched_fields are used, phrase_limit specifies the number of phrases for each matched field. A higher phrase_limit leads to increased query time and more memory consumption. Valid only for the fvh highlighter. Default is 256.
+  optional int32 phrase_limit = 17;
+
+  // [optional] Specifies the HTML end tags for the highlighted text as an array of strings.
+  repeated string post_tags = 18;
+
+  // [optional] Specifies the HTML start tags for the highlighted text as an array of strings.
+  repeated string pre_tags = 19;
+
+  // [optional] Specifies whether to highlight only fields that contain a search query match. Default is true. To highlight all fields, set this option to false.
+  optional bool require_field_match = 20;
+
+  enum HighlighterTagsSchema {
+    HIGHLIGHTER_TAGS_SCHEMA_UNSPECIFIED = 0;
+    // Defines the following pre_tags and defines post_tags as </em>.
+    HIGHLIGHTER_TAGS_SCHEMA_STYLED = 1;
+  }
+
+  HighlighterTagsSchema tags_schema = 21;
+
+  // [optional] If you set this option to styled, OpenSearch uses the built-in tag schema. In this schema, the pre_tags are <em class="hlt1">, <em class="hlt2">, <em class="hlt3">, <em class="hlt4">, <em class="hlt5">, <em class="hlt6">, <em class="hlt7">, <em class="hlt8">, <em class="hlt9">, and <em class="hlt10">, and the post_tags is </em>.
+  optional int32 fragment_offset = 22;
+
+  // [optional] Combines matches from different fields to highlight one field. The most common use case for this functionality is highlighting text that is analyzed in different ways and kept in multi-fields. All fields in the matched_fields list must have the term_vector field set to with_positions_offsets. The field in which the matches are combined is the only loaded field, so it is beneficial to set its store option to yes. Valid only for the fvh highlighter.
+  repeated string matched_fields = 23;
+
+  optional Analyzer analyzer = 24;
+
+}
+
+message SortCombinations {
+  oneof sort_combinations{
+    // [optional] Sort based on field name.
+    string string_value = 1;
+    // [optional] Sort based on a map of fields with specified order directions.
+    FieldWithOrderMap field_with_order_map = 2;
+    // [optional] Sort using a combination of advanced sort options, such as score, document ID, geo-distance, or a custom script.
+    SortOptions sort_options = 3;
+  }
+}
+
+message FieldWithOrderMap {
+  // [required] Map of fields and their corresponding sort order.
+  map<string, ScoreSort> field_with_order_map = 1;
+}
+
+message SortOptions {
+  oneof sort_options{
+    // [optional] Sort by score.
+    ScoreSort score = 1 [json_name = "_score"];
+    // [optional] Sort by index order.
+    ScoreSort doc = 2 [json_name = "_doc"];
+    // [optional] Sort by _geo_distance
+    GeoDistanceSort geo_distance = 3 [json_name = "_geo_distance"];
+    // [optional] Sort based on custom scripts
+    ScriptSort script = 4 [json_name = "_script"];
+  }
+}
+
+message ScoreSort {
+  // Specifies the sort order (asc or dsc) for the score.
+  SortOrder order = 1;
+  enum SortOrder {
+    SORT_ORDER_UNSPECIFIED = 0;
+    // Sort in ascending order.
+    SORT_ORDER_ASC = 1;
+    // Sort in descending order
+    SORT_ORDER_DESC = 2;
+  }
+}
+
+message GeoDistanceSort {
+
+  // Specifies how to handle a field with several geopoints.
+  SortMode mode = 1;
+  enum SortMode {
+    SORT_MODE_UNSPECIFIED = 0;
+    // Use the average of all values as sort value. Only applicable for number based array fields.
+    SORT_MODE_AVG = 1;
+    // Pick the highest value.
+    SORT_MODE_MAX = 2;
+    // Use the median of all values as sort value. Only applicable for number based array fields.
+    SORT_MODE_MEDIAN = 3;
+    // Pick the lowest value.
+    SORT_MODE_MIN = 4;
+    // Use the sum of all values as sort value. Only applicable for number based array fields.
+    SORT_MODE_SUM = 5;
+  }
+
+  // [optional] Specifies the method of computing the distance.
+  GeoDistanceType distance_type = 2;
+
+  enum GeoDistanceType {
+    GEO_DISTANCE_TYPE_UNSPECIFIED = 0;
+    // Default
+    GEO_DISTANCE_TYPE_ARC = 1;
+    // Faster but less accurate for long distances or close to the poles.
+    GEO_DISTANCE_TYPE_PLANE = 2;
+  }
+
+  // [optional] Specifies how to treat an unmapped field. Set ignore_unmapped to true to ignore unmapped fields. Default is false
+  bool ignore_unmapped = 3;
+
+  // [optional] Specifies the sort order (asc or dsc) for the score.
+  SortOrder order = 4;
+
+  enum SortOrder {
+    SORT_ORDER_UNSPECIFIED = 0;
+    // Sort in ascending order.
+    SORT_ORDER_ASC = 1;
+    // Sort in descending order
+    SORT_ORDER_DESC = 2;
+  }
+
+  // [optional] Specifies the units used to compute sort values. Default is meters (m).
+  DistanceUnit unit = 5;
+
+  enum DistanceUnit {
+    DISTANCE_UNIT_UNSPECIFIED = 0;
+    DISTANCE_UNIT_CM = 1;
+    DISTANCE_UNIT_FT = 2;
+    DISTANCE_UNIT_IN = 3;
+    DISTANCE_UNIT_KM = 4;
+    DISTANCE_UNIT_M = 5;
+    DISTANCE_UNIT_MI = 6;
+    DISTANCE_UNIT_MM = 7;
+    DISTANCE_UNIT_NMI = 8;
+    DISTANCE_UNIT_YD = 9;
+  }
+}
+
+message ScriptSort {
+
+  // [optional] Specifies the sort order (asc or dsc) for the score.
+  SortOrder order = 1;
+  enum SortOrder {
+    SORT_ORDER_UNSPECIFIED = 0;
+    // Sort in ascending order.
+    SORT_ORDER_ASC = 1;
+    // Sort in descending order
+    SORT_ORDER_DESC = 2;
+  }
+
+  // [optional] The script to execute for custom sorting.
+  Script script = 2;
+
+  // [optional] Specifies script sort type.
+  ScriptSortType type = 3;
+  enum ScriptSortType {
+    SCRIPT_SORT_TYPE_UNSPECIFIED = 0;
+    SCRIPT_SORT_TYPE_NUMBER = 1;
+    SCRIPT_SORT_TYPE_STRING = 2;
+    SCRIPT_SORT_TYPE_VERSION = 3;
+  }
+
+  // [optional] Specifies what array value should be chosen for sorting the document.
+  SortMode mode = 4;
+  enum SortMode {
+    SORT_MODE_UNSPECIFIED = 0;
+    // Use the average of all values as sort value. Only applicable for number based array fields.
+    SORT_MODE_AVG = 1;
+    // Pick the highest value.
+    SORT_MODE_MAX = 2;
+    // Use the median of all values as sort value. Only applicable for number based array fields.
+    SORT_MODE_MEDIAN = 3;
+    // Pick the lowest value.
+    SORT_MODE_MIN = 4;
+    // Use the sum of all values as sort value. Only applicable for number based array fields.
+    SORT_MODE_SUM = 5;
+  }
+
+  // Supports sorting by fields that are inside one or more nested objects.
+  NestedSortValue nested = 5;
+
+}
+
+message NestedSortValue {
+
+  // [optional] A filter that the inner objects inside the nested path should match with in order for its field values to be taken into account by sorting. Common case is to repeat the query / filter inside the nested filter or query. By default no filter is active.
+  QueryContainer filter = 1;
+
+  // [optional] The maximum number of children to consider per root document when picking the sort value. Defaults to unlimited.
+  int32 max_children = 2;
+
+  // [optional] Same as top-level nested but applies to another nested path within the current nested object.
+  NestedSortValue nested = 3;
+
+  // [required] Specifies the path to the field on which to sort.
+  string path = 4;
+
+}
+
+message FieldAndFormat {
+
+  // [required] Wildcard pattern. The request returns doc values for field names matching this pattern.
+  string field = 1;
+
+  // [optional] Format in which the values are returned.
+  string format = 2;
+
+  // [optional] Retrieve unmapped fields in an object from _source
+  bool include_unmapped = 3;
+
+}
+
+message FieldCollapse {
+
+  // [required] The document field by which you want to group or collapse the search results
+  string field = 1;
+
+  // [optional] Expanding each group uses an additional query for each inner_hit request for every collapsed hit in the response.
+  repeated InnerHits inner_hits = 2;
+
+  // [optional] Use to control the maximum number of concurrent searches allowed in this phase.
+  int32 max_concurrent_group_searches = 3;
+
+  // [optional] Nested collapse within this collapse.
+  FieldCollapse collapse = 4;
+
+}
+
+message ScriptScoreQuery {
+
+  // Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
+  float boost = 1;
+
+  string name = 2 [json_name = "_name"];
+
+  // Documents with a score lower than this floating point number are excluded from the search results.
+  float min_score = 3;
+
+  QueryContainer query = 4;
+
+  Script script = 5;
+
+}
+
+message ExistsQuery {
+
+  // [optional]
+  // Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
+  float boost = 1;
+  // [optional]
+  // Query name for query tagging.
+  string name = 2 [json_name = "_name"];
+
+  // [required]
+  // Name of the field you wish to search.
+  string field = 3;
+
+}
+
+message SimpleQueryStringQuery {
+
+  // Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
+  float boost = 1;
+
+  string name = 2 [json_name = "_name"];
+
+  // Analyzer used to convert text in the query string into tokens.
+  string analyzer = 3;
+
+  // If `true`, the query attempts to analyze wildcard terms in the query string.
+  bool analyze_wildcard = 4;
+
+  // If `true`, the parser creates a match_phrase query for each multi-position token.
+  bool auto_generate_synonyms_phrase_query = 5;
+
+  Operator default_operator = 6;
+  enum Operator {
+    OPERATOR_UNSPECIFIED = 0;
+    OPERATOR_AND = 1;
+    OPERATOR_OR = 2;
+  }
+
+  repeated string fields = 7;
+
+  PipeSeparatedFlagsSimpleQueryStringFlag flags = 8;
+
+  // Maximum number of terms to which the query expands for fuzzy matching.
+  int32 fuzzy_max_expansions = 9;
+
+  // Number of beginning characters left unchanged for fuzzy matching.
+  int32 fuzzy_prefix_length = 10;
+
+  // If `true`, edits for fuzzy matching include transpositions of two adjacent characters (for example, `ab` to `ba`).
+  bool fuzzy_transpositions = 11;
+
+  // If `true`, format-based errors, such as providing a text value for a numeric field, are ignored.
+  bool lenient = 12;
+
+  MinimumShouldMatch minimum_should_match = 13;
+  // Query string in the simple query string syntax you wish to parse and use for search.
+  string query = 14;
+
+  // Suffix appended to quoted text in the query string.
+  string quote_field_suffix = 15;
+
+}
+
+message WildcardQuery {
+
+  // Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
+  float boost = 1;
+
+  string name = 2 [json_name = "_name"];
+
+  // Allows case insensitive matching of the pattern with the indexed field values when set to `true`. Default is `false` which means the case sensitivity of matching depends on the underlying field's mapping.
+  bool case_insensitive = 3;
+
+  MultiTermQueryRewrite rewrite = 4;
+  enum MultiTermQueryRewrite {
+    MULTI_TERM_QUERY_REWRITE_UNSPECIFIED = 0;
+    MULTI_TERM_QUERY_REWRITE_CONSTANT_SCORE = 1;
+    MULTI_TERM_QUERY_REWRITE_CONSTANT_SCORE_BOOLEAN = 2;
+    MULTI_TERM_QUERY_REWRITE_SCORING_BOOLEAN = 3;
+    MULTI_TERM_QUERY_REWRITE_TOP_TERMS_N = 4;
+    MULTI_TERM_QUERY_REWRITE_TOP_TERMS_BLENDED_FREQS_N = 5;
+    MULTI_TERM_QUERY_REWRITE_TOP_TERMS_BOOST_N = 6;
+  }
+
+  // Wildcard pattern for terms you wish to find in the provided field. Required, when wildcard is not set.
+  string value = 5;
+
+  // Wildcard pattern for terms you wish to find in the provided field. Required, when value is not set.
+  string wildcard = 6;
+
+}
+
+message PipeSeparatedFlagsSimpleQueryStringFlag {
+
+  enum SimpleQueryStringFlag {
+    SIMPLE_QUERY_STRING_FLAG_UNSPECIFIED = 0;
+    SIMPLE_QUERY_STRING_FLAG_ALL = 1;
+    SIMPLE_QUERY_STRING_FLAG_AND = 2;
+    SIMPLE_QUERY_STRING_FLAG_ESCAPE = 3;
+    SIMPLE_QUERY_STRING_FLAG_FUZZY = 4;
+    SIMPLE_QUERY_STRING_FLAG_NEAR = 5;
+    SIMPLE_QUERY_STRING_FLAG_NONE = 6;
+    SIMPLE_QUERY_STRING_FLAG_NOT = 7;
+    SIMPLE_QUERY_STRING_FLAG_OR = 8;
+    SIMPLE_QUERY_STRING_FLAG_PHRASE = 9;
+    SIMPLE_QUERY_STRING_FLAG_PRECEDENCE = 10;
+    SIMPLE_QUERY_STRING_FLAG_PREFIX = 11;
+    SIMPLE_QUERY_STRING_FLAG_SLOP = 12;
+    SIMPLE_QUERY_STRING_FLAG_WHITESPACE = 13;
+  }
+
+  oneof pipe_separated_flags_simple_query_string_flag{
+    string string_value = 1;
+    SimpleQueryStringFlag simple_query_string_flag = 2;
+  }
+
+}
+
+message KnnField {
+  // [optional]
+  // Query vector. Must have the same number of dimensions as the vector field you are searching against.
+  repeated float vector = 1;
+
+  // [optional]
+  // The final number of nearest neighbors to return as top hits.
+  int32 k = 2;
+
+  // [optional]
+  // The minimum similarity score for a neighbor to be considered a hit.
+  float min_score = 3;
+
+  // [optional]
+  // The maximum physical distance in vector space for a neighbor to be considered a hit.
+  float max_distance = 4;
+
+  // [optional]
+  // Filters for the kNN search query. The kNN search will return the top k documents that also match this filter. If filter is not provided, all documents are allowed to match.
+  QueryContainer filter = 5;
+
+  // [optional]
+  // Boost value to apply to kNN scores
+  float boost = 6;
+
+  // [optional]
+  // Method parameters are dependent on the combination of engine and method used to create the index.
+  // Available method ef_search see https://opensearch.org/docs/latest/search-plugins/knn/approximate-knn/#ef_search and nprobes "https://opensearch.org/docs/latest/search-plugins/knn/approximate-knn/#nprobes"
+  map<string, int32> method_parameters = 7;
+
+  // [optional]
+  // Available in version later than 2.17
+  // To explicitly apply rescoring, provide the rescore parameter in a query on a quantized index and specify the oversample_factor "https://opensearch.org/docs/latest/search-plugins/knn/approximate-knn/#rescoring-quantized-results-using-full-precision"
+  map<string, float> rescore = 8;
+
+}
+
+message MatchQueryTypeless {
+  oneof match_query_typeless {
+    // Standard match query for performing a full-text search, including options for fuzzy matching.
+    MatchQuery match_query = 1;
+    // Simplified match query syntax by combining the <field> and query parameters
+    ObjectMap object_map = 2;
+  }
+}
+
+message MatchQuery {
+
+  // [optional]
+  // Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
+  float boost = 1;
+
+  // [optional]
+  // Query name for query tagging
+  string name = 2 [json_name = "_name"];
+
+  // [optional]
+  // The analyzer used to tokenize the query string text.
+  // Default is the index-time analyzer specified for the default_field. If no analyzer is specified for the default_field, the analyzer is the default analyzer for the index.
+  string analyzer = 3;
+
+  // [optional]
+  // Specifies whether to create a match phrase query automatically for multi-term synonyms.
+  // For example, if you specify ba,batting average as synonyms and search for ba, OpenSearch searches for ba OR "batting average" (if this option is true) or ba OR (batting AND average) (if this option is false).
+  // Default is true.
+  bool auto_generate_synonyms_phrase_query = 4;
+
+  // [x-deprecated]
+  float cutoff_frequency = 5;
+
+  // [optional]
+  // The number of character edits (insertions, deletions, substitutions, or transpositions) that it takes to change one word to another when determining whether a term matched a value.
+  // For example, the distance between wined and wind is 1. Valid values are non-negative integers or AUTO.
+  // The default, AUTO, chooses a value based on the length of each term and is a good choice for most use cases.
+  Fuzziness fuzziness = 6;
+
+  // [optional]
+  // Determines how OpenSearch rewrites the query.
+  // Default is constant_score.
+  MultiTermQueryRewrite fuzzy_rewrite = 7;
+  enum MultiTermQueryRewrite {
+    MULTI_TERM_QUERY_REWRITE_UNSPECIFIED = 0;
+    // Uses the constant_score_boolean method for fewer matching terms. Otherwise, this method finds all matching terms in sequence and returns matching documents using a bit set.
+    MULTI_TERM_QUERY_REWRITE_CONSTANT_SCORE = 1;
+    // Assigns each document a relevance score equal to the boost parameter.
+    // This method changes the original query to a bool query. This bool query contains a should clause and term query for each matching term. This method can cause the final bool query to exceed the clause limit in the indices.query.bool.max_clause_count setting. If the query exceeds this limit, opensearch returns an error.
+    MULTI_TERM_QUERY_REWRITE_CONSTANT_SCORE_BOOLEAN = 2;
+    // Calculates a relevance score for each matching document.
+    // This method changes the original query to a bool query. This bool query contains a should clause and term query for each matching term. This method can cause the final bool query to exceed the clause limit in the indices.query.bool.max_clause_count setting. If the query exceeds this limit, Elasticsearch returns an error.
+    MULTI_TERM_QUERY_REWRITE_SCORING_BOOLEAN = 3;
+    // Calculates a relevance score for each matching document.
+    // This method changes the original query to a bool query. This bool query contains a should clause and term query for each matching term. The final bool query only includes term queries for the top N scoring terms. You can use this method to avoid exceeding the clause limit in the indices.query.bool.max_clause_count setting.
+    MULTI_TERM_QUERY_REWRITE_TOP_TERMS_N = 4;
+    // Calculates a relevance score for each matching document as if all terms had the same frequency. This frequency is the maximum frequency of all matching terms.
+    // This method changes the original query to a bool query. This bool query contains a should clause and term query for each matching term. The final bool query only includes term queries for the top N scoring terms. You can use this method to avoid exceeding the clause limit in the indices.query.bool.max_clause_count setting.
+    MULTI_TERM_QUERY_REWRITE_TOP_TERMS_BLENDED_FREQS_N = 5;
+    // Calculates a relevance score for each matching document.
+    // This method changes the original query to a bool query. This bool query contains a should clause and term query for each matching term. The final bool query only includes term queries for the top N scoring terms. You can use this method to avoid exceeding the clause limit in the indices.query.bool.max_clause_count setting.
+    MULTI_TERM_QUERY_REWRITE_TOP_TERMS_BOOST_N = 6;
+  }
+
+  // [optional]
+  // Setting fuzzy_transpositions to true (default) adds swaps of adjacent characters to the insert, delete, and substitute operations of the fuzziness option.
+  // For example, the distance between wind and wnid is 1 if fuzzy_transpositions is true (swap “n” and “i”) and 2 if it is false (delete “n”, insert “n”). If fuzzy_transpositions is false, rewind and wnid have the same distance (2) from wind, despite the more human-centric opinion that wnid is an obvious typo.
+  // The default(true) is a good choice for most use cases.
+  bool fuzzy_transpositions = 8;
+
+  // [optional]
+  // Setting lenient to true ignores data type mismatches between the query and the document field.
+  // For example, a query string of "8.2" could match a field of type float.
+  // Default is false.
+  bool lenient = 9;
+
+  // [optional]
+  // The maximum number of terms to which the query can expand. Fuzzy queries “expand to” a number of matching terms that are within the distance specified in fuzziness. Then OpenSearch tries to match those terms.
+  // Default is 50.
+  int32 max_expansions = 10;
+
+  // [optional]
+  // If the query string contains multiple search terms and you use the or operator, the number of terms that need to match for the document to be considered a match.
+  // For example, if minimum_should_match is 2, wind often rising does not match The Wind Rises. If minimum_should_match is 1, it matches.
+  MinimumShouldMatch minimum_should_match = 11;
+
+  // [optional]
+  // If the query string contains multiple search terms, whether all terms need to match (AND) or only one term needs to match (OR) for a document to be considered a match.
+  // Default is OR.
+  Operator operator = 12;
+  enum Operator {
+    OPERATOR_UNSPECIFIED = 0;
+    // All terms need to match. The string `to be` is interpreted as `to AND be`
+    OPERATOR_AND = 1;
+    // Only one term needs to match. The string `to be` is interpreted as `to OR be`
+    OPERATOR_OR = 2;
+  }
+
+  // [optional]
+  // The number of leading characters that are not considered in fuzziness.
+  // Default is 0.
+  int32 prefix_length = 13;
+
+  message Query {
+    oneof query{
+      // if the query value is string type.
+      string string_value = 1;
+      // if the query value is number type.
+      GeneralNumber general_number = 2;
+      // if the query value is boolean type.
+      bool bool_value = 3;
+    }
+  }
+
+  // [required]
+  // The query string to use for search.
+  Query query = 14;
+
+  // [optional]
+  // In some cases, the analyzer removes all terms from a query string.
+  // For example, the stop analyzer removes all terms from the string an but this. In those cases, zero_terms_query specifies whether to match no documents (none) or all documents (all). Valid values are none and all.
+  // Default is none.
+  ZeroTermsQuery zero_terms_query = 15;
+
+  enum ZeroTermsQuery {
+    ZERO_TERMS_QUERY_UNSPECIFIED = 0;
+    // zero_terms_query specifies whether to match all documents (all).
+    ZERO_TERMS_QUERY_ALL = 1;
+    // zero_terms_query specifies whether to match no documents (none)
+    ZERO_TERMS_QUERY_NONE = 2;
+  }
+
+}
+
+message BoolQuery {
+
+  // Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
+  float boost = 1;
+
+  string name = 2 [json_name = "_name"];
+
+  // The clause (query) must appear in matching documents. However, unlike `must`, the score of the query will be ignored.
+  repeated QueryContainer filter = 3;
+
+  MinimumShouldMatch minimum_should_match = 4;
+
+  // The clause (query) must appear in matching documents and will contribute to the score.
+  repeated QueryContainer must = 5;
+
+  // The clause (query) must not appear in the matching documents. Because scoring is ignored, a score of `0` is returned for all documents.
+  repeated QueryContainer must_not = 6;
+
+  // The clause (query) should appear in the matching document.
+  repeated QueryContainer should = 7;
+
+}
+
+message MinimumShouldMatch{
+  oneof minimum_should_match{
+    // if minimum_should_match is integer type. see "https://opensearch.org/docs/latest/query-dsl/minimum-should-match/#valid-values"
+    int32 int32_value = 1;
+    // if minimum_should_match is string type like percentage or combinations. see "https://opensearch.org/docs/latest/query-dsl/minimum-should-match/#valid-values"
+    string string_value = 2;
+  }
+}
+
+message BoostingQuery {
+
+  // Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
+  float boost = 1;
+
+  string name = 2 [json_name = "_name"];
+
+  // Floating point number between 0 and 1.0 used to decrease the relevance scores of documents matching the `negative` query.
+  float negative_boost = 3;
+
+  QueryContainer negative = 4;
+
+  QueryContainer positive = 5;
+
+}
+
+message ConstantScoreQuery {
+
+  // Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
+  float boost = 1;
+
+  string name = 2 [json_name = "_name"];
+
+  QueryContainer filter = 3;
+
+}
+
+message DisMaxQuery {
+
+  // Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
+  float boost = 1;
+
+  string name = 2 [json_name = "_name"];
+
+  // One or more query clauses. Returned documents must match one or more of these queries. If a document matches multiple queries, OpenSearch uses the highest relevance score.
+  repeated QueryContainer queries = 3;
+
+  // Floating point number between 0 and 1.0 used to increase the relevance scores of documents matching multiple query clauses.
+  float tie_breaker = 4;
+
+}
+
+message FunctionScoreQuery {
+
+  // Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
+  float boost = 1;
+
+  string name = 2 [json_name = "_name"];
+
+  FunctionBoostMode boost_mode = 3;
+
+  enum FunctionBoostMode {
+    FUNCTION_BOOST_MODE_UNSPECIFIED = 0;
+    FUNCTION_BOOST_MODE_AVG = 1;
+    FUNCTION_BOOST_MODE_MAX = 2;
+    FUNCTION_BOOST_MODE_MIN = 3;
+    FUNCTION_BOOST_MODE_MULTIPLY = 4;
+    FUNCTION_BOOST_MODE_REPLACE = 5;
+    FUNCTION_BOOST_MODE_SUM = 6;
+  }
+
+  // One or more functions that compute a new score for each document returned by the query.
+  repeated FunctionScoreContainer functions = 4;
+
+  // Restricts the new score to not exceed the provided limit.
+  float max_boost = 5;
+
+  // Excludes documents that do not meet the provided score threshold.
+  float min_score = 6;
+
+  QueryContainer query = 7;
+
+  FunctionScoreMode score_mode = 8;
+
+  enum FunctionScoreMode {
+    FUNCTION_SCORE_MODE_UNSPECIFIED = 0;
+    FUNCTION_SCORE_MODE_AVG = 1;
+    FUNCTION_SCORE_MODE_FIRST = 2;
+    FUNCTION_SCORE_MODE_MAX = 3;
+    FUNCTION_SCORE_MODE_MIN = 4;
+    FUNCTION_SCORE_MODE_MULTIPLY = 5;
+    FUNCTION_SCORE_MODE_SUM = 6;
+  }
+
+}
+
+message IntervalsAllOf {
+
+  // An array of rules to combine. All rules must produce a match in a document for the overall source to match.
+  repeated IntervalsContainer intervals = 1;
+
+  // Maximum number of positions between the matching terms. Intervals produced by the rules further apart than this are not considered matches.
+  int32 max_gaps = 2;
+
+  // If `true`, intervals produced by the rules should appear in the order in which they are specified.
+  bool ordered = 3;
+
+  IntervalsFilter filter = 4;
+
+}
+
+message IntervalsAnyOf {
+
+  // An array of rules to match.
+  repeated IntervalsContainer intervals = 1;
+
+  IntervalsFilter filter = 2;
+
+}
+
+message IntervalsMatch {
+
+  // Analyzer used to analyze terms in the query.
+  string analyzer = 1;
+
+  // Maximum number of positions between the matching terms. Terms further apart than this are not considered matches.
+  int32 max_gaps = 2;
+
+  // If `true`, matching terms must appear in their specified order.
+  bool ordered = 3;
+
+  // Text you wish to find in the provided field.
+  string query = 4;
+
+  // Path to field or array of paths. Some API's support wildcards in the path to select multiple fields.
+  string use_field = 5;
+
+  IntervalsFilter filter = 6;
+
+}
+
+message IntervalsQuery {
+
+  // Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
+  float boost = 1;
+
+  string name = 2 [json_name = "_name"];
+
+  oneof intervals_query {
+    IntervalsAllOf all_of = 3;
+
+    IntervalsAnyOf any_of = 4;
+
+    IntervalsFuzzy fuzzy = 5;
+
+    IntervalsMatch match = 6;
+
+    IntervalsPrefix prefix = 7;
+
+    IntervalsWildcard wildcard = 8;
+  }
+
+}
+
+message FunctionScoreContainer {
+  QueryContainer filter = 1;
+
+  float weight = 2;
+
+  //TODO: add decay function
+  oneof function_score_container {
+
+    //   Decay function not supported
+    //    DecayFunction exp = 3;
+    //
+    //    DecayFunction gauss = 4;
+    //
+    //    DecayFunction linear = 5;
+
+    FieldValueFactorScoreFunction field_value_factor = 6;
+
+    RandomScoreFunction random_score = 7;
+
+    ScriptScoreFunction script_score = 8;
+  }
+
+}
+
+message ScriptScoreFunction {
+
+  Script script = 1;
+
+}
+
+message IntervalsFilter {
+  oneof intervals_filter {
+    IntervalsContainer after = 1;
+
+    IntervalsContainer before = 2;
+
+    IntervalsContainer contained_by = 3;
+
+    IntervalsContainer containing = 4;
+
+    IntervalsContainer not_contained_by = 5;
+
+    IntervalsContainer not_containing = 6;
+
+    IntervalsContainer not_overlapping = 7;
+
+    IntervalsContainer overlapping = 8;
+
+    Script script = 9;
+  }
+
+}
+
+message IntervalsContainer {
+
+  oneof intervals_container {
+    IntervalsAllOf all_of = 1;
+
+    IntervalsAnyOf any_of = 2;
+
+    IntervalsFuzzy fuzzy = 3;
+
+    IntervalsMatch match = 4;
+
+    IntervalsPrefix prefix = 5;
+
+    IntervalsWildcard wildcard = 6;
+  }
+
+}
+
+message PrefixQuery {
+
+  // [optional]
+  // Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
+  float boost = 1;
+
+  // [optional]
+  // Query name for query tagging
+  string name = 2 [json_name = "_name"];
+
+  // [optional]
+  // Determines how OpenSearch rewrites the query.
+  // Default is constant_score.
+  MultiTermQueryRewrite rewrite = 3;
+  enum MultiTermQueryRewrite {
+    MULTI_TERM_QUERY_REWRITE_UNSPECIFIED = 0;
+    // Uses the constant_score_boolean method for fewer matching terms. Otherwise, this method finds all matching terms in sequence and returns matching documents using a bit set.
+    MULTI_TERM_QUERY_REWRITE_CONSTANT_SCORE = 1;
+    // Assigns each document a relevance score equal to the boost parameter.
+    // This method changes the original query to a bool query. This bool query contains a should clause and term query for each matching term. This method can cause the final bool query to exceed the clause limit in the indices.query.bool.max_clause_count setting. If the query exceeds this limit, opensearch returns an error.
+    MULTI_TERM_QUERY_REWRITE_CONSTANT_SCORE_BOOLEAN = 2;
+    // Calculates a relevance score for each matching document.
+    // This method changes the original query to a bool query. This bool query contains a should clause and term query for each matching term. This method can cause the final bool query to exceed the clause limit in the indices.query.bool.max_clause_count setting. If the query exceeds this limit, Elasticsearch returns an error.
+    MULTI_TERM_QUERY_REWRITE_SCORING_BOOLEAN = 3;
+    // Calculates a relevance score for each matching document.
+    // This method changes the original query to a bool query. This bool query contains a should clause and term query for each matching term. The final bool query only includes term queries for the top N scoring terms. You can use this method to avoid exceeding the clause limit in the indices.query.bool.max_clause_count setting.
+    MULTI_TERM_QUERY_REWRITE_TOP_TERMS_N = 4;
+    // Calculates a relevance score for each matching document as if all terms had the same frequency. This frequency is the maximum frequency of all matching terms.
+    // This method changes the original query to a bool query. This bool query contains a should clause and term query for each matching term. The final bool query only includes term queries for the top N scoring terms. You can use this method to avoid exceeding the clause limit in the indices.query.bool.max_clause_count setting.
+    MULTI_TERM_QUERY_REWRITE_TOP_TERMS_BLENDED_FREQS_N = 5;
+    // Calculates a relevance score for each matching document.
+    // This method changes the original query to a bool query. This bool query contains a should clause and term query for each matching term. The final bool query only includes term queries for the top N scoring terms. You can use this method to avoid exceeding the clause limit in the indices.query.bool.max_clause_count setting.
+    MULTI_TERM_QUERY_REWRITE_TOP_TERMS_BOOST_N = 6;
+  }
+
+  // [required]
+  // The term to search for in the field specified in <field>.
+  string value = 4;
+
+  // [optional]
+  // Allows ASCII case insensitive matching of the value with the indexed field values when set to `true`. Default is `false` which means the case sensitivity of matching depends on the underlying field's mapping.
+  bool case_insensitive = 5;
+
+}
+
+message TermsLookupFieldStringArrayMap {
+  oneof terms_lookup_field_string_array_map {
+    // terms_lookup_field terms you wish to find in the provided field
+    TermsLookupField terms_lookup_field = 1;
+    // string_array terms value you wish to find in the provided field
+    StringArray string_array = 2;
+  }
+}
+
+message TermsQueryField {
+  // [optional]
+  // A floating-point value that specifies the weight of this field toward the relevance score. Values above 1.0 increase the field's relevance. Values between 0.0 and 1.0 decrease the field's relevance.
+  // Default is 1.0.
+  optional float boost = 1;
+
+  // [required]
+  map<string, TermsLookupFieldStringArrayMap> terms_lookup_field_string_array_map = 2;
+}
+
+message TermsLookupField {
+
+  // [required]
+  // The name of the index from which to fetch field values
+  string index = 1;
+
+  // [required]
+  // The document ID of the document from which to fetch field values.
+  string id = 2;
+
+  // [required]
+  // The name of the field from which to fetch field values. Specify nested fields using dot path notation
+  string path = 3;
+
+  // [optional]
+  // Custom routing value of the document from which to fetch term values. If a custom routing value was provided when the document was indexed, this parameter is required.
+  repeated string routing = 4;
+}
+
+message TermsSetQuery {
+  // [optional]
+  // Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
+  float boost = 1;
+
+  // [optional]
+  // Query name for query tagging
+  string name = 2 [json_name = "_name"];
+
+  // [optional]
+  // The name of the numeric field that specifies the number of matching terms required in order to return a document in the results.
+  string minimum_should_match_field = 3;
+
+  // [optional]
+  // A script that returns the number of matching terms required in order to return a document in the results.
+  Script minimum_should_match_script = 4;
+
+  // [required]
+  // The array of terms to search for in the field specified in <field>. A document is returned in the results only if the required number of terms matches the document's field values exactly, with the correct spacing and capitalization.
+  repeated string terms = 5;
+
+}
+
+message TermQueryFieldValue {
+  oneof term_query_field_value{
+    TermQuery term_query = 1;
+    FieldValue field_value = 2;
+  }
+}
+
+message TermQuery {
+  // [optional]
+  // Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
+  float boost = 1;
+
+  // [optional]
+  // Query name for query tagging
+  string name = 2 [json_name = "_name"];
+
+  // [required]
+  // Term you wish to find in the provided <field>. To return a document, the term must exactly match the field value, including whitespace and capitalization.
+  FieldValue value = 3;
+
+  // [optional]
+  // Allows ASCII case insensitive matching of the value with the indexed field values when set to `true`. When `false`, the case sensitivity of matching depends on the underlying field's mapping.
+  bool case_insensitive = 4;
+
+}
+
+
+message QueryStringQuery {
+
+  // Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
+  float boost = 1;
+
+  string name = 2 [json_name = "_name"];
+
+  bool allow_leading_wildcard = 3;
+
+  // Analyzer used to convert text in the query string into tokens.
+  string analyzer = 4;
+
+  // If `true`, the query attempts to analyze wildcard terms in the query string.
+  bool analyze_wildcard = 5;
+
+  // If `true`, match phrase queries are automatically created for multi-term synonyms.
+  bool auto_generate_synonyms_phrase_query = 6;
+
+  // Path to field or array of paths. Some API's support wildcards in the path to select multiple fields.
+  string default_field = 7;
+
+  Operator default_operator = 8;
+  enum Operator {
+    OPERATOR_UNSPECIFIED = 0;
+    OPERATOR_AND = 1;
+    OPERATOR_OR = 2;
+  }
+
+  // If `true`, enable position increments in queries constructed from a `query_string` search.
+  bool enable_position_increments = 9;
+
+  bool escape = 10;
+
+  repeated string fields = 11;
+
+  Fuzziness fuzziness = 12;
+
+  // Maximum number of terms to which the query expands for fuzzy matching.
+  int32 fuzzy_max_expansions = 13;
+
+  // Number of beginning characters left unchanged for fuzzy matching.
+  int32 fuzzy_prefix_length = 14;
+
+  MultiTermQueryRewrite fuzzy_rewrite = 15;
+  enum MultiTermQueryRewrite {
+    MULTI_TERM_QUERY_REWRITE_UNSPECIFIED = 0;
+    MULTI_TERM_QUERY_REWRITE_CONSTANT_SCORE = 1;
+    MULTI_TERM_QUERY_REWRITE_CONSTANT_SCORE_BOOLEAN = 2;
+    MULTI_TERM_QUERY_REWRITE_SCORING_BOOLEAN = 3;
+    MULTI_TERM_QUERY_REWRITE_TOP_TERMS_N = 4;
+    MULTI_TERM_QUERY_REWRITE_TOP_TERMS_BLENDED_FREQS_N = 5;
+    MULTI_TERM_QUERY_REWRITE_TOP_TERMS_BOOST_N = 6;
+  }
+
+  // If `true`, edits for fuzzy matching include transpositions of two adjacent characters (for example, `ab` to `ba`).
+  bool fuzzy_transpositions = 16;
+
+  // If `true`, format-based errors, such as providing a text value for a numeric field, are ignored.
+  bool lenient = 17;
+
+  // Maximum number of automaton states required for the query.
+  int32 max_determinized_states = 18;
+
+  MinimumShouldMatch minimum_should_match = 19;
+
+  // Maximum number of positions allowed between matching tokens for phrases.
+  int32 phrase_slop = 20;
+
+  // Query string you wish to parse and use for search.
+  string query = 21;
+
+  // Analyzer used to convert quoted text in the query string into tokens. For quoted text, this parameter overrides the analyzer specified in the `analyzer` parameter.
+  string quote_analyzer = 22;
+
+  // Suffix appended to quoted text in the query string. You can use this suffix to use a different analysis method for exact matches.
+  string quote_field_suffix = 23;
+
+  MultiTermQueryRewrite rewrite = 24;
+
+  // How to combine the queries generated from the individual search terms in the resulting `dis_max` query.
+  float tie_breaker = 25;
+
+  string time_zone = 26;
+
+  TextQueryType type = 27;
+  enum TextQueryType {
+    TEXT_QUERY_TYPE_UNSPECIFIED = 0;
+    TEXT_QUERY_TYPE_BEST_FIELDS = 1;
+    TEXT_QUERY_TYPE_BOOL_PREFIX = 2;
+    TEXT_QUERY_TYPE_CROSS_FIELDS = 3;
+    TEXT_QUERY_TYPE_MOST_FIELDS = 4;
+    TEXT_QUERY_TYPE_PHRASE = 5;
+    TEXT_QUERY_TYPE_PHRASE_PREFIX = 6;
+  }
+
+}
+
+message RandomScoreFunction {
+
+  // Path to field or array of paths. Some API's support wildcards in the path to select multiple fields.
+  string field = 1;
+
+  message Seed {
+    oneof seed {
+      int32 int32_value = 1;
+      string string_value = 2;
+    }
+  }
+  Seed seed = 2;
+}
+
+// TODO: need to revisit RangeQuery def
+message RangeQuery {
+  oneof range_query{
+    DateRangeQuery date_range_query = 1;
+    NumberRangeQuery number_range_query = 2;
+  }
+}
+
+message RegexpQuery {
+
+  // Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
+  float boost = 1;
+
+  string name = 2 [json_name = "_name"];
+
+  // Allows case insensitive matching of the regular expression value with the indexed field values when set to `true`. When `false`, case sensitivity of matching depends on the underlying field's mapping.
+  bool case_insensitive = 3;
+
+  // Enables optional operators for the regular expression.
+  string flags = 4;
+
+  // Maximum number of automaton states required for the query.
+  int32 max_determinized_states = 5;
+
+  MultiTermQueryRewrite rewrite = 6;
+  enum MultiTermQueryRewrite {
+    MULTI_TERM_QUERY_REWRITE_UNSPECIFIED = 0;
+    MULTI_TERM_QUERY_REWRITE_CONSTANT_SCORE = 1;
+    MULTI_TERM_QUERY_REWRITE_CONSTANT_SCORE_BOOLEAN = 2;
+    MULTI_TERM_QUERY_REWRITE_SCORING_BOOLEAN = 3;
+    MULTI_TERM_QUERY_REWRITE_TOP_TERMS_N = 4;
+    MULTI_TERM_QUERY_REWRITE_TOP_TERMS_BLENDED_FREQS_N = 5;
+    MULTI_TERM_QUERY_REWRITE_TOP_TERMS_BOOST_N = 6;
+  }
+
+  // Regular expression for terms you wish to find in the provided field.
+  string value = 7;
+
+}
+
+message DateRangeQuery {
+
+  // Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
+  float boost = 1;
+
+  string name = 2 [json_name = "_name"];
+
+  RangeRelation relation = 3;
+  enum RangeRelation {
+    RANGE_RELATION_UNSPECIFIED = 0;
+    RANGE_RELATION_CONTAINS = 1;
+    RANGE_RELATION_INTERSECTS = 2;
+    RANGE_RELATION_WITHIN = 3;
+  }
+
+  string gt = 4;
+
+  string gte = 5;
+
+  string lt = 6;
+
+  string lte = 7;
+
+  message From {
+    oneof from {
+      string string_value = 1;
+      NullValue null_value = 2;
+    }
+  }
+
+  From from = 8;
+
+  message To {
+    oneof to {
+      string string_value = 1;
+      NullValue null_value = 2;
+    }
+  }
+  To to = 9;
+
+  string format = 10;
+
+  string time_zone = 11;
+
+}
+
+message NumberRangeQuery {
+
+  // Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
+  float boost = 1;
+
+  string name = 2 [json_name = "_name"];
+
+  RangeRelation relation = 3;
+  enum RangeRelation {
+    RANGE_RELATION_UNSPECIFIED = 0;
+    RANGE_RELATION_CONTAINS = 1;
+    RANGE_RELATION_INTERSECTS = 2;
+    RANGE_RELATION_WITHIN = 3;
+  }
+
+
+  // Greater than.
+  GeneralNumber gt = 4;
+
+  // Greater than or equal to.
+  GeneralNumber gte = 5;
+
+  // Less than.
+  GeneralNumber lt = 6;
+
+  // Less than or equal to.
+  GeneralNumber lte = 7;
+
+  message From {
+    oneof from {
+      string string_value = 1;
+      GeneralNumber general_number = 2;
+      NullValue null_value = 3;
+    }
+  }
+  From from = 8;
+
+  message To {
+    oneof to {
+      string string_value = 1;
+      GeneralNumber general_number = 2;
+      NullValue null_value = 3;
+    }
+  }
+  To to = 9;
+}
+
+message FuzzyQuery {
+
+  // [optional]
+  // Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
+  float boost = 1;
+
+  // [optional]
+  // Query name for query tagging
+  string name = 2 [json_name = "_name"];
+
+  // [optional]
+  // The maximum number of terms to which the query can expand. Fuzzy queries “expand to” a number of matching terms that are within the distance specified in fuzziness. Then OpenSearch tries to match those terms. Default is 50.
+  int32 max_expansions = 3;
+
+  // [optional]
+  // The number of leading characters that are not considered in fuzziness. Default is 0.
+  int32 prefix_length = 4;
+
+  // [optional]
+  // Determines how OpenSearch rewrites the query.
+  // Default is constant_score.
+  MultiTermQueryRewrite rewrite = 5;
+  enum MultiTermQueryRewrite {
+    MULTI_TERM_QUERY_REWRITE_UNSPECIFIED = 0;
+    // Uses the constant_score_boolean method for fewer matching terms. Otherwise, this method finds all matching terms in sequence and returns matching documents using a bit set.
+    MULTI_TERM_QUERY_REWRITE_CONSTANT_SCORE = 1;
+    // Assigns each document a relevance score equal to the boost parameter.
+    // This method changes the original query to a bool query. This bool query contains a should clause and term query for each matching term. This method can cause the final bool query to exceed the clause limit in the indices.query.bool.max_clause_count setting. If the query exceeds this limit, opensearch returns an error.
+    MULTI_TERM_QUERY_REWRITE_CONSTANT_SCORE_BOOLEAN = 2;
+    // Calculates a relevance score for each matching document.
+    // This method changes the original query to a bool query. This bool query contains a should clause and term query for each matching term. This method can cause the final bool query to exceed the clause limit in the indices.query.bool.max_clause_count setting. If the query exceeds this limit, Elasticsearch returns an error.
+    MULTI_TERM_QUERY_REWRITE_SCORING_BOOLEAN = 3;
+    // Calculates a relevance score for each matching document.
+    // This method changes the original query to a bool query. This bool query contains a should clause and term query for each matching term. The final bool query only includes term queries for the top N scoring terms. You can use this method to avoid exceeding the clause limit in the indices.query.bool.max_clause_count setting.
+    MULTI_TERM_QUERY_REWRITE_TOP_TERMS_N = 4;
+    // Calculates a relevance score for each matching document as if all terms had the same frequency. This frequency is the maximum frequency of all matching terms.
+    // This method changes the original query to a bool query. This bool query contains a should clause and term query for each matching term. The final bool query only includes term queries for the top N scoring terms. You can use this method to avoid exceeding the clause limit in the indices.query.bool.max_clause_count setting.
+    MULTI_TERM_QUERY_REWRITE_TOP_TERMS_BLENDED_FREQS_N = 5;
+    // Calculates a relevance score for each matching document.
+    // This method changes the original query to a bool query. This bool query contains a should clause and term query for each matching term. The final bool query only includes term queries for the top N scoring terms. You can use this method to avoid exceeding the clause limit in the indices.query.bool.max_clause_count setting.
+    MULTI_TERM_QUERY_REWRITE_TOP_TERMS_BOOST_N = 6;
+  }
+  // [optional]
+  // Specifies whether to allow transpositions of two adjacent characters (ab to ba) as edits. Default is true.
+  bool transpositions = 6;
+  // [optional]
+  // The number of character edits (insert, delete, substitute) needed to change one word to another when determining whether a term matched a value.
+  Fuzziness fuzziness = 7;
+
+  message Value {
+    oneof value {
+      string string_value = 1;
+      bool bool_value = 2;
+      GeneralNumber general_number = 3;
+    }
+  }
+
+  // [required]
+  // Term you wish to find in the provided <field>.
+  Value value = 8;
+}
+
+message Fuzziness{
+
+  oneof fuzziness{
+    // AUTO: Generates an edit distance based on the length of the term. Low and high distance arguments may be optionally provided AUTO:[low],[high]. AUTO should generally be the preferred value for fuzziness.
+    string string_value = 1;
+    // 0,1,2: The maximum allowed Levenshtein Edit Distance (or number of edits)
+    int32 int32_value = 2;
+  }
+
+}
+
+message FieldValue {
+  oneof type{
+    GeneralNumber general_number = 1;
+    string string_value = 2;
+    ObjectMap object_map = 3;
+    bool bool_value = 4;
+  }
+}
+
+message FieldValueResponse {
+  oneof value{
+    double double_value = 1;
+    string string_value = 2;
+    .google.protobuf.Struct object = 3;
+    bool bool_value = 4;
+  }
+}
+
+message IdsQuery {
+
+  float boost = 1;
+
+  string name = 2 [json_name = "_name"];
+
+  repeated string values = 3;
+
+}
+
+message IntervalsFuzzy {
+
+  // Analyzer used to normalize the term.
+  string analyzer = 1;
+
+  Fuzziness fuzziness = 2;
+
+  // Number of beginning characters left unchanged when creating expansions.
+  int32 prefix_length = 3;
+
+  // The term to match.
+  string term = 4;
+
+  // Indicates whether edits include transpositions of two adjacent characters (for example, `ab` to `ba`).
+  bool transpositions = 5;
+
+  // Path to field or array of paths. Some API's support wildcards in the path to select multiple fields.
+  string use_field = 6;
+
+}
+
+message IntervalsPrefix {
+
+  // Analyzer used to analyze the `prefix`.
+  string analyzer = 1;
+
+  // Beginning characters of terms you wish to find in the top-level field.
+  string prefix = 2;
+
+  // Path to field or array of paths. Some API's support wildcards in the path to select multiple fields.
+  string use_field = 3;
+
+}
+
+message IntervalsWildcard {
+
+  // Analyzer used to analyze the `pattern`. Defaults to the top-level field's analyzer.
+  string analyzer = 1;
+
+  // Wildcard pattern used to find matching terms.
+  string pattern = 2;
+
+  // Path to field or array of paths. Some API's support wildcards in the path to select multiple fields.
+  string use_field = 3;
+
+}
+
+message MatchAllQuery {
+
+  // [optional]
+  // Boosts the clause by the given multiplier. Useful for weighing clauses in compound queries. Values in the [0, 1) range decrease relevance, and values greater than 1 increase relevance. Default is 1.
+  float boost = 1;
+
+  // [optional]
+  // Query name for query tagging
+  string name = 2 [json_name = "_name"];
+}
+
+message MatchBoolPrefixQuery {
+  // [optional]
+  // Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
+  float boost = 1;
+
+  // [optional]
+  // Query name for query tagging
+  string name = 2 [json_name = "_name"];
+
+  // [optional]
+  // The analyzer used to tokenize the query string text.
+  // Default is the index-time analyzer specified for the default_field. If no analyzer is specified for the default_field, the analyzer is the default analyzer for the index.
+  string analyzer = 3;
+
+  // [optional]
+  // The number of character edits (insert, delete, substitute) that it takes to change one word to another when determining whether a term matched a value.
+  // For example, the distance between wined and wind is 1.
+  // The default, AUTO, chooses a value based on the length of each term and is a good choice for most use cases.
+  Fuzziness fuzziness = 4;
+
+  // [optional]
+  // Determines how OpenSearch rewrites the query.
+  // Default is constant_score.
+  MultiTermQueryRewrite fuzzy_rewrite = 5;
+  enum MultiTermQueryRewrite {
+    MULTI_TERM_QUERY_REWRITE_UNSPECIFIED = 0;
+    // Uses the constant_score_boolean method for fewer matching terms. Otherwise, this method finds all matching terms in sequence and returns matching documents using a bit set.
+    MULTI_TERM_QUERY_REWRITE_CONSTANT_SCORE = 1;
+    // Assigns each document a relevance score equal to the boost parameter.
+    // This method changes the original query to a bool query. This bool query contains a should clause and term query for each matching term. This method can cause the final bool query to exceed the clause limit in the indices.query.bool.max_clause_count setting. If the query exceeds this limit, opensearch returns an error.
+    MULTI_TERM_QUERY_REWRITE_CONSTANT_SCORE_BOOLEAN = 2;
+    // Calculates a relevance score for each matching document.
+    // This method changes the original query to a bool query. This bool query contains a should clause and term query for each matching term. This method can cause the final bool query to exceed the clause limit in the indices.query.bool.max_clause_count setting. If the query exceeds this limit, Elasticsearch returns an error.
+    MULTI_TERM_QUERY_REWRITE_SCORING_BOOLEAN = 3;
+    // Calculates a relevance score for each matching document.
+    // This method changes the original query to a bool query. This bool query contains a should clause and term query for each matching term. The final bool query only includes term queries for the top N scoring terms. You can use this method to avoid exceeding the clause limit in the indices.query.bool.max_clause_count setting.
+    MULTI_TERM_QUERY_REWRITE_TOP_TERMS_N = 4;
+    // Calculates a relevance score for each matching document as if all terms had the same frequency. This frequency is the maximum frequency of all matching terms.
+    // This method changes the original query to a bool query. This bool query contains a should clause and term query for each matching term. The final bool query only includes term queries for the top N scoring terms. You can use this method to avoid exceeding the clause limit in the indices.query.bool.max_clause_count setting.
+    MULTI_TERM_QUERY_REWRITE_TOP_TERMS_BLENDED_FREQS_N = 5;
+    // Calculates a relevance score for each matching document.
+    // This method changes the original query to a bool query. This bool query contains a should clause and term query for each matching term. The final bool query only includes term queries for the top N scoring terms. You can use this method to avoid exceeding the clause limit in the indices.query.bool.max_clause_count setting.
+    MULTI_TERM_QUERY_REWRITE_TOP_TERMS_BOOST_N = 6;
+  }
+
+  // [optional]
+  // Setting fuzzy_transpositions to true (default) adds swaps of adjacent characters to the insert, delete, and substitute operations of the fuzziness option.
+  // For example, the distance between wind and wnid is 1 if fuzzy_transpositions is true (swap “n” and “i”) and 2 if it is false (delete “n”, insert “n”). If fuzzy_transpositions is false, rewind and wnid have the same distance (2) from wind, despite the more human-centric opinion that wnid is an obvious typo.
+  // The default(true) is a good choice for most use cases.
+  bool fuzzy_transpositions = 6;
+
+  // [optional]
+  // The maximum number of terms to which the query can expand. Fuzzy queries “expand to” a number of matching terms that are within the distance specified in fuzziness. Then OpenSearch tries to match those terms.
+  // Default is 50.
+  int32 max_expansions = 7;
+
+  // [optional]
+  // If the query string contains multiple search terms and you use the or operator, the number of terms that need to match for the document to be considered a match.
+  // For example, if minimum_should_match is 2, wind often rising does not match The Wind Rises. If minimum_should_match is 1, it matches.
+  MinimumShouldMatch minimum_should_match = 8;
+
+  // [optional]
+  // If the query string contains multiple search terms, whether all terms need to match (and) or only one term needs to match (or) for a document to be considered a match.
+  // Default is or.
+  Operator operator = 9;
+  enum Operator {
+    OPERATOR_UNSPECIFIED = 0;
+    // All terms need to match. The string `to be` is interpreted as `to AND be`
+    OPERATOR_AND = 1;
+    // Only one term needs to match. The string `to be` is interpreted as `to OR be`
+    OPERATOR_OR = 2;
+  }
+
+  // [optional]
+  // The number of leading characters that are not considered in fuzziness.
+  // Default is 0.
+  int32 prefix_length = 10;
+
+  // [required]
+  // Terms you wish to find in the provided field. The last term is used in a prefix query.
+  string query = 11;
+
+}
+
+message MatchNoneQuery {
+
+  float boost = 1;
+
+  string name = 2 [json_name = "_name"];
+
+  ObjectMap object = 3;
+}
+
+message MatchPhrasePrefixQuery {
+  // [optional]
+  // Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
+  float boost = 1;
+
+  // [optional]
+  // Query name for query tagging
+  string name = 2 [json_name = "_name"];
+
+  // [optional]
+  // The analyzer used to tokenize the query string text.
+  // Default is the index-time analyzer specified for the default_field. If no analyzer is specified for the default_field, the analyzer is the default analyzer for the index.
+  string analyzer = 3;
+
+  // [optional]
+  // The maximum number of terms to which the query can expand. Fuzzy queries “expand to” a number of matching terms that are within the distance specified in fuzziness. Then OpenSearch tries to match those terms.
+  // Default is 50.
+  int32 max_expansions = 4;
+
+  // [required]
+  // The query string to use for search
+  string query = 5;
+
+  // [optional]
+  // Controls the degree to which words in a query can be misordered and still be considered a match. From the Lucene documentation: “The number of other words permitted between words in query phrase.
+  // For example, to switch the order of two words requires two moves (the first move places the words atop one another), so to permit reorderings of phrases, the slop must be at least two. A value of zero requires an exact match.”
+  int32 slop = 6;
+
+  // [optional]
+  // In some cases, the analyzer removes all terms from a query string. For example, the stop analyzer removes all terms from the string an but this. In those cases, zero_terms_query specifies whether to match no documents (none) or all documents (all). Valid values are none and all.
+  // Default is none.
+  ZeroTermsQuery zero_terms_query = 7;
+  enum ZeroTermsQuery {
+    ZERO_TERMS_QUERY_UNSPECIFIED = 0;
+    // zero_terms_query specifies whether to match all documents (all).
+    ZERO_TERMS_QUERY_ALL = 1;
+    // zero_terms_query specifies whether to match no documents (none)
+    ZERO_TERMS_QUERY_NONE = 2;
+  }
+
+}
+
+message MatchPhraseQuery {
+
+  // [optional]
+  // Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
+  float boost = 1;
+
+  // [optional]
+  // Query name for query tagging
+  string name = 2 [json_name = "_name"];
+
+  // [optional]
+  // The analyzer used to tokenize the query string text.
+  // Default is the index-time analyzer specified for the default_field. If no analyzer is specified for the default_field, the analyzer is the default analyzer for the index.
+  string analyzer = 3;
+
+  // [required]
+  // The query string to use for search.
+  string query = 4;
+
+  // [optional]
+  // Controls the degree to which words in a query can be misordered and still be considered a match. From the Lucene documentation: “The number of other words permitted between words in query phrase. For example, to switch the order of two words requires two moves (the first move places the words atop one another), so to permit reorderings of phrases, the slop must be at least two. A value of zero requires an exact match.”
+  int32 slop = 5;
+
+  // [optional]
+  // In some cases, the analyzer removes all terms from a query string. For example, the stop analyzer removes all terms from the string an but this. In those cases, zero_terms_query specifies whether to match no documents (none) or all documents (all). Valid values are none and all.
+  // Default is none.
+  ZeroTermsQuery zero_terms_query = 6;
+  enum ZeroTermsQuery {
+    ZERO_TERMS_QUERY_UNSPECIFIED = 0;
+    // zero_terms_query specifies whether to match all documents (all).
+    ZERO_TERMS_QUERY_ALL = 1;
+    // zero_terms_query specifies whether to match no documents (none)
+    ZERO_TERMS_QUERY_NONE = 2;
+  }
+
+}
+
+message MultiMatchQuery {
+
+  // Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
+  float boost = 1;
+
+  string name = 2 [json_name = "_name"];
+
+  // Analyzer used to convert the text in the query value into tokens.
+  string analyzer = 3;
+
+  // If `true`, match phrase queries are automatically created for multi-term synonyms.
+  bool auto_generate_synonyms_phrase_query = 4;
+
+  float cutoff_frequency = 5;
+
+  repeated string fields = 6;
+
+  Fuzziness fuzziness = 7;
+
+  string fuzzy_rewrite = 8;
+
+  // If `true`, edits for fuzzy matching include transpositions of two adjacent characters (for example, `ab` to `ba`). Can be applied to the term subqueries constructed for all terms but the final term.
+  MultiTermQueryRewrite fuzzy_transpositions = 9;
+  enum MultiTermQueryRewrite {
+    MULTI_TERM_QUERY_REWRITE_UNSPECIFIED = 0;
+    MULTI_TERM_QUERY_REWRITE_CONSTANT_SCORE = 1;
+    MULTI_TERM_QUERY_REWRITE_CONSTANT_SCORE_BOOLEAN = 2;
+    MULTI_TERM_QUERY_REWRITE_SCORING_BOOLEAN = 3;
+    MULTI_TERM_QUERY_REWRITE_TOP_TERMS_N = 4;
+    MULTI_TERM_QUERY_REWRITE_TOP_TERMS_BLENDED_FREQS_N = 5;
+    MULTI_TERM_QUERY_REWRITE_TOP_TERMS_BOOST_N = 6;
+  }
+
+  // If `true`, format-based errors, such as providing a text query value for a numeric field, are ignored.
+  bool lenient = 10;
+
+  // Maximum number of terms to which the query will expand.
+  int32 max_expansions = 11;
+
+  MinimumShouldMatch minimum_should_match = 12;
+
+  Operator operator = 13;
+  enum Operator {
+    OPERATOR_UNSPECIFIED = 0;
+    OPERATOR_AND = 1;
+    OPERATOR_OR = 2;
+  }
+
+  // Number of beginning characters left unchanged for fuzzy matching.
+  int32 prefix_length = 14;
+
+  // Text, number, boolean value or date you wish to find in the provided field.
+  string query = 15;
+
+  // Maximum number of positions allowed between matching tokens.
+  int32 slop = 16;
+
+  // Determines how scores for each per-term blended query and scores across groups are combined.
+  float tie_breaker = 17;
+
+  TextQueryType type = 18;
+  enum TextQueryType {
+    TEXT_QUERY_TYPE_UNSPECIFIED = 0;
+    TEXT_QUERY_TYPE_BEST_FIELDS = 1;
+    TEXT_QUERY_TYPE_BOOL_PREFIX = 2;
+    TEXT_QUERY_TYPE_CROSS_FIELDS = 3;
+    TEXT_QUERY_TYPE_MOST_FIELDS = 4;
+    TEXT_QUERY_TYPE_PHRASE = 5;
+    TEXT_QUERY_TYPE_PHRASE_PREFIX = 6;
+  }
+
+  ZeroTermsQuery zero_terms_query = 19;
+  enum ZeroTermsQuery {
+    ZERO_TERMS_QUERY_UNSPECIFIED = 0;
+    ZERO_TERMS_QUERY_ALL = 1;
+    ZERO_TERMS_QUERY_NONE = 2;
+  }
+
+}
+
+message FieldValueFactorScoreFunction {
+
+  // Path to field or array of paths. Some API's support wildcards in the path to select multiple fields.
+  string field = 1;
+
+  // Optional factor to multiply the field value with.
+  float factor = 2;
+
+  // Value used if the document doesn't have that field. The modifier and factor are still applied to it as though it were read from the document.
+  double missing = 3;
+
+  FieldValueFactorModifier modifier = 4;
+
+  enum FieldValueFactorModifier {
+    FIELD_VALUE_FACTOR_MODIFIER_UNSPECIFIED = 0;
+    FIELD_VALUE_FACTOR_MODIFIER_LN = 1;
+    FIELD_VALUE_FACTOR_MODIFIER_LN1P = 2;
+    FIELD_VALUE_FACTOR_MODIFIER_LN2P = 3;
+    FIELD_VALUE_FACTOR_MODIFIER_LOG = 4;
+    FIELD_VALUE_FACTOR_MODIFIER_LOG1P = 5;
+    FIELD_VALUE_FACTOR_MODIFIER_LOG2P = 6;
+    FIELD_VALUE_FACTOR_MODIFIER_NONE = 7;
+    FIELD_VALUE_FACTOR_MODIFIER_RECIPROCAL = 8;
+    FIELD_VALUE_FACTOR_MODIFIER_SQRT = 9;
+    FIELD_VALUE_FACTOR_MODIFIER_SQUARE = 10;
+  }
+
+}
+
+message DutchAnalyzer{
+  enum Type {
+    TYPE_UNSPECIFIED = 0;
+    TYPE_DUTCH = 1;
+  }
+  Type type = 1;
+
+  repeated string stopwords = 2;
+}
+
+message FingerprintAnalyzer {
+  enum Type {
+    TYPE_UNSPECIFIED = 0;
+    TYPE_FINGERPRINT = 1;
+  }
+  Type type = 1;
+
+  string version = 2;
+
+  float max_output_size = 3;
+
+  bool preserve_original = 4;
+
+  string separator = 5;
+
+  // Language value, such as _arabic_ or _thai_. Defaults to _english_. Each language value corresponds to a predefined list of stop words in Lucene. See Stop words by language for supported language values and their stop words. Also accepts an array of stop words.
+  repeated string stopwords = 6;
+
+  string stopwords_path = 7;
+}
+
+message IcuAnalyzer{
+  enum Type {
+    TYPE_UNSPECIFIED = 0;
+    TYPE_ICU_ANALYZER = 1;
+  }
+  Type type = 1;
+
+  enum IcuNormalizationType {
+    ICU_NORMALIZATION_TYPE_UNSPECIFIED = 0;
+    ICU_NORMALIZATION_TYPE_NFC = 1;
+    ICU_NORMALIZATION_TYPE_NFKC = 2;
+    ICU_NORMALIZATION_TYPE_NFKC_CF = 3;
+  }
+  IcuNormalizationType method = 2;
+
+  enum IcuNormalizationMode {
+    ICU_NORMALIZATION_MODE_UNSPECIFIED = 0;
+    ICU_NORMALIZATION_MODE_COMPOSE = 1;
+    ICU_NORMALIZATION_MODE_DECOMPOSE = 2;
+  }
+
+  IcuNormalizationMode mode = 3;
+}
+
+//manual generate
+message KeywordAnalyzer{
+  enum Type {
+    TYPE_UNSPECIFIED = 0;
+    TYPE_KEYWORD = 1;
+  }
+  Type type = 1;
+
+  string version = 2;
+}
+
+message KuromojiAnalyzer{
+  enum Type {
+    TYPE_UNSPECIFIED = 0;
+    TYPE_KUROMOJI = 1;
+  }
+  Type type = 1;
+
+
+  enum Mode {
+    MODE_UNSPECIFIED = 0;
+    MODE_EXTENDED = 1;
+    MODE_NORMAL = 2;
+    MODE_SEARCH = 3;
+  }
+
+  Mode mode = 2;
+
+  string user_dictionary = 3;
+}
+
+
+message LanguageAnalyzer{
+  enum Type {
+    TYPE_UNSPECIFIED = 0;
+    TYPE_LANGUAGE = 1;
+  }
+  Type type = 1;
+
+  string version = 2;
+
+  enum Language {
+    LANGUAGE_UNSPECIFIED = 0;
+    LANGUAGE_ARABIC = 1;
+    LANGUAGE_ARMENIAN = 2;
+    LANGUAGE_BASQUE = 3;
+    LANGUAGE_BRAZILIAN = 4;
+    LANGUAGE_BULGARIAN = 5;
+    LANGUAGE_CATALAN = 6;
+    LANGUAGE_CHINESE = 7;
+    LANGUAGE_CJK = 8;
+    LANGUAGE_CZECH = 9;
+    LANGUAGE_DANISH = 10;
+    LANGUAGE_DUTCH = 11;
+    LANGUAGE_ENGLISH = 12;
+    LANGUAGE_ESTONIAN = 13;
+    LANGUAGE_FINNISH = 14;
+    LANGUAGE_FRENCH = 15;
+    LANGUAGE_GALICIAN = 16;
+    LANGUAGE_GERMAN = 17;
+    LANGUAGE_GREEK = 18;
+    LANGUAGE_HINDI = 19;
+    LANGUAGE_HUNGARIAN = 20;
+    LANGUAGE_INDONESIAN = 21;
+    LANGUAGE_IRISH = 22;
+    LANGUAGE_ITALIAN = 23;
+    LANGUAGE_LATVIAN = 24;
+    LANGUAGE_NORWEGIAN = 25;
+    LANGUAGE_PERSIAN = 26;
+    LANGUAGE_PORTUGUESE = 27;
+    LANGUAGE_ROMANIAN = 28;
+    LANGUAGE_RUSSIAN = 29;
+    LANGUAGE_SORANI = 30;
+    LANGUAGE_SPANISH = 31;
+    LANGUAGE_SWEDISH = 32;
+    LANGUAGE_THAI = 33;
+    LANGUAGE_TURKISH = 34;
+  }
+
+  Language language = 3;
+
+  repeated string stem_exclusion = 4;
+
+  // Language value, such as _arabic_ or _thai_. Defaults to _english_. Each language value corresponds to a predefined list of stop words in Lucene. See Stop words by language for supported language values and their stop words. Also accepts an array of stop words.
+  repeated string stopwords = 5;
+
+  string stopwords_path = 6;
+
+}
+
+message NoriAnalyzer{
+  enum Type {
+    TYPE_UNSPECIFIED = 0;
+    TYPE_NORI = 1;
+  }
+  Type type = 1;
+
+  string version = 2;
+
+  enum NoriDecompoundMode {
+    NORI_DECOMPOUND_MODE_UNSPECIFIED = 0;
+    NORI_DECOMPOUND_MODE_NONE = 1;
+    NORI_DECOMPOUND_MODE_DISCARD = 2;
+    NORI_DECOMPOUND_MODE_MIXED = 3;
+  }
+
+  NoriDecompoundMode decompound_mode = 3;
+
+  repeated string stoptags = 4;
+
+  string user_dictionary = 5;
+}
+
+message PatternAnalyzer{
+  enum Type {
+    TYPE_UNSPECIFIED = 0;
+    TYPE_PATTERN = 1;
+  }
+  Type type = 1;
+
+  string version = 2;
+
+  string flags = 3;
+
+  bool lowercase = 4;
+
+  string pattern = 5;
+
+  repeated string stopwords = 6;
+
+}
+
+message SimpleAnalyzer{
+  enum Type {
+    TYPE_UNSPECIFIED = 0;
+    TYPE_SIMPLE = 1;
+  }
+  Type type = 1;
+
+  string version = 2;
+}
+
+message SnowballAnalyzer{
+  enum Type {
+    TYPE_UNSPECIFIED = 0;
+    TYPE_SNOWBALL = 1;
+  }
+  Type type = 1;
+
+  string version = 2;
+
+  enum SnowballLanguage {
+    SNOWBALL_LANGUAGE_UNSPECIFIED = 0;
+    SNOWBALL_LANGUAGE_ARMENIAN = 1;
+    SNOWBALL_LANGUAGE_BASQUE = 2;
+    SNOWBALL_LANGUAGE_CATALAN = 3;
+    SNOWBALL_LANGUAGE_DANISH = 4;
+    SNOWBALL_LANGUAGE_DUTCH = 5;
+    SNOWBALL_LANGUAGE_ENGLISH = 6;
+    SNOWBALL_LANGUAGE_FINNISH = 7;
+    SNOWBALL_LANGUAGE_FRENCH = 8;
+    SNOWBALL_LANGUAGE_GERMAN = 9;
+    SNOWBALL_LANGUAGE_GERMAN2 = 10;
+    SNOWBALL_LANGUAGE_HUNGARIAN = 11;
+    SNOWBALL_LANGUAGE_ITALIAN = 12;
+    SNOWBALL_LANGUAGE_KP = 13;
+    SNOWBALL_LANGUAGE_LOVINS = 14;
+    SNOWBALL_LANGUAGE_NORWEGIAN = 15;
+    SNOWBALL_LANGUAGE_PORTER = 16;
+    SNOWBALL_LANGUAGE_PORTUGUESE = 17;
+    SNOWBALL_LANGUAGE_ROMANIAN = 18;
+    SNOWBALL_LANGUAGE_RUSSIAN = 19;
+    SNOWBALL_LANGUAGE_SPANISH = 20;
+    SNOWBALL_LANGUAGE_SWEDISH = 21;
+    SNOWBALL_LANGUAGE_TURKISH = 22;
+  }
+
+  SnowballLanguage language = 3;
+
+  repeated string stopwords = 4;
+}
+
+message StandardAnalyzer{
+  enum Type {
+    TYPE_UNSPECIFIED = 0;
+    TYPE_STANDARD = 1;
+  }
+  Type type = 1;
+
+  float max_token_length = 2;
+  repeated string stopwords = 3;
+}
+
+message StopAnalyzer{
+  enum Type {
+    TYPE_UNSPECIFIED = 0;
+    TYPE_STOP = 1;
+  }
+  Type type = 1;
+
+  string version = 2;
+
+  repeated string stopwords = 3;
+
+  string stopwords_path = 4;
+}
+
+message WhitespaceAnalyzer{
+  enum Type {
+    TYPE_UNSPECIFIED = 0;
+    TYPE_WHITESPACE = 1;
+  }
+  Type type = 1;
+
+  string version = 2;
+
+}
+
+message CustomAnalyzer {
+  enum Type {
+    TYPE_UNSPECIFIED = 0;
+    TYPE_CUSTOM = 1;
+  }
+
+  Type type = 1;
+
+  repeated string char_filter = 2;
+
+  repeated string filter = 3;
+
+  float position_increment_gap = 4;
+
+  float position_offset_gap = 5;
+
+  string tokenizer = 6;
+}
+
+message Analyzer {
+  oneof analyzer {
+    CustomAnalyzer custom_analyzer = 1;
+    FingerprintAnalyzer fingerprint_analyzer = 2;
+    KeywordAnalyzer keyword_analyzer = 3;
+    LanguageAnalyzer language_analyzer = 4;
+    NoriAnalyzer nori_analyzer = 5;
+    PatternAnalyzer pattern_analyzer = 6;
+    SimpleAnalyzer simple_analyzer = 7;
+    StandardAnalyzer standard_analyzer = 8;
+    StopAnalyzer stop_analyzer = 9;
+    WhitespaceAnalyzer whitespace_analyzer = 10;
+    IcuAnalyzer icu_analyzer = 11;
+    KuromojiAnalyzer kuromoji_analyzer = 12;
+    SnowballAnalyzer snowball_analyzer = 13;
+    DutchAnalyzer dutch_analyzer = 14;
+  }
+}
+
+message Error {
+  oneof version {
+    OpenSearchExceptionV1 v1 = 1;
+  }
+}
+
+
+message OpenSearchExceptionV1 {
+  string type = 1;
+  string reason = 2;
+  repeated .google.protobuf.Struct root_cause = 3;
+
+  .google.protobuf.Struct caused_by = 4;
+  string stack_trace = 5;
+  .google.protobuf.Struct suppressed = 6;
+
+  .google.protobuf.Struct additional_details = 7;
+}
+
+message InlineGet {
+
+  .google.protobuf.Struct fields = 1;
+
+  bool found = 2;
+
+  int64 seq_no = 3 [json_name = "_seq_no"];
+
+  int64 primary_term = 4 [json_name = "_primary_term"];
+
+  repeated string routing = 5 [json_name = "_routing"];
+
+  oneof inline_get_source {
+
+    // struct_source field to be returned upon explicit request by user
+    .google.protobuf.Struct struct_source = 6;
+
+    // Use bytes for better latency/performance, as it reduces payload size over the wire
+    bytes source = 7 [json_name = "_source"];
+
+  }
+}

--- a/protos/schemas/document.proto
+++ b/protos/schemas/document.proto
@@ -1,0 +1,324 @@
+/**
+ This is generated from the spec. DO NOT manually modify.
+ */
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "org.opensearch.protobuf";
+option java_outer_classname = "DocumentProto";
+option go_package = "opensearchpb";
+
+import "google/protobuf/struct.proto";
+import "protos/schemas/common.proto";
+
+
+// The bulk operation lets you add, update, or delete multiple documents in a single request, index name needs to be specified in `BulkRequestBody`
+message BulkRequest {
+  // [optional] If not provided here, index will be required in the BulkRequestBody instead
+  optional string index = 1;
+  // [optional] Set `true` or `false` to return the `_source` field or not, or a list of fields to return.
+  optional SourceConfigParam source = 2;
+  // [optional] A list of source fields to exclude from the response.
+  repeated string source_excludes = 3;
+  // [optional] A list of source fields to include in the response.
+  repeated string source_includes = 4;
+  // [optional] ID of the pipeline to use to preprocess incoming documents. If the index has a default ingest pipeline specified, then setting the value to `_none` disables the default ingest pipeline for this request. If a final pipeline is configured it will always run, regardless of the value of this parameter.
+  optional string pipeline = 5;
+
+  enum Refresh {
+    REFRESH_UNSPECIFIED = 0;
+    // `REFRESH_FALSE` do nothing with refreshes.
+    REFRESH_FALSE = 1;
+    // `REFRESH_TRUE` makes the changes show up in search results immediately, but hurts cluster performance.
+    REFRESH_TRUE = 2;
+    // `REFRESH_WAIT_FOR` waits for a refresh. Requests take longer to return, but cluster performance doesn't suffer.
+    REFRESH_WAIT_FOR = 3;
+  }
+  // [optional] The enum of whether to refresh the affected shards after performing the indexing operations. Default is false
+  optional Refresh refresh = 6;
+  // [optional] If `true`, the request's actions must target an index alias. Defaults to false.
+  optional bool require_alias = 7;
+  // [optional] Custom value used to route operations to a specific shard.
+  optional string routing = 8;
+  // [optional] Period each action waits for the following operations: automatic index creation, dynamic mapping updates, waiting for active shards.
+  // pattern: ^([0-9\.]+)(?:d|h|m|s|ms|micros|nanos)$
+  // Defaults to 1m (one minute). This guarantees OpenSearch waits for at least the timeout before failing. The actual wait time could be longer, particularly when multiple waits occur.
+  optional string timeout = 9;
+  // [deprecated] The default document type for documents that don't specify a type. Default is _doc. We highly recommend ignoring this parameter and using a type of _doc for all indexes.
+  optional string type = 10;
+  // [optional] The number of active shards that must be available before OpenSearch processes the request. Default is 1 (only the primary shard). Set to all or a positive integer. Values greater than 1 require replicas. For example, if you specify a value of 3, the index must have two replicas distributed across two additional nodes for the operation to succeed.
+  optional WaitForActiveShards wait_for_active_shards = 11;
+  // [required] The request body contains create, delete, index, and update actions and their associated source data
+  repeated BulkRequestBody request_body = 12;
+
+  // [optional] Controls how document source fields are returned in the response.
+  // - If not set, source is returned as bytes (default, recommended for better performance)
+  // - If set to SOURCE_TYPE_STRUCT: source is returned as a structured protobuf message
+  // Note: Using SOURCE_TYPE_STRUCT may impact performance due to additional serialization overhead
+  // Note: This diverges from the API spec.
+  optional SourceType source_type = 13;
+}
+
+message BulkRequestBody {
+
+  // [required] operation to perform (index, create, update, or delete)
+  oneof operation_container {
+    // Indexes the specified document. If the document exists, replaces the document and increments the version. It must followed with source data to be indexed in `doc` field.
+    IndexOperation index = 1;
+    // Indexes the specified document if it does not already exist. It must followed with the source data to be indexed in `object` field.
+    CreateOperation create = 2;
+    // Performs a partial document update. It must followed with the partial document and update options in in `doc` field.
+    UpdateOperation update = 3;
+    // Removes the specified document from the index.
+    DeleteOperation delete = 4;
+  }
+
+  // [optional] Set to false to disable setting 'result' in the response to 'noop' if no change to the document occurred.
+  optional bool detect_noop = 5;
+
+  // [optional] The partial document to index. Required for update, index operations
+  optional bytes doc = 15;
+
+  // [optional] When `true`, uses the contents of 'doc' as the value of 'upsert'. If a document exists, it is updated; if it does not exist, a new document is indexed with the parameters specified in the `doc` field. it's only supported for the `update` operation.
+  optional bool doc_as_upsert = 7;
+  // [optional] Script for more complex document updates by defining the script with the `source` or `id` from a document
+  optional Script script = 8;
+
+  // [optional] When `true`, executes the script whether or not the document exists.
+  optional bool scripted_upsert = 9;
+
+  // [optional] Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered.
+  optional SourceConfig source = 10;
+
+  // [optional] If the document does not already exist, the contents of 'upsert' are inserted as a new document. If the document exists, the 'script' is executed. it's only supported for the `update` operation.
+  optional bytes upsert = 16;
+
+  // Use bytes for better latency/performance, as it reduces payload size over the wire
+  optional bytes object = 17;
+}
+
+message IndexOperation {
+  // [optional] The document ID. If no ID is specified, a document ID is automatically generated.
+  optional string id = 1;
+  // [optional] Name of the the data stream, index, or index alias to perform the action on. This parameter is required if index not specified in bulk request.
+  optional string index = 2;
+
+  // [optional] Custom value used to route operations to a specific shard.
+  optional string routing = 3;
+
+  // [optional] Only perform the operation if the document has this primary term.
+  optional int64 if_primary_term = 4;
+  // [optional] Only perform the operation if the document has this sequence number
+  optional int64 if_seq_no = 5;
+
+  enum OpType {
+    OP_TYPE_UNSPECIFIED = 0;
+    // Index a document only if it doesn't exist. Similarly as PUT <index>/_create/<_id>, will throw error if the document exist
+    OP_TYPE_CREATE = 1;
+    // A document ID is included in the request. default value.
+    OP_TYPE_INDEX = 2;
+  }
+  // [optional] Set to create to only index the document if it does not already exist (put if absent). If a document with the specified `_id` already exists, the indexing operation will fail. Same as using the `<index>/_create` endpoint. Valid values: `index`, `create`. If document id is specified, it defaults to `index`. Otherwise, it defaults to `create`.
+  optional OpType op_type = 6;
+  // [optional] Explicit version number for concurrency control. The specified version must match the current version of the document for the request to succeed.
+  optional int64 version = 7;
+
+  enum VersionType {
+    VERSION_TYPE_UNSPECIFIED = 0;
+    // Retrieve the document if the specified version number is greater than the document's current version
+    VERSION_TYPE_EXTERNAL = 1;
+    // Retrieve the document if the specified version number is greater than or equal to the document's current version
+    VERSION_TYPE_EXTERNAL_GTE = 2;
+  }
+  // [optional] Assigns a specific type to the document.
+  optional VersionType version_type = 8;
+
+  // [optional] A map from the full name of fields to the name of dynamic templates. Defaults to an empty map. If a name matches a dynamic template, then that template will be applied regardless of other match predicates defined in the template. If a field is already defined in the mapping, then this parameter won't be used.
+  // TODO where is this used? remove it?
+  // map<string, string> dynamic_templates = 9;
+
+  // [optional] ID of the pipeline to use to preprocess incoming documents. If the index has a default ingest pipeline specified, then setting the value to `_none` disables the default ingest pipeline for this request. If a final pipeline is configured it will always run, regardless of the value of this parameter.
+  optional string pipeline = 10;
+
+  // [optional] If `true`, the request's actions must target an index alias. Defaults to false.
+  optional bool require_alias = 11;
+
+}
+
+message CreateOperation {
+  // [optional] The document ID. If no ID is specified, a document ID is automatically generated.
+  optional string id = 1;
+  // [optional] Name of the the data stream, index, or index alias to perform the action on. This parameter is required if index not specified in bulk request.
+  optional string index = 2;
+
+  // [optional] Custom value used to route operations to a specific shard.
+  optional string routing = 3;
+  // [optional] Only perform the operation if the document has this primary term
+  optional int64 if_primary_term = 4;
+  // [optional] Only perform the operation if the document has this sequence number
+  optional int64 if_seq_no = 5;
+  // [optional] Explicit version number for concurrency control. The specified version must match the current version of the document for the request to succeed.
+  optional int64 version = 6;
+
+  enum VersionType {
+    VERSION_TYPE_UNSPECIFIED = 0;
+    // Retrieve the document if the specified version number is greater than the document's current version
+    VERSION_TYPE_EXTERNAL = 1;
+    // Retrieve the document if the specified version number is greater than or equal to the document's current version
+    VERSION_TYPE_EXTERNAL_GTE = 2;
+  }
+  // [optional] Assigns a specific type to the document.
+  optional VersionType version_type = 7;
+
+  // [optional] A map from the full name of fields to the name of dynamic templates. Defaults to an empty map. If a name matches a dynamic template, then that template will be applied regardless of other match predicates defined in the template. If a field is already defined in the mapping, then this parameter won't be used.
+  // TODO where is this used? remove it?
+  // map<string, string> dynamic_templates = 10;
+
+  // [optional] ID of the pipeline to use to preprocess incoming documents. If the index has a default ingest pipeline specified, then setting the value to `_none` disables the default ingest pipeline for this request. If a final pipeline is configured it will always run, regardless of the value of this parameter.
+  optional string pipeline = 8;
+
+  // [optional] If `true`, the request's actions must target an index alias. Defaults to false.
+  optional bool require_alias = 9;
+
+}
+
+message UpdateOperation {
+  // [required] The document ID.
+  optional string id = 1;
+  // [optional] Name of the the data stream, index, or index alias to perform the action on. This parameter is required if index not specified in bulk request.
+  optional string index = 2;
+  // [optional] Custom value used to route operations to a specific shard.
+  optional string routing = 3;
+
+  // [optional] Only perform the operation if the document has this primary term
+  optional int64 if_primary_term = 4;
+  // [optional] Only perform the operation if the document has this sequence number
+  optional int64 if_seq_no = 5;
+  // [optional] If `true`, the request's actions must target an index alias. Defaults to false.
+  optional bool require_alias = 6;
+  // [optional] Specify how many times an update should be retried in the case of a version conflict.
+  optional int32 retry_on_conflict = 7;
+
+}
+
+message DeleteOperation {
+  // [required] The document ID.
+  optional string id = 1;
+  // [optional] Name of the the data stream, index, or index alias to perform the action on. This parameter is required if index not specified in bulk request.
+  optional string index = 2;
+  // [optional] Custom value used to route operations to a specific shard.
+  optional string routing = 3;
+
+  // [optional] Only perform the operation if the document has this primary term
+  optional int64 if_primary_term = 4;
+  // [optional] Only perform the operation if the document has this sequence number
+  optional int64 if_seq_no = 5;
+  // [optional] Explicit version number for concurrency control. The specified version must match the current version of the document for the request to succeed.
+  optional int64 version = 6;
+
+  enum VersionType {
+    VERSION_TYPE_UNSPECIFIED = 0;
+    // Retrieve the document if the specified version number is greater than the document's current version
+    VERSION_TYPE_EXTERNAL = 1;
+    // Retrieve the document if the specified version number is greater than or equal to the document's current version
+    VERSION_TYPE_EXTERNAL_GTE = 2;
+  }
+  // [optional] Assigns a specific type to the document.
+  optional VersionType version_type = 7;
+
+}
+
+// Bulk response contains the individual results of each operation in the request, returned in the order submitted. The success or failure of an individual operation does not affect other operations in the request.
+message BulkResponse {
+  oneof response {
+    // The bulk success response
+    BulkResponseBody bulk_response_body = 1;
+    // The bulk error response
+    BulkErrorResponse bulk_error_response = 2;
+  }
+}
+
+message BulkErrorResponse {
+  // [optional] The bulk error
+  Error error = 1;
+  // [optional] HTTP response status code
+  optional int32 status = 2;
+}
+
+message BulkResponseBody {
+
+  // [optional] If true, one or more of the operations in the bulk request did not complete successfully.
+  optional bool errors = 1;
+  // [optional] Contains the result of each operation in the bulk request, in the order they were submitted.
+  repeated Item items = 2;
+  // [optional] How long, in milliseconds, it took to process the bulk request.
+  optional int64 took = 3;
+  // [optional] How long, in milliseconds, it took to process documents through an ingest pipeline
+  optional int64 ingest_took = 4;
+
+}
+
+message Item {
+  oneof item {
+    ResponseItem create = 1;
+    ResponseItem delete = 2;
+    ResponseItem index = 3;
+    ResponseItem update = 4;
+  }
+}
+
+message ResponseItem {
+
+  // [optional] The document type.
+  optional string type = 1;
+
+  message Id {
+    oneof id {
+      NullValue null_value = 1;
+      string string = 2;
+    }
+  }
+  // [optional] The document ID associated with the operation.
+  optional Id id = 2;
+
+  // [optional] Name of the index associated with the operation. If the operation targeted a data stream, this is the backing index into which the document was written.
+  optional string index = 3;
+
+  // [optional] HTTP status code returned for the operation.
+  // TODO: use grpc status code instead
+  optional int32 status = 4;
+  // [optional] Contains additional information about the failed operation.
+  optional ErrorCause error = 5;
+
+  // [optional] The primary term assigned to the document for the operation.
+  optional int64 primary_term = 6;
+
+  // [optional] Result of the operation. Successful values are `created`, `deleted`, and `updated`.
+  optional string result = 7;
+  // [optional] The sequence number assigned to the document for the operation. Sequence numbers are used to ensure an older version of a document doesn't overwrite a newer version
+  optional int64 seq_no = 8;
+  // [optional] Contains shard information for the operation. This parameter is only returned for successful operations.
+  optional ShardInfo shards = 9;
+  // [optional] The document version associated with the operation. The document version is incremented each time the document is updated. This parameter is only returned for successful actions.
+  optional int64 version = 10;
+  // [optional] if `true`, it requires immediate visibility of the document
+  optional bool forced_refresh = 11;
+  // [optional]
+  optional InlineGetDictUserDefined get = 12;
+}
+
+
+message InlineGetDictUserDefined {
+  // [optional]
+  optional ObjectMap fields = 1;
+  // [required] Whether the document exists.
+  bool found = 2;
+  // [optional] The sequence number assigned to the document for the operation. Sequence numbers are used to ensure an older version of a document doesn't overwrite a newer version
+  optional int64 seq_no = 3;
+  // [optional] The primary term assigned to the document for the operation.
+  optional int64 primary_term = 4;
+  // [optional] Custom value used to route operations to a specific shard.
+  repeated string routing = 5;
+  // [optional] Contains the document's data
+  optional bytes source = 7;
+}

--- a/protos/schemas/search.proto
+++ b/protos/schemas/search.proto
@@ -1,0 +1,758 @@
+/**
+ This is generated from the spec. DO NOT manually modify.
+*/
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "org.opensearch.protobuf";
+option java_outer_classname = "SearchProto";
+option go_package = "opensearchpb";
+
+import "google/protobuf/struct.proto";
+import "protos/schemas/common.proto";
+
+
+// The Search API operation to perform a search across all indices in the cluster.
+// The Search API operation to perform a search or index search
+message SearchRequest {
+   // [optional] A list of indices to search for documents. If not provided, the default value will be to search through all indexes.
+   repeated string index = 1;
+   // [optional] Whether to include the _source field in the response.
+   SourceConfigParam source = 2 [json_name = "_source"];
+   // [optional] A list of source fields to exclude from the response. You can also use this parameter to exclude fields from the subset specified in `source_includes` query parameter. If the `source` parameter is `false`, this parameter is ignored.
+   repeated string source_excludes = 3;
+   // [optional] A list of source fields to include in the response. If this parameter is specified, only these source fields are returned. You can exclude fields from this subset using the `source_excludes` query parameter. If the `source` parameter is `false`, this parameter is ignored.
+   repeated string source_includes = 4 [json_name = "_source_includes"];
+   // [optional] Whether to ignore wildcards that don't match any indexes. Default is true.
+   optional bool allow_no_indices = 5;
+   // [optional] Whether to return partial results if the request runs into an error or times out. Default is true.
+   optional bool allow_partial_search_results = 6;
+   // [optional] Whether the update operation should include wildcard and prefix queries in the analysis. Default is false.
+   optional bool analyze_wildcard = 7;
+   // [optional] Analyzer to use for the query string. This parameter can only be used when the q query string parameter is specified.
+   optional string analyzer = 8;
+   // [optional] How many shard results to reduce on a node. Default is 512.
+   optional int32 batched_reduce_size = 9;
+   // [optional] The time after which the search request will be canceled. Request-level parameter takes precedence over cancel_after_time_interval cluster setting. Default is -1.
+   optional string cancel_after_time_interval = 10;
+   // [optional] Whether to minimize round-trips between a node and remote clusters. Default is true.
+   optional bool ccs_minimize_roundtrips = 11;
+   // [optional] Indicates whether the default operator for a string query should be AND or OR. Default is OR.
+   optional Operator default_operator = 12;
+   enum Operator {
+     OPERATOR_UNSPECIFIED = 0;
+     // All terms need to match. The string `to be` is interpreted as `to AND be`
+     OPERATOR_AND = 1;
+     // Only one term needs to match. The string `to be` is interpreted as `to OR be`
+     OPERATOR_OR = 2;
+   }
+   // [optional] The default field in case a field prefix is not provided in the query string.
+   optional string df = 13;
+   // [optional] The fields that OpenSearch should return using their docvalue forms.
+   repeated string docvalue_fields = 14;
+   // [optional] Specifies the type of index that wildcard expressions can match. Supports list of values. Default is open.
+   repeated ExpandWildcard expand_wildcards = 15;
+   enum ExpandWildcard {
+     EXPAND_WILDCARD_UNSPECIFIED = 0;
+     // Match any index
+     EXPAND_WILDCARD_ALL = 1;
+     // Match closed, non-hidden indexes
+     EXPAND_WILDCARD_CLOSED = 2;
+     // Match hidden indexes
+     EXPAND_WILDCARD_HIDDEN = 3;
+     // Deny wildcard expressions
+     EXPAND_WILDCARD_NONE = 4;
+     // Match open, non-hidden indexes
+     EXPAND_WILDCARD_OPEN = 5;
+   }
+   // [optional] Whether to return details about how OpenSearch computed the document's score. Default is false.
+   optional bool explain = 16;
+   // [optional] The starting index to search from. Default is 0.
+   optional int32 from = 17;
+   // [optional] Whether to ignore concrete, expanded, or indexes with aliases if indexes are frozen. Default is true.
+   optional bool ignore_throttled = 18;
+   // [optional] Specifies whether to include missing or closed indexes in the response and ignores unavailable shards during the search request. Default is false.
+   optional bool ignore_unavailable = 19;
+   // [optional] Whether to return scores with named queries. Default is false.
+   optional bool include_named_queries_score = 20;
+   // [optional] Specifies whether OpenSearch should accept requests if queries have format errors (for example, querying a text field for an integer). Default is false.
+   optional bool lenient = 21;
+   // [optional] Numbers of concurrent shard requests this request should execute on each node. Default is 5.
+   optional int32 max_concurrent_shard_requests = 22;
+   // [optional] Whether to return phase-level took time values in the response. Default is false.
+   optional bool phase_took = 23;
+   // [optional] A prefilter size threshold that triggers a prefilter operation if the request exceeds the threshold. Default is 128 shards.
+   optional int32 pre_filter_shard_size = 24;
+   // [optional] Specifies the shards or nodes on which OpenSearch should perform the search. For valid values see "https://opensearch.org/docs/latest/api-reference/search/#the-preference-query-parameter"
+   optional string preference = 25;
+   // [optional] Query in the Lucene query string syntax using query parameter search.
+   optional string q = 26;
+   // [optional] Specifies whether OpenSearch should use the request cache. Default is whether it's enabled in the index's settings.
+   optional bool request_cache = 27;
+   // [optional] Indicates whether to return hits.total as an integer. Returns an object otherwise. Default is false.
+   // TODO should we rename this field to remove "rest"?
+   optional bool rest_total_hits_as_int = 28;
+   // [optional] Value used to route the update by query operation to a specific shard.
+   repeated string routing = 29;
+   // [optional] Period to keep the search context open.
+   optional string scroll = 30;
+   // [optional] Customizable sequence of processing stages applied to search queries.
+   optional string search_pipeline = 31;
+   // [optional] Whether OpenSearch should use global term and document frequencies when calculating relevance scores. Default is SEARCH_TYPE_QUERY_THEN_FETCH.
+   // TODO remove these fields from spec?
+   // do not allow 'query_and_fetch' or 'dfs_query_and_fetch' search types
+   // from the REST layer. these modes are an internal optimization and should
+   // not be specified explicitly by the user.
+
+   optional SearchType search_type = 32;
+   enum SearchType {
+     SEARCH_TYPE_UNSPECIFIED = 0;
+     // Scores documents using global term and document frequencies across all shards. It's usually slower but more accurate.
+     SEARCH_TYPE_DFS_QUERY_THEN_FETCH = 1;
+     // Scores documents using local term and document frequencies for the shard. It's usually faster but less accurate.
+     SEARCH_TYPE_QUERY_THEN_FETCH = 2;
+   }
+   // [optional] Whether to return sequence number and primary term of the last operation of each document hit.
+   optional bool seq_no_primary_term = 33;
+   // [optional] Number of results to include in the response.
+   optional int32 size = 34;
+   // [optional] A list of <field> : <direction> pairs to sort by.
+   // TODO use this improvement instead?
+   message SortOrder {
+     // [required]
+     string field = 1;
+     // [optional]
+     optional Direction direction = 2;
+
+     enum Direction {
+       DIRECTION_UNSPECIFIED = 0;
+       DIRECTION_ASC = 1;
+       DIRECTION_DESC = 2;
+     }
+   }
+   repeated SortOrder sort = 35;
+
+   //  repeated string sort = 35;
+   // [optional] Value to associate with the request for additional logging.
+   repeated string stats = 36;
+   // [optional] Whether the get operation should retrieve fields stored in the index. Default is false.
+   repeated string stored_fields = 37;
+   // [optional] Fields OpenSearch can use to look for similar terms.
+   optional string suggest_field = 38;
+   // [optional] The mode to use when searching. This parameter can only be used when the `suggest_field` and `suggest_text` query string parameters are specified.
+   optional SuggestMode suggest_mode = 39;
+   enum SuggestMode {
+     SUGGEST_MODE_UNSPECIFIED = 0;
+     // Use suggestions based on the provided terms
+     SUGGEST_MODE_ALWAYS = 1;
+     // Use suggestions for terms not in the index
+     SUGGEST_MODE_MISSING = 2;
+     // Use suggestions that have more occurrences
+     SUGGEST_MODE_POPULAR = 3;
+   }
+   // [optional] Number of suggestions to return.
+   optional int32 suggest_size = 40;
+   // [optional] The source that suggestions should be based off of.
+   optional string suggest_text = 41;
+   // [optional] The maximum number of documents OpenSearch should process before terminating the request. Default is 0.
+   optional int32 terminate_after = 42;
+   // [optional] Period of time to wait for a response from active shards. Default is 1m.
+   optional string timeout = 43;
+   // [optional] Whether to return document scores. Default is false.
+   optional bool track_scores = 44;
+   // [optional] Whether to return how many documents matched the query.
+   optional TrackHits track_total_hits = 45;
+   // [optional] Whether returned aggregations and suggested terms should include their types in the response. Default is true.
+   optional bool typed_keys = 46;
+   // [optional] Whether to include the document version as a match. Default is false
+   optional bool version = 47;
+   // [optional] Search Request body
+   SearchRequestBody request_body = 48;
+
+   // [optional] The DSL query to use in the request.
+ //  optional QueryContainer query = 48;
+ }
+
+ // TODO do we really need this extra layer?
+ message SearchRequestBody {
+   // [optional] The DSL query to use in the request.
+   optional QueryContainer query = 1;
+ }
+
+ message TrackHits {
+   oneof track_hits{
+     bool bool_value = 1;
+     int32 int32_value = 2;
+   }
+ }
+
+ // The response from search request.
+ message SearchResponse {
+ //  oneof response {
+ //    // The search success response
+ //    ResponseBody response_body = 1;
+ //  }
+ //}
+ //
+ //// The response body from a search/index-search request.
+ //message ResponseBody {
+
+   // [required] Milliseconds it took Elasticsearch to execute the request.
+   optional int64 took = 1;
+
+   // [required]  If true, the request timed out before completion; returned results may be partial or empty.
+   optional bool timed_out = 2;
+
+   // [required] Contains a count of shards used for the request.
+   ShardStatistics shards = 3;
+
+   // [optional] Phase-level took time values in the response.
+   optional PhaseTook phase_took = 4;
+
+   // [required] Contains returned documents and metadata.
+   HitsMetadata hits = 5;
+
+   // [optional] When you search one or more remote clusters, a `_clusters` section is included to provide information about the search on each cluster.
+   optional ClusterStatistics clusters = 6;
+
+   // [optional] Retrieved specific fields in the search response
+   optional .google.protobuf.Struct fields = 7;
+
+   // [optional] Highest returned document _score.
+   optional float max_score = 8; // TODO where is this used? remove?
+
+   // [optional] The number of times that the coordinating node aggregates results from batches of shard responses
+   optional int32 num_reduce_phases = 9;
+
+   // [optional] Contains profiling information.
+   Profile profile = 10;
+
+   // [optional] The PIT ID.
+   optional string pit_id = 11;
+
+   // [optional] Identifier for the search and its search context.
+   optional string scroll_id = 12;
+
+   // [optional] If the query was terminated early, the terminated_early flag will be set to true in the response
+   optional bool terminated_early = 13;
+
+ }
+
+ message PhaseTook {
+
+   // [required] Time taken in dfs_pre_query phase.
+   int64 dfs_pre_query = 1;
+   // [required] Time taken in query phase.
+   int64 query = 2;
+   // [required] Time taken in fetch phase.
+   int64 fetch = 3;
+   // [required] Time taken in dfs_query phase.
+   int64 dfs_query = 4;
+   // [required] Time taken in expand phase.
+   int64 expand = 5;
+   // [required] Time taken in can_match phase.
+   int64 can_match = 6;
+
+ }
+
+ message HitsMetadata {
+   message Total {
+     oneof total{
+       TotalHits total_hits = 1;
+       double double_value = 2;
+     }
+   }
+   // [optional] Metadata about the number of matching documents.
+   Total total = 1;
+
+   // [required] Array of returned document objects.
+   repeated Hit hits = 2;
+
+   message MaxScore{
+     oneof max_score{
+       float float_value = 1;
+       string string_value = 2;
+       NullValue null_value = 3;
+     }
+   }
+
+   // [optional] Highest returned document _score.
+   MaxScore max_score = 3;
+
+ }
+
+ message TotalHits {
+
+   // [required] Indicates whether the number of matching documents in the value parameter is accurate or a lower bound.
+   TotalHitsRelation relation = 1;
+   enum TotalHitsRelation {
+     TOTAL_HITS_RELATION_UNSPECIFIED = 0;
+     // Accurate
+     TOTAL_HITS_RELATION_EQ = 1;
+     // Lower bound
+     TOTAL_HITS_RELATION_GTE = 2;
+   }
+   // [required] Total number of matching documents.
+   int64 value = 2;
+
+ }
+
+ message InnerHitsResult {
+
+   // [required] An additional nested hits value.
+   HitsMetadata hits = 1;
+
+ }
+
+ message Hit {
+
+   optional string type = 1;
+
+   // [required] Name of the index containing the returned document.
+   string index = 2;
+   // [required] Unique identifier for the returned document. This ID is only unique within the returned index.
+   string id = 3;
+
+   message Score {
+     oneof score{
+       float float_value = 1;
+       string string_value = 2;
+       NullValue null_value = 3;
+     }
+   }
+
+   // [optional] Relevance of the returned document.
+   optional Score score = 4;
+
+   // [optional] Explanation of how the relevance score (_score) is calculated for every result.
+   optional Explanation explanation = 5;
+
+   // [optional] Contains field values for the documents.
+   optional .google.protobuf.Struct fields = 6;
+
+   // [optional] An additional highlight element for each search hit that includes the highlighted fields and the highlighted fragments.
+   map<string, StringArray> highlight = 7;
+
+   // [optional] An additional nested hits that caused a search hit to match in a different scope.
+   map<string, InnerHitsResult> inner_hits = 8;
+
+   // [optional] List of matched query names used in the search request.
+   repeated string matched_queries = 9;
+
+   // [optional] Defines from what inner nested object this inner hit came from
+   optional NestedIdentity nested = 10;
+
+   // [optional] List of fields ignored.
+   repeated string ignored = 11;
+
+   // [optional] These values are retrieved from the document’s original JSON source and are raw so will not be formatted or treated in any way, unlike the successfully indexed fields which are returned in the fields section.
+   map<string, StringArray> ignored_field_values = 12;
+
+   // [optional] Shard from which this document was retrieved.
+   optional string shard = 13;
+
+   // [optional] Node from which this document was retrieved.
+   optional string node = 14;
+
+   optional string routing = 15;
+
+   // [optional] Source document.
+   optional bytes source = 16;
+
+   // [optional] Counts the number of operations that happened on the index
+   optional int64 seq_no = 17;
+
+   // [optional] Counts the number of shard has changed.
+   optional int64 primary_term = 18;
+
+   // [optional] Version number of the document.
+   optional int64 version = 19;
+
+   // [optional] Sorted values
+   repeated FieldValueResponse sort = 20;
+
+ }
+
+
+ message ClusterStatistics {
+
+   // [required] Number of shards that skipped the request because a lightweight check helped realize that no documents could possibly match on this shard. This typically happens when a search request includes a range filter and the shard only has values that fall outside of that range.
+   int32 skipped = 1;
+
+   // [required] Number of shards that executed the request successfully.
+   int32 successful = 2;
+
+   // [required] Total number of shards that require querying, including unallocated shards.
+   int32 total = 3;
+
+
+   // TODO these fields dont exist in SearchResponse.Clusters class
+   // [required] Number of shards currently executing the search operation
+ //  int32 running = 4;
+ //
+ //  // [required] The number of shards that returned partial results.
+ //  int32 partial = 5;
+ //
+ //  // [required] Number of shards that failed to execute the request. Note that shards that are not allocated will be considered neither successful nor failed. Having failed+successful less than total is thus an indication that some of the shards were not allocated.
+ //  int32 failed = 6;
+ //
+ //  // [optional] Shows metadata about the search on each cluster.
+ //  map<string, ClusterDetails> details = 7;
+
+ }
+
+ message ClusterDetails {
+
+   enum ClusterSearchStatus {
+     CLUSTER_SEARCH_STATUS_UNSPECIFIED = 0;
+     // The search failed on a cluster marked with skip_unavailable=false
+     CLUSTER_SEARCH_STATUS_FAILED = 1;
+     // Searches on at least one shard of the cluster was successful and at least one failed
+     CLUSTER_SEARCH_STATUS_PARTIAL = 2;
+     // Searches on all shards were successful
+     CLUSTER_SEARCH_STATUS_RUNNING = 3;
+     // The search failed on a cluster marked with skip_unavailable=true
+     CLUSTER_SEARCH_STATUS_SKIPPED = 4;
+     // Searches on all shards were successful
+     CLUSTER_SEARCH_STATUS_SUCCESSFUL = 5;
+   }
+   // [required] All possible cluster search states.
+   ClusterSearchStatus status = 1;
+
+   // [required] The index expression supplied by the user. If you provide a wildcard such as logs-*, this section will show the value with the wildcard, not the concrete indices being searched.
+   string indices = 2;
+
+   // [optional] How long (in milliseconds) the sub-search took on that cluster.
+   optional int64 took = 3;
+
+   // [required] If true, the request timed out before completion; returned results may be partial or empty.
+   bool timed_out = 4;
+
+   // [optional] The shard details for the sub-search on that cluster.
+   optional ShardStatistics shards = 5;
+
+   // [optional] An array of any shard-specific failures that occurred during the search operation
+   repeated ShardSearchFailure failures = 6;
+
+ }
+
+ message Profile {
+
+   // [required] A search request can be executed against one or more shards in the index, and a search may involve one or more indexes. Thus, the profile.shards array contains profiling information for each shard that was involved in the search.
+   repeated ShardProfile shards = 1;
+
+ }
+
+ message ShardProfile {
+
+   // [required] Profiling information about the aggregation execution.
+   repeated AggregationProfile aggregations = 1;
+
+   // [required] The shard ID of the shard in the [node-ID][index-name][shard-ID] format.
+   string id = 2;
+
+   // [required] Search represents a query executed against the underlying Lucene index. Most search requests execute a single search against a Lucene index, but some search requests can execute more than one search. For example, including a global aggregation results in a secondary match_all query for the global context. The profile.shards array contains profiling information about each search execution.
+   repeated SearchProfile searches = 3;
+
+   // [optional] Fetch timing and debug information.
+   optional FetchProfile fetch = 4;
+
+ }
+
+ message AggregationProfile {
+
+   optional AggregationBreakdown breakdown = 1;
+
+   optional string description = 2;
+
+   // Time unit for nanoseconds
+   optional int64 time_in_nanos = 3;
+
+   optional string type = 4;
+
+   optional AggregationProfileDebug debug = 5;
+
+   repeated AggregationProfile children = 6;
+
+ }
+
+ message AggregationBreakdown {
+
+   // [required] Contains the time spent running the aggregation’s buildAggregations() method, which builds the results of this aggregation. For concurrent segment search, the build_aggregation method contains the total elapsed time across all slices (the difference between the last completed slice execution end time and the first slice execution start time).
+   int64 build_aggregation = 1;
+
+   // [required] Contains the number of invocations of a build_aggregation.
+   int64 build_aggregation_count = 2;
+
+   // [required] Contains the time spent running the aggregation’s getLeafCollector() method, which creates a new collector to collect the given context. For concurrent segment search, the build_leaf_collector method contains the total elapsed time across all slices (the difference between the last completed slice execution end time and the first slice execution start time).
+   int64 build_leaf_collector = 3;
+
+   // [required] Contains the number of invocations of a build_leaf_collector.
+   int64 build_leaf_collector_count = 4;
+
+   // [required] Contains the time spent collecting the documents into buckets. For concurrent segment search, the collect method contains the total elapsed time across all slices (the difference between the last completed slice execution end time and the first slice execution start time).
+   int64 collect = 5;
+
+   // [required] Contains the number of invocations of a collect.
+   int64 collect_count = 6;
+
+   // [required] Contains the amount of time taken to execute the preCollection() callback method during AggregationCollectorManager creation. For concurrent segment search, the initialize method contains the total elapsed time across all slices (the difference between the last completed slice execution end time and the first slice execution start time).
+   int64 initialize = 7;
+
+   // [required] Contains the number of invocations of a initialize.
+   int64 initialize_count = 8;
+
+   // [optional] Contains the time spent running the aggregation’s postCollection() callback method. For concurrent segment search, the post_collection method contains the total elapsed time across all slices (the difference between the last completed slice execution end time and the first slice execution start time).
+   optional int64 post_collection = 9;
+
+   // [optional] Contains the number of invocations of a post_collection.
+   optional int64 post_collection_count = 10;
+
+   // [required] Contains the time spent in the reduce phase. For concurrent segment search, the reduce method contains the total elapsed time across all slices (the difference between the last completed slice execution end time and the first slice execution start time).
+   int64 reduce = 11;
+
+   // [required] Contains the number of invocations of a reduce.
+   int64 reduce_count = 12;
+
+ }
+
+ message SearchProfile {
+
+   // [required] Profiling information about the Lucene collectors that ran the search.
+   repeated Collector collector = 1;
+
+   // [required] Profiling information about the query execution.
+   repeated QueryProfile query = 2;
+
+   // [required] All Lucene queries are rewritten. A query and its children may be rewritten more than once, until the query stops changing. The rewriting process involves performing optimizations, such as removing redundant clauses or replacing a query path with a more efficient one. After the rewriting process, the original query may change significantly. The rewrite_time field contains the cumulative total rewrite time for the query and all its children, in nanoseconds.
+   int64 rewrite_time = 3;
+
+ }
+
+ message Collector {
+
+   // [required] The collector name.
+   string name = 1;
+
+   // [required] Contains a description of the collector.
+   string reason = 2;
+
+   // [required] The total elapsed time for this collector, in nanoseconds. For concurrent segment search, time_in_nanos is the total amount of time across all slices (the difference between the last completed slice execution end time and the first slice execution start time).
+   int64 time_in_nanos = 3;
+
+   // [optional] If a collector has subcollectors (children), this field contains information about the subcollectors.
+   repeated Collector children = 4;
+
+ }
+
+ message QueryProfile {
+
+   // [required] Contains timing statistics about low-level Lucene execution.
+   QueryBreakdown breakdown = 1;
+
+   // [required] Contains a Lucene explanation of the query. Helps differentiate queries with the same type.
+   string description = 2;
+
+   // [required] The total elapsed time for this query, in nanoseconds. For concurrent segment search, time_in_nanos is the total time spent across all the slices (the difference between the last completed slice execution end time and the first slice execution start time).
+   int64 time_in_nanos = 3;
+
+   // [required] The Lucene query type into which the search query was rewritten. Corresponds to the Lucene class name (which often has the same name in OpenSearch).
+   string type = 4;
+
+   // [optional] If a query has subqueries (children), this field contains information about the subqueries.
+   repeated QueryProfile children = 5;
+
+ }
+
+ message QueryBreakdown {
+
+   // [required] The advance method is a lower-level version of the next_doc method in Lucene. It also finds the next matching document but necessitates that the calling query perform additional tasks, such as identifying skips. Some queries, such as conjunctions (must clauses in Boolean queries), cannot use next_doc. For those queries, advance is timed.
+   int64 advance = 1;
+   // [required] Contains the number of invocations of the advance method. Different invocations of the same method occur because the method is called on different documents. You can determine the selectivity of a query by comparing counts in different query components.
+   int64 advance_count = 2;
+   // [required] A Scorer iterates over matching documents and generates a score for each document. The build_scorer field contains the amount of time spent generating the Scorer object. This does not include the time spent scoring the documents. The Scorer initialization time depends on the optimization and complexity of a particular query. The build_scorer parameter also includes the amount of time associated with caching, if caching is applicable and enabled for the query.
+   int64 build_scorer = 3;
+   // [required] Build_scorer_count contains the number of invocations of the build_scorer method. Different invocations of the same method occur because the method is called on different documents. You can determine the selectivity of a query by comparing counts in different query components.
+   int64 build_scorer_count = 4;
+   // [required] A Query object in Lucene is immutable. Yet, Lucene should be able to reuse Query objects in multiple IndexSearcher objects. Thus, Query objects need to keep temporary state and statistics associated with the index in which the query is executed. To achieve reuse, every Query object generates a Weight object, which keeps the temporary context (state) associated with the <IndexSearcher, Query> tuple. The create_weight field contains the amount of time spent creating the Weight object.
+   int64 create_weight = 5;
+   // [required] Create_weight_count contains the number of invocations of the create_weight method. Different invocations of the same method occur because the method is called on different documents. You can determine the selectivity of a query by comparing counts in different query components.
+   int64 create_weight_count = 6;
+   // [required] For some queries, document matching is performed in two steps. First, the document is matched approximately. Second, those documents that are approximately matched are examined through a more comprehensive process. For example, a phrase query first checks whether a document contains all terms in the phrase. Next, it verifies that the terms are in order (which is a more expensive process). The match field is non-zero only for those queries that use the two-step verification process.
+   int64 match = 7;
+   // [required] Match_count contains the number of invocations of the match method. Different invocations of the same method occur because the method is called on different documents. You can determine the selectivity of a query by comparing counts in different query components.
+   int64 match_count = 8;
+   // [required] Contains the amount of time required to execute the advanceShallow Lucene method.
+   int64 shallow_advance = 9;
+   // [required] Shallow_advance_count contains the number of invocations of the shallow_advance method. Different invocations of the same method occur because the method is called on different documents. You can determine the selectivity of a query by comparing counts in different query components.
+   int64 shallow_advance_count = 10;
+   // [required] The next_doc Lucene method returns the document ID of the next document that matches the query. This method is a special type of the advance method and is equivalent to advance(docId() + 1). The next_doc method is more convenient for many Lucene queries. The next_doc field contains the amount of time required to determine the next matching document, which varies depending on the query type.
+   int64 next_doc = 11;
+   // [required] Next_doc_count contains the number of invocations of the next_doc method. Different invocations of the same method occur because the method is called on different documents. You can determine the selectivity of a query by comparing counts in different query components.
+   int64 next_doc_count = 12;
+   // [required] Contains the time taken for a Scorer to score a particular document.
+   int64 score = 13;
+   // [required] Score_count contains the number of invocations of the score method. Different invocations of the same method occur because the method is called on different documents. You can determine the selectivity of a query by comparing counts in different query components.
+   int64 score_count = 14;
+   // [required] Contains the amount of time required to execute the getMaxScore Lucene method.
+   int64 compute_max_score = 15;
+   // [required] Compute_max_score_count contains the number of invocations of the compute_max_score method. Different invocations of the same method occur because the method is called on different documents. You can determine the selectivity of a query by comparing counts in different query components.
+   int64 compute_max_score_count = 16;
+   // [required] Contains the amount of time required to execute the setMinCompetitiveScore Lucene method.
+   int64 set_min_competitive_score = 17;
+   // [required] Set_min_competitive_score_count contains the number of invocations of the set_min_competitive_score method. Different invocations of the same method occur because the method is called on different documents. You can determine the selectivity of a query by comparing counts in different query components.
+   int64 set_min_competitive_score_count = 18;
+
+ }
+
+ message FetchProfileDebug {
+
+   repeated string stored_fields = 1;
+
+   optional int32 fast_path = 2;
+
+ }
+
+ message FetchProfile {
+
+   optional string type = 1;
+
+   optional string description = 2;
+
+   // Time unit for nanoseconds
+   optional int64 time_in_nanos = 3;
+
+   optional FetchProfileBreakdown breakdown = 4;
+
+   optional FetchProfileDebug debug = 5;
+
+   repeated FetchProfile children = 6;
+
+ }
+
+
+ message FetchProfileBreakdown {
+
+   optional int32 load_stored_fields = 1;
+
+   optional int32 load_stored_fields_count = 2;
+
+   optional int32 next_reader = 3;
+
+   optional int32 next_reader_count = 4;
+
+   optional int32 process_count = 5;
+
+   optional int32 process = 6;
+
+ }
+
+ message AggregationProfileDebug {
+
+   optional int32 segments_with_multi_valued_ords = 1;
+
+   optional string collection_strategy = 2;
+
+   optional int32 segments_with_single_valued_ords = 3;
+
+   optional int32 total_buckets = 4;
+
+   optional int32 built_buckets = 5;
+
+   optional string result_strategy = 6;
+
+   optional bool has_filter = 7;
+
+   optional string delegate = 8;
+
+   optional AggregationProfileDebug delegate_debug = 9;
+
+   optional int32 chars_fetched = 10;
+
+   optional int32 extract_count = 11;
+
+   optional int32 extract_ns = 12;
+
+   optional int32 values_fetched = 13;
+
+   optional int32 collect_analyzed_ns = 14;
+
+   optional int32 collect_analyzed_count = 15;
+
+   optional int32 surviving_buckets = 16;
+
+   optional int32 ordinals_collectors_used = 17;
+
+   optional int32 ordinals_collectors_overhead_too_high = 18;
+
+   optional int32 string_hashing_collectors_used = 19;
+
+   optional int32 numeric_collectors_used = 20;
+
+   optional int32 empty_collectors_used = 21;
+
+   repeated string deferred_aggregators = 22;
+
+   optional int32 segments_with_doc_count_field = 23;
+
+   optional int32 segments_with_deleted_docs = 24;
+
+   repeated AggregationProfileDelegateDebugFilter filters = 25;
+
+   optional int32 segments_counted = 26;
+
+   optional int32 segments_collected = 27;
+
+   optional string map_reducer = 28;
+
+ }
+
+ message AggregationProfileDelegateDebugFilter {
+
+   optional int32 results_from_metadata = 1;
+
+   optional string query = 2;
+
+   optional string specialized_for = 3;
+
+   optional int32 segments_counted_in_constant_time = 4;
+
+ }
+
+ message Explanation {
+
+   // [required] Explains what type of calculation is performed
+   string description = 1;
+   // [optional] Shows any subcalculations performed.
+   repeated ExplanationDetail details = 2;
+   // [required] Shows the result of the calculation,
+   double value = 3;
+
+ }
+
+ message ExplanationDetail {
+
+   // [required] Explains what type of calculation is performed
+   string description = 1;
+
+   // [required] Shows any subcalculations performed.
+   repeated ExplanationDetail details = 2;
+
+   // [required] Shows the result of the calculation,
+   double value = 3;
+
+ }
+
+ message NestedIdentity {
+
+   // [required] The name of the nested field.
+   string field = 1;
+
+   // [required] Indicates the position or index of the nested document.
+   int32 offset = 2;
+
+   // [optional] Inner nested object.
+   optional NestedIdentity nested = 3;
+
+ }

--- a/search_service.proto
+++ b/search_service.proto
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+syntax = "proto3";
+package org.opensearch.protobuf.services;
+
+option java_multiple_files = true;
+option java_package = "org.opensearch.protobuf.services";
+option java_outer_classname = "SearchServiceProto";
+
+import "protos/schemas/search.proto";
+
+service SearchService {
+  rpc Search(SearchRequest) returns (SearchResponse) {}
+}


### PR DESCRIPTION
### Description
Initial bulk and search service definitions and protobufs, to be used in GRPC implementation in core. 

### Test Plan 
Compiles via bazel
```
~/opensearch-protobufs on [protos-initial] % bazel build :protos_java

INFO: Analyzed target //:protos_java (1 packages loaded, 5 targets configured).
INFO: Found 1 target...
Target //:protos_java up-to-date:
  bazel-bin/protos/schemas/libcommon_proto-speed.jar
  bazel-bin/protos/schemas/libdocument_proto-speed.jar
  bazel-bin/libdocument_service_proto-speed.jar
  bazel-bin/protos/schemas/libsearch_proto-speed.jar
  bazel-bin/libsearch_service_proto-speed.jar
  bazel-bin/document_service_proto-speed-src.jar
  bazel-bin/search_service_proto-speed-src.jar
INFO: Elapsed time: 0.512s, Critical Path: 0.03s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
```
### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/16783 
https://github.com/opensearch-project/OpenSearch/issues/16784
https://github.com/opensearch-project/opensearch-api-specification/issues/707

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
