### PR TITLE
Alphabetize maintainers list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,5 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 
 ### Fixed
+- Alphabetize maintainers ([#6](https://github.com/opensearch-project/opensearch-protobufs/pull/7))
+
 
 ### Security

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,6 +10,6 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Maintainer           | GitHub ID                                       | Affiliation |
 | -------------------- | ----------------------------------------------- | ----------- |
 | Karen Xu             | [karenyrx](https://github.com/karenyrx)         | Uber        |
+| Philip Chan          | [philiplhchan](https://github.com/philiplhchan) | Uber        |
 | Shuyi Zhang          | [amberzsy](https://github.com/amberzsy)         | Uber        |
 | Xi Lu                | [lucy66hw](https://github.com/lucy66hw)         | Uber        |
-| Philip Chan          | [philiplhchan](https://github.com/philiplhchan) | Uber         |


### PR DESCRIPTION
### Description
Alphabetize maintainers list similar to other repositories (e.g. core https://github.com/opensearch-project/OpenSearch/blob/main/MAINTAINERS.md#current-maintainers) 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
