### PR TITLE
Add Protocol Buffers Compiler to maven publish workflow

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -19,6 +19,10 @@ jobs:
           distribution: temurin # Temurin is a distribution of adoptium
           java-version: 21
       - uses: actions/checkout@v3
+      - name: Install Protocol Buffers Compiler
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
       - uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.PUBLISH_SNAPSHOTS_ROLE }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add scripts to create java opensearch-protobuf-1.0.0.jar ([#6](https://github.com/opensearch-project/opensearch-protobufs/pull/6))
 - Add GHA to build and publish snapshots to maven & add mvn process ([#11](https://github.com/opensearch-project/opensearch-protobufs/pull/11))
 - Use java_grpc_library instead of protoc to generate GRPC Java libraries. ([#15](https://github.com/opensearch-project/opensearch-protobufs/pull/15))
-
+- Add Protocol Buffers Compiler to maven-publish workflow ([#16](https://github.com/opensearch-project/opensearch-protobufs/pull/16/files)
 
 ### Removed
 


### PR DESCRIPTION
### Description
Add Protocol Buffers Compiler to maven publish workflow

### Issues Resolved
Add publish maven failure `./tools/java/generate_grpc_java.sh: line 30: protoc: command not found`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
