### PR TITLE
Rename opensearch-protobuf to opensearch-protobufs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@karenyrx @amberzsy @lucy66hw @philiplhchan
+* @karenyrx @amberzsy @lucy66hw @philiplhchan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 - Alphabetize maintainers ([#6](https://github.com/opensearch-project/opensearch-protobufs/pull/7))
-
+- Rename opensearch-protobuf to opensearch-protobufs ([#12](https://github.com/opensearch-project/opensearch-protobufs/pull/12))
 
 ### Security

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -62,7 +62,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.opensearch.protobuf:opensearch-protobuf:1.0.0'
+    implementation 'org.opensearch.protobufs:opensearch-protobufs:1.0.0'
 }
 ```
 

--- a/document_service.proto
+++ b/document_service.proto
@@ -10,10 +10,10 @@
  */
 
 syntax = "proto3";
-package org.opensearch.protobuf.services;
+package org.opensearch.protobufs.services;
 
 option java_multiple_files = true;
-option java_package = "org.opensearch.protobuf.services";
+option java_package = "org.opensearch.protobufs.services";
 option java_outer_classname = "DocumentServiceProto";
 
 import "protos/schemas/document.proto";

--- a/protos/schemas/common.proto
+++ b/protos/schemas/common.proto
@@ -4,7 +4,7 @@ This is generated from the spec. DO NOT manually modify.
 syntax = "proto3";
 
 option java_multiple_files = true;
-option java_package = "org.opensearch.protobuf";
+option java_package = "org.opensearch.protobufs";
 option java_outer_classname = "CommonProto";
 option go_package = "opensearchpb";
 

--- a/protos/schemas/document.proto
+++ b/protos/schemas/document.proto
@@ -4,7 +4,7 @@
 syntax = "proto3";
 
 option java_multiple_files = true;
-option java_package = "org.opensearch.protobuf";
+option java_package = "org.opensearch.protobufs";
 option java_outer_classname = "DocumentProto";
 option go_package = "opensearchpb";
 

--- a/protos/schemas/search.proto
+++ b/protos/schemas/search.proto
@@ -5,7 +5,7 @@
 syntax = "proto3";
 
 option java_multiple_files = true;
-option java_package = "org.opensearch.protobuf";
+option java_package = "org.opensearch.protobufs";
 option java_outer_classname = "SearchProto";
 option go_package = "opensearchpb";
 

--- a/search_service.proto
+++ b/search_service.proto
@@ -10,10 +10,10 @@
  */
 
 syntax = "proto3";
-package org.opensearch.protobuf.services;
+package org.opensearch.protobufs.services;
 
 option java_multiple_files = true;
-option java_package = "org.opensearch.protobuf.services";
+option java_package = "org.opensearch.protobufs.services";
 option java_outer_classname = "SearchServiceProto";
 
 import "protos/schemas/search.proto";

--- a/tools/java/generate_grpc_java.sh
+++ b/tools/java/generate_grpc_java.sh
@@ -41,7 +41,7 @@ protoc \
   search_service.proto
 
 # Check if the gRPC stubs were generated
-if [ -f "$OUTPUT_DIR/org/opensearch/protobuf/services/DocumentServiceGrpc.java" ] && [ -f "$OUTPUT_DIR/org/opensearch/protobuf/services/SearchServiceGrpc.java" ]; then
+if [ -f "$OUTPUT_DIR/org/opensearch/protobufs/services/DocumentServiceGrpc.java" ] && [ -f "$OUTPUT_DIR/org/opensearch/protobufs/services/SearchServiceGrpc.java" ]; then
   echo "Successfully generated gRPC stubs!"
 else
   echo "Warning: gRPC stubs may not have been generated correctly."

--- a/tools/java/package_proto_jar.sh
+++ b/tools/java/package_proto_jar.sh
@@ -2,8 +2,8 @@
 # Script to package generated Java proto files into a Maven-compatible JAR
 
 # Configuration
-GROUP_ID="org.opensearch.protobuf"
-ARTIFACT_ID="opensearch-protobuf"
+GROUP_ID="org.opensearch.protobufs"
+ARTIFACT_ID="opensearch-protobufs"
 VERSION="1.0.0-SNAPSHOT"
 JAR_NAME="${ARTIFACT_ID}-${VERSION}.jar"
 POM_NAME="${ARTIFACT_ID}-${VERSION}.pom"
@@ -21,7 +21,7 @@ if [ ! -d "generated/java" ] || [ -z "$(find generated/java -name '*.java')" ]; 
 fi
 
 # Step 1.5: Generate gRPC stubs (if not already done)
-if [ ! -f "generated/java/opensearch/proto/services/DocumentServiceGrpc.java" ] || [ ! -f "generated/java/opensearch/proto/services/SearchServiceGrpc.java" ]; then
+if [ ! -f "generated/java/opensearch/protobufs/services/DocumentServiceGrpc.java" ] || [ ! -f "generated/java/opensearch/protobufs/services/SearchServiceGrpc.java" ]; then
   echo "Generating gRPC stubs..."
   ./tools/java/generate_grpc_java.sh
 fi
@@ -217,14 +217,16 @@ echo "dependencies {"
 echo "    implementation '${GROUP_ID}:${ARTIFACT_ID}:${VERSION}'"
 echo "}"
 
-mvn deploy:deploy-file \
-  -Dfile=${OUTPUT_DIR}/${JAR_NAME} \
-  -DpomFile="${OUTPUT_DIR}/META-INF/maven/${GROUP_ID}/${ARTIFACT_ID}/pom.xml" \
-  -DgroupId=${GROUP_ID} \
-  -DartifactId=${ARTIFACT_ID} \
-  -Dversion=${VERSION} \
-  -Dpackaging=jar \
-  -DrepositoryId=Snapshots \
-  -Durl=https://aws.oss.sonatype.org/content/repositories/snapshots/ \
-  -Dusername=$SONATYPE_USERNAME \
-  -Dpassword=$SONATYPE_PASSWORD
+if [[ -z "${SONATYPE_USERNAME}" && "${SONATYPE_PASSWORD}" ]]; then
+  mvn deploy:deploy-file \
+    -Dfile=${OUTPUT_DIR}/${JAR_NAME} \
+    -DpomFile="${OUTPUT_DIR}/META-INF/maven/${GROUP_ID}/${ARTIFACT_ID}/pom.xml" \
+    -DgroupId=${GROUP_ID} \
+    -DartifactId=${ARTIFACT_ID} \
+    -Dversion=${VERSION} \
+    -Dpackaging=jar \
+    -DrepositoryId=Snapshots \
+    -Durl=https://aws.oss.sonatype.org/content/repositories/snapshots/ \
+    -Dusername=$SONATYPE_USERNAME \
+    -Dpassword=$SONATYPE_PASSWORD
+fi


### PR DESCRIPTION
### Description
Rename the java maven artifact + group ids and Java package names to `opensearch-protobufs` (plural) to match the repository name. 

## Test Plan
`rm -rf generated && ./tools/java/package_proto_jar.sh` generated the jar correctly without any error output
<img width="535" alt="Screenshot 2025-03-24 at 6 51 23 PM" src="https://github.com/user-attachments/assets/78f7a297-2186-46a0-b890-9da618972bd6" />


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
