### PR TITLE
Add missing 'header' field to ErrorCause and fix type of 'metadata' f…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Update jar generation script with proper exit trap and add java build github action workflow ([#24](https://github.com/opensearch-project/opensearch-protobufs/pull/24))
 - Add proto convert preprocessing scripts. ([#7](https://github.com/opensearch-project/opensearch-protobufs/pull/7)
 - Remove maven pom dependencies ([#26](https://github.com/opensearch-project/opensearch-protobufs/pull/26))
-- Resolve CVE-2023-36665 protobufjs
-
+- Resolve CVE-2023-36665 protobufjs ([#32](https://github.com/opensearch-project/opensearch-protobufs/pull/32))
 
 ### Removed
 
@@ -24,5 +23,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Rename opensearch-protobuf to opensearch-protobufs ([#13](https://github.com/opensearch-project/opensearch-protobufs/pull/13))
 - Fix sourcefiles not found ([#18](https://github.com/opensearch-project/opensearch-protobufs/pull/18))
 - Fix ErrorCause and InlineGetDictUserDefined protos ([#29](https://github.com/opensearch-project/opensearch-protobufs/pull/29))
+- Add missing 'header' field to ErrorCause and fix type of 'metadata' field ([#33](https://github.com/opensearch-project/opensearch-protobufs/pull/33))
 
 ### Security

--- a/protos/schemas/common.proto
+++ b/protos/schemas/common.proto
@@ -274,8 +274,11 @@ message ErrorCause {
 
   optional string index_uuid = 9;
 
-  .google.protobuf.Struct metadata = 10;
+  // [optional] The spec actually does not have a field named 'metadata'. This should have adaptor_unnest. 
+  map<string, StringOrStringArray> metadata = 10;
 
+  // [optional] 
+  map<string, StringOrStringArray> header = 11;
 }
 message ShardStatistics {
   // [required] Number of shards that failed to execute the request. Note that shards that are not allocated will be considered neither successful nor failed. Having failed+successful less than total is thus an indication that some of the shards were not allocated.


### PR DESCRIPTION
### Description
1. Per the [code](https://github.com/opensearch-project/OpenSearch/blob/1937f5f06271cd70522c4d7391140b01070a16db/libs/core/src/main/java/org/opensearch/OpenSearchException.java#L421), ErrorCause should have an additional field called `header`, whch is a `Map<String, List<String> | String>`  
2. Similarly, the [metadata](https://github.com/opensearch-project/OpenSearch/blob/1937f5f06271cd70522c4d7391140b01070a16db/libs/core/src/main/java/org/opensearch/OpenSearchException.java#L402-L404) field in ErrorCause is actually a `Map<String, List<String> | String>`,  rather a `Struct` (which can have recursively nested maps inside the original map value)

### Issues Resolved
https://github.com/opensearch-project/opensearch-protobufs/issues/28

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
