### PR TITLE
Fix ErrorCause and InlineGetDictUserDefined protos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,5 +22,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Alphabetize maintainers ([#6](https://github.com/opensearch-project/opensearch-protobufs/pull/7))
 - Rename opensearch-protobuf to opensearch-protobufs ([#13](https://github.com/opensearch-project/opensearch-protobufs/pull/13))
 - Fix sourcefiles not found ([#18](https://github.com/opensearch-project/opensearch-protobufs/pull/18))
+- Fix ErrorCause and InlineGetDictUserDefined protos ([#29](https://github.com/opensearch-project/opensearch-protobufs/pull/29))
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository stores the Protobufs and generated code used for client <> serve
 
 The [opensearch-api-specification repo](https://github.com/opensearch-project/opensearch-api-specification)  will continue to be the source of truth, and these protobufs will mostly be a downstream consumer of the spec.
 
-This repository will also include a variety of tooling and CI, linters and validators, and generated code, described in more default below.
+This repository will also include a variety of tooling and CI, linters and validators, and generated code, which is described in more detail below.
 
 ## Intended usage of the repo
 The repo will consist of:

--- a/protos/schemas/common.proto
+++ b/protos/schemas/common.proto
@@ -89,7 +89,6 @@ message ObjectMap {
       // Represents a repeated `Value`.
       ListValue list_value = 6;
     }
-
   }
 
   // `ListValue` is a wrapper around a repeated field of values.
@@ -275,7 +274,7 @@ message ErrorCause {
 
   optional string index_uuid = 9;
 
-  .google.protobuf.Struct additional_details = 10;
+  .google.protobuf.Struct metadata = 10;
 
 }
 message ShardStatistics {

--- a/protos/schemas/document.proto
+++ b/protos/schemas/document.proto
@@ -310,15 +310,17 @@ message ResponseItem {
 
 message InlineGetDictUserDefined {
   // [optional]
-  optional ObjectMap fields = 1;
+  .google.protobuf.Struct metadata_fields = 1;
+  // [optional]
+  .google.protobuf.Struct fields = 2;
   // [required] Whether the document exists.
-  bool found = 2;
+  bool found = 3;
   // [optional] The sequence number assigned to the document for the operation. Sequence numbers are used to ensure an older version of a document doesn't overwrite a newer version
-  optional int64 seq_no = 3;
+  optional int64 seq_no = 4;
   // [optional] The primary term assigned to the document for the operation.
-  optional int64 primary_term = 4;
+  optional int64 primary_term = 5;
   // [optional] Custom value used to route operations to a specific shard.
-  repeated string routing = 5;
+  repeated string routing = 6;
   // [optional] Contains the document's data
   optional bytes source = 7;
 }


### PR DESCRIPTION
### Description

1. Per the [spec](https://github.com/opensearch-project/opensearch-api-specification/blob/3c22a3ef1ff2e49092057a9e2fb9d57806191eb3/spec/schemas/_common.yaml#L374), the map in the `ErrorCause` message is called `metadata`  not `additional_details`.
2. Per the [code](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/index/get/GetResult.java#L300-L307), `InlineGetDictUserDefined` message is missing an additional `metadata fields` . (Corresponding spec fixes will also be made in a separate PR: https://github.com/opensearch-project/opensearch-api-specification/pull/843). 

### Issues Resolved
https://github.com/opensearch-project/opensearch-protobufs/issues/28

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
