### PR TITLE
Remove testing exec which cause child process to take over current shell

### DIFF
--- a/tools/java/package_proto_jar.sh
+++ b/tools/java/package_proto_jar.sh
@@ -25,7 +25,7 @@ mkdir -p "${OUTPUT_DIR}/META-INF/maven/${GROUP_ID}/${ARTIFACT_ID}"
 # Step 1: Generate Java files from proto files (if not already done)
 if [ ! -d "$OUTPUT_DIR_JAVA" ] || [ -z "$(find "$OUTPUT_DIR_JAVA" -name '*.java')" ]; then
   echo "Generating Java files from proto files..."
-  exec "$ROOT_DIR/tools/java/generate_java.sh"
+  "$ROOT_DIR/tools/java/generate_java.sh"
 fi
 
 


### PR DESCRIPTION
### Description
Remove testing exec which cause child process to take over current shell

### Issues Resolved
https://github.com/opensearch-project/.github/issues/305
https://github.com/opensearch-project/opensearch-protobufs/actions/runs/14073340440/job/39411773806
```
> Task :generatePomFileForCreatePublication FAILED
FAILURE: Build failed with an exception.
* Where:
Build file '/home/runner/work/opensearch-protobufs/opensearch-protobufs/build.gradle' line: 44
* What went wrong:
Execution failed for task ':generatePomFileForCreatePublication'.
> java.io.FileNotFoundException: /home/runner/work/opensearch-protobufs/opensearch-protobufs/generated/maven/publish/protobufs-1.0.0-SNAPSHOT.pom (No such file or directory)
* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org./
BUILD FAILED in 741ms
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
