### PR TITLE
Exclude `com.google.protobuf.*` classes from the `opensearch-protobuf-*` jar and upgrade dependency versions to match core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add scripts to create java opensearch-protobuf-1.0.0.jar ([#6](https://github.com/opensearch-project/opensearch-protobufs/pull/6))
 - Add GHA to build and publish snapshots to maven & add mvn process ([#11](https://github.com/opensearch-project/opensearch-protobufs/pull/11))
 - Use java_grpc_library instead of protoc to generate GRPC Java libraries. ([#15](https://github.com/opensearch-project/opensearch-protobufs/pull/15))
+- Upgrade protobuf, grpc, guava versions to match core. ([#17](https://github.com/opensearch-project/opensearch-protobufs/pull/17))
 
 
 ### Removed

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -1,16 +1,6 @@
 # Prerequisites
-Install protoc v25.1
-```
-PB_REL="https://github.com/protocolbuffers/protobuf/releases"
-curl -LO $PB_REL/download/v25.1/protoc-25.1-linux-x86_64.zip
-unzip protoc-25.1-linux-x86_64.zip -d $HOME/.local
-export PATH="$PATH:$HOME/.local/bin"
-```
+Install bazel, using the version in .bazelversion.
 
-The follow command should output `v25.1`:
-```
-protoc --version
-```
 # Compile protos and grpc
 ```
 bazel build //...
@@ -21,7 +11,10 @@ bazel build //...
 
 To package the generated Java files into a Maven-compatible JAR that can be used as a Gradle dependency, run the provided script:
 ```bash
-rm -rf bazel* && rm -rf generated && ./tools/java/package_proto_jar.sh
+#optional
+rm -rf bazel*
+
+rm -rf generated && bazel build //... && ./tools/java/package_proto_jar.sh
 ```
 
 This script will:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,9 +5,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Protocol Buffers dependencies
 http_archive(
     name = "com_google_protobuf",
-    sha256 = "946ba5371e423e1220d2cbefc1f65e69a1e81ca5bab62a03d66894172983cfcd",
-    strip_prefix = "protobuf-3.12.0",
-    urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.12.0.tar.gz"],
+    sha256 = "4356e78744dfb2df3890282386c8568c85868116317d9b3ad80eb11c2aecf2ff",
+    strip_prefix = "protobuf-3.25.5",
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.25.5.tar.gz"],
 )
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
@@ -16,19 +16,21 @@ protobuf_deps()
 # Java rules
 http_archive(
     name = "rules_java",
-    sha256 = "220b87d8cfabd22d1c6d8e3cdb4249abd4c93dcc152e0667db061fb1b957ee68",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/0.1.1/rules_java-0.1.1.tar.gz"],
+    urls = [
+        "https://github.com/bazelbuild/rules_java/releases/download/7.6.1/rules_java-7.6.1.tar.gz",
+    ],
+    sha256 = "f8ae9ed3887df02f40de9f4f7ac3873e6dd7a471f9cddf63952538b94b59aeb3",
 )
 
-load("@rules_java//java:repositories.bzl", "rules_java_dependencies")
-rules_java_dependencies()
+# load("@rules_java//java:repositories.bzl", "rules_java_dependencies")
+# rules_java_dependencies()
 
 # Proto rules
 http_archive(
     name = "rules_proto",
-    sha256 = "66bfdf8782796239d3875d37e7de19b1d94301e8972b3cbd2446b332429b4df1",
-    strip_prefix = "rules_proto-4.0.0",
-    urls = ["https://github.com/bazelbuild/rules_proto/archive/refs/tags/4.0.0.zip"],
+    sha256 = "37005d35aba73a843b34f194c0c41633a0b2fd90f8b84c91b391b995ffc593f2",
+    strip_prefix = "rules_proto-5.3.0-21.7",
+    urls = ["https://github.com/bazelbuild/rules_proto/archive/refs/tags/5.3.0-21.7.zip"],
 )
 
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
@@ -38,9 +40,9 @@ rules_proto_toolchains()
 # gRPC dependencies
 http_archive(
     name = "io_grpc_grpc_java",
-    sha256 = "c454e068bfb5d0b5bdb5e3d7e32cd1fc34aaf22202855e29e048f3ad338e57b2",
-    strip_prefix = "grpc-java-1.38.0",
-    urls = ["https://github.com/grpc/grpc-java/archive/v1.38.0.tar.gz"],
+    sha256 = "dc1ad2272c1442075c59116ec468a7227d0612350c44401237facd35aab15732",
+    strip_prefix = "grpc-java-1.68.2",
+    urls = ["https://github.com/grpc/grpc-java/archive/v1.68.2.tar.gz"],
 )
 
 load("@io_grpc_grpc_java//:repositories.bzl", "grpc_java_repositories")

--- a/third_party/guava.BUILD
+++ b/third_party/guava.BUILD
@@ -2,5 +2,5 @@ package(default_visibility = ["//visibility:public"])
 
 java_import(
     name = "jar",
-    jars = ["guava-31.0.1-jre.jar"],
+    jars = ["guava-33.2.1-jre.jar"],
 )

--- a/tools/java/generate_java.sh
+++ b/tools/java/generate_java.sh
@@ -27,4 +27,6 @@ for jar in $SRC_JARS; do
   (cd "$OUTPUT_DIR" && jar xf "$jar")
 done
 
+rm -rf "$OUTPUT_DIR/com/google/protobuf"
+
 echo "Done! Generated Java files are in $OUTPUT_DIR"

--- a/tools/java/package_proto_jar.sh
+++ b/tools/java/package_proto_jar.sh
@@ -23,8 +23,8 @@ fi
 
 # Step 2: Download protobuf-java and gRPC dependencies if needed
 PROTOBUF_VERSION="3.25.5"
-GRPC_VERSION="1.38.0"
-GUAVA_VERSION="31.0.1-jre"
+GRPC_VERSION="1.68.2"
+GUAVA_VERSION="33.2.1-jre"
 JAVAX_ANNOTATION_VERSION="1.3.2"
 PROTOBUF_JAR="${OUTPUT_DIR}/protobuf-java-${PROTOBUF_VERSION}.jar"
 GRPC_STUB_JAR="${OUTPUT_DIR}/grpc-stub-${GRPC_VERSION}.jar"
@@ -137,7 +137,12 @@ groupId=${GROUP_ID}
 artifactId=${ARTIFACT_ID}
 EOF
 
-# Step 4: Create JAR file
+# Step 4: Ensure Google Protobuf classes are excluded
+echo "Ensuring Google Protobuf classes are excluded..."
+rm -rf "${OUTPUT_DIR}/classes/com/google/protobuf"
+rm -rf "${OUTPUT_DIR}/classes/google/protobuf"
+
+# Step 5: Create JAR file
 echo "Creating JAR file..."
 (cd "${OUTPUT_DIR}/classes" && jar cf "../${JAR_NAME}" .)
 jar uf "${OUTPUT_DIR}/${JAR_NAME}" -C "${OUTPUT_DIR}" META-INF


### PR DESCRIPTION
### Description

1. Excludes the `com.google.protobuf.*` classes from the `opensearch-protobuf-1.0.0.jar.` Previously the jar generated from this repo was failing at runtime with core. Specifically, this command:
```
./gradlew run -PinstalledPlugins="['transport-grpc']" --info -Dtests.opensearch.aux.transport.types="[experimental-transport-grpc]" -Drepos.mavenLocal
```
gave jar hell due to duplicate classes in `com.google.protobuf.*` (which appeared in both `opensearch-protobufs-1.0.0.jar` and the `protobuf-java-3.25.5.jar` introduced by the transport-grpc plugin) -
```
Caused by: java.lang.IllegalStateException: jar hell!
class: com.google.protobuf.ListValueOrBuilder
jar1: /home/user/opensearch/build/testclusters/runTask-0/distro/3.0.0-ARCHIVE/lib/protobuf-java-3.25.5.jar
jar2: /home/user/opensearch/build/testclusters/runTask-0/distro/3.0.0-ARCHIVE/plugins/.installing-5759844670181928339/opensearch-protobufs-1.0.0.jar
```
2. Additionally, aligns the protobuf, grpc, and guava versions with core, as defined in https://github.com/opensearch-project/OpenSearch/blob/main/gradle/libs.versions.toml

### Test plan
Uploaded the new generated jar to local maven repository in core, and grpc server is working
```
~/opensearch on [bulk_squash4_rebase_main] % grpcurl -plaintext localhost:9400 list

grpc.health.v1.Health
grpc.reflection.v1alpha.ServerReflection
org.opensearch.protobufs.services.DocumentService
```
### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
