### PR TITLE
Fix source files not found

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - 'main'
-  pull_request:
 jobs:
   build-and-publish-snapshots:
     runs-on: ubuntu-latest
@@ -20,14 +19,14 @@ jobs:
           distribution: temurin # Temurin is a distribution of adoptium
           java-version: 21
       - uses: actions/checkout@v3
-      # - uses: aws-actions/configure-aws-credentials@v1
-      #   with:
-      #     role-to-assume: ${{ secrets.PUBLISH_SNAPSHOTS_ROLE }}
-      #     aws-region: us-east-1
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.PUBLISH_SNAPSHOTS_ROLE }}
+          aws-region: us-east-1
       - name: publish snapshots to maven
         run: |
-          # export SONATYPE_USERNAME=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-username --query SecretString --output text)
-          # export SONATYPE_PASSWORD=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-password --query SecretString --output text)
-          # echo "::add-mask::$SONATYPE_USERNAME"
-          # echo "::add-mask::$SONATYPE_PASSWORD"
+          export SONATYPE_USERNAME=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-username --query SecretString --output text)
+          export SONATYPE_PASSWORD=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-password --query SecretString --output text)
+          echo "::add-mask::$SONATYPE_USERNAME"
+          echo "::add-mask::$SONATYPE_PASSWORD"
           ./tools/java/package_proto_jar.sh

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - 'main'
+  pull_request:
 jobs:
   build-and-publish-snapshots:
     runs-on: ubuntu-latest
@@ -19,14 +20,14 @@ jobs:
           distribution: temurin # Temurin is a distribution of adoptium
           java-version: 21
       - uses: actions/checkout@v3
-      - uses: aws-actions/configure-aws-credentials@v1
-        with:
-          role-to-assume: ${{ secrets.PUBLISH_SNAPSHOTS_ROLE }}
-          aws-region: us-east-1
+      # - uses: aws-actions/configure-aws-credentials@v1
+      #   with:
+      #     role-to-assume: ${{ secrets.PUBLISH_SNAPSHOTS_ROLE }}
+      #     aws-region: us-east-1
       - name: publish snapshots to maven
         run: |
-          export SONATYPE_USERNAME=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-username --query SecretString --output text)
-          export SONATYPE_PASSWORD=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-password --query SecretString --output text)
-          echo "::add-mask::$SONATYPE_USERNAME"
-          echo "::add-mask::$SONATYPE_PASSWORD"
+          # export SONATYPE_USERNAME=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-username --query SecretString --output text)
+          # export SONATYPE_PASSWORD=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-password --query SecretString --output text)
+          # echo "::add-mask::$SONATYPE_USERNAME"
+          # echo "::add-mask::$SONATYPE_PASSWORD"
           ./tools/java/package_proto_jar.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,13 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add scripts to create java opensearch-protobuf-1.0.0.jar ([#6](https://github.com/opensearch-project/opensearch-protobufs/pull/6))
 - Add GHA to build and publish snapshots to maven & add mvn process ([#11](https://github.com/opensearch-project/opensearch-protobufs/pull/11))
 - Use java_grpc_library instead of protoc to generate GRPC Java libraries. ([#15](https://github.com/opensearch-project/opensearch-protobufs/pull/15))
-- Upgrade protobuf, grpc, guava versions to match core. ([#17](https://github.com/opensearch-project/opensearch-protobufs/pull/17))
-
+- Exclude `com.google.protobuf.*` classes from the `opensearch-protobuf-*` jar and upgrade dependency versions to match core ([#17](https://github.com/opensearch-project/opensearch-protobufs/pull/17))
 
 ### Removed
 
 ### Fixed
 - Alphabetize maintainers ([#6](https://github.com/opensearch-project/opensearch-protobufs/pull/7))
 - Rename opensearch-protobuf to opensearch-protobufs ([#13](https://github.com/opensearch-project/opensearch-protobufs/pull/13))
+- Fix sourcefiles not found ([#18](https://github.com/opensearch-project/opensearch-protobufs/pull/18))
 
 ### Security

--- a/tools/java/generate_java.sh
+++ b/tools/java/generate_java.sh
@@ -16,9 +16,9 @@ cd $(dirname "$0")/../.. && bazel build //... && cd - > /dev/null
 
 # Find all source JAR files
 echo "Finding source JAR files..."
-SRC_JARS=$(find "$BAZEL_BIN_DIR" -name "*-speed-src.jar")
+SRC_JARS=$(find "$BAZEL_BIN_DIR"/ -name "*-speed-src.jar")
 SRC_JARS+=" "
-SRC_JARS+=$(find "$BAZEL_BIN_DIR" -name "*grpc_java-src.jar")
+SRC_JARS+=$(find "$BAZEL_BIN_DIR"/ -name "*grpc_java-src.jar")
 echo $SRC_JARS
 # Extract Java files from source JAR files
 echo "Extracting Java files from source JAR files..."


### PR DESCRIPTION
### Description
* Before: 

In this CI run: https://github.com/opensearch-project/opensearch-protobufs/actions/runs/14051257187/job/39341951150 , output shows `error: no source files` and the CI failed: 
```
+ javac -cp generated/maven/protobuf-java-3.25.5.jar:generated/maven/grpc-stub-1.38.0.jar:generated/maven/grpc-protobuf-1.38.0.jar:generated/maven/grpc-core-1.38.0.jar:generated/maven/grpc-api-1.38.0.jar:generated/maven/guava-31.0.1-jre.jar:generated/maven/javax.annotation-api-1.3.2.jar -d generated/maven/classes @generated/maven/sources.txt
error: no source files
```

Despite `bazel build //...` being run, still no `SRC_JARS` were found:
```
# Find all source JAR files
echo "Finding source JAR files..."
+ echo 'Finding source JAR files...'
SRC_JARS=$(find "$BAZEL_BIN_DIR" -name "*-speed-src.jar")
Finding source JAR files...
++ find /home/runner/work/opensearch-protobufs/opensearch-protobufs/bazel-bin -name '*-speed-src.jar'
+ SRC_JARS=
SRC_JARS+=" "
+ SRC_JARS+=' '
SRC_JARS+=$(find "$BAZEL_BIN_DIR" -name "*grpc_java-src.jar")
++ find /home/runner/work/opensearch-protobufs/opensearch-protobufs/bazel-bin -name '*grpc_java-src.jar'
+ SRC_JARS+=
```

* After:

Triggered the CI with the changes in this PR, and CI passed: https://github.com/opensearch-project/opensearch-protobufs/actions/runs/14052564342/job/39345464470?pr=18 

### Issues Resolved
https://github.com/opensearch-project/opensearch-protobufs/issues/9

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
