### PR TITLE
Generate python wheel from protos

### DIFF
--- a/Dockerfile.py
+++ b/Dockerfile.py
@@ -156,4 +156,4 @@ FROM base AS package-out
 COPY --from=make-package /dist /dist
 
 VOLUME /output
-CMD ["cp", "/dist", "/output/"]
+CMD ["cp", "-r", "/dist", "/output/"]

--- a/Dockerfile.py
+++ b/Dockerfile.py
@@ -1,0 +1,92 @@
+FROM python:3.10-slim AS proto-build
+
+# Build and run
+# docker build --target proto-build -t opensearch-proto-python -f Dockerfile.py .
+# docker build --target proto-run -t opensearch-proto-python -f Dockerfile.py .
+
+ENV PIP_GRPCIO_VERSION=1.69.0
+ENV PIP_GRPCIO_TOOLS_VERSION=1.69.0
+ENV PIP_PROTOBUF_VERSION=4.3.0
+
+# Update pip
+RUN pip install --upgrade pip
+
+# Set up container dependencies
+RUN apt-get update && apt-get install -y \
+    protobuf-compiler \
+    git \
+    sed \
+    findutils \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /build
+RUN pip install --no-cache-dir grpcio==$PIP_GRPCIO_VERSION grpcio-tools==$PIP_GRPCIO_TOOLS_VERSION protobuf==$PIP_PROTOBUF_VERSION
+
+# Copy entire repository for convenience
+COPY . .
+
+# Setup and 
+RUN bash -c 'set -e; \
+    # Set up variables \
+    ROOT_DIR="/build"; \
+    OUTPUT_DIR="$ROOT_DIR/generated/python"; \
+    PROTO_DIR="$ROOT_DIR/protos"; \
+    \
+    # Create output directory \
+    rm -rf "$OUTPUT_DIR"; \
+    mkdir -p "$OUTPUT_DIR"; \
+    touch "$OUTPUT_DIR/__init__.py"; \
+    \
+    echo "Generating Python code from Proto files..."; \
+    \
+    # Find all proto files \
+    SCHEMA_PROTO_FILES=$(find "$PROTO_DIR/schemas" -name "*.proto"); \
+    SERVICE_PROTO_FILES=$(find "$ROOT_DIR" -maxdepth 1 -name "*.proto"); \
+    ALL_PROTO_FILES="$SCHEMA_PROTO_FILES $SERVICE_PROTO_FILES"; \
+    \
+    # Create Python package structure \
+    mkdir -p "$OUTPUT_DIR/protos/schemas"; \
+    touch "$OUTPUT_DIR/protos/__init__.py"; \
+    touch "$OUTPUT_DIR/protos/schemas/__init__.py"; \
+    \
+    # Generate Python code using grpcio-tools package \
+    python -m grpc_tools.protoc \
+        --proto_path="$ROOT_DIR" \
+        --python_out="$OUTPUT_DIR" \
+        --grpc_python_out="$OUTPUT_DIR" \
+        $ALL_PROTO_FILES; \
+    \
+    echo "Python code generation completed!"; \
+    \
+    # Fix imports in generated Python files \
+    find "$OUTPUT_DIR" -name "*.py" -type f -exec sed -i.bak "s/^import protos\./import generated.python.protos./g" {} \; ; \
+    find "$OUTPUT_DIR" -name "*.py" -type f -exec sed -i.bak "s/^from protos\./from generated.python.protos./g" {} \; ; \
+    find "$OUTPUT_DIR" -name "*.bak" -type f -delete; \
+    \
+    echo "Done! Generated Python files are in $OUTPUT_DIR"; \
+'
+
+# Stage 2: Create a lightweight runtime image
+FROM python:3.10-slim as proto-run
+
+# Set working directory
+WORKDIR /app
+
+# Copy only the generated Python code from the builder stage
+COPY --from=proto-build /build/generated/python /app/generated/python
+
+# Install runtime dependencies
+RUN pip install --no-cache-dir grpcio protobuf
+
+# Create a Python package structure
+RUN cd /app && \
+    touch generated/__init__.py && \
+    touch generated/python/__init__.py
+
+# Add the package to Python path
+ENV PYTHONPATH="/app:${PYTHONPATH}"
+
+# Create a simple test script to verify imports
+RUN echo 'import sys; print("Python version:", sys.version); print("Available modules:"); import os; print(os.listdir("/app/generated/python"))' > /app/test_imports.py
+
+# Command to run when container starts
+CMD ["python", "/app/test_imports.py"]

--- a/Dockerfile.py
+++ b/Dockerfile.py
@@ -4,9 +4,15 @@ FROM python:3.10-slim AS proto-build
 # docker build --target proto-build -t opensearch-proto-python -f Dockerfile.py .
 # docker build --target proto-run -t opensearch-proto-python -f Dockerfile.py .
 
-ENV PIP_GRPCIO_VERSION=1.69.0
-ENV PIP_GRPCIO_TOOLS_VERSION=1.69.0
-ENV PIP_PROTOBUF_VERSION=4.3.0
+# Notes on OpenSearch trying to match core proto & gRPC versions: 
+# https://github.com/opensearch-project/OpenSearch/blob/main/gradle/libs.versions.toml
+# - No pip package for grpcio 1.68.2 so we use closest 1.68.1 release.
+# - pip packages bump major versions independently of pensource protobuf repo - in both java & python the minor version corresponds to open source release tags.
+# - pip enforces "grpcio-tools 1.68.1 depends on protobuf<6.0dev and >=5.26.1" so we have to bump proto 25.5 -> 26.1.
+
+ENV PIP_GRPCIO_VERSION=1.68.1
+ENV PIP_GRPCIO_TOOLS_VERSION=1.68.1
+ENV PIP_PROTOBUF_VERSION=5.26.1
 
 # Update pip
 RUN pip install --upgrade pip

--- a/Dockerfile.py
+++ b/Dockerfile.py
@@ -139,6 +139,8 @@ COPY --from=make-package /dist /dist
 WORKDIR /dist
 
 # Small sanity test script to load and use package
+RUN pip install --no-cache-dir grpcio==$PIP_GRPCIO_VERSION grpcio-tools==$PIP_GRPCIO_TOOLS_VERSION protobuf==$PIP_PROTOBUF_VERSION
+RUN pip install --no-cache-dir /dist/*
 RUN echo 'import grpc\n\
 from opensearch_protos.protos.schemas import document_pb2\n\
 \n\
@@ -147,12 +149,11 @@ def testdocument_pb2BulkRequest():\n\
     body = bulk_request.request_body.add()\n\
     body.index.id = "doc1"\n\
     body.index.index = "my_index"\n\
-    body.doc = b'{"field1": "value1", "field2": 42}'\n\
+    body.doc = '{"field1": "value1", "field2": 42}'\n\
     print(bulk_request.SerializeToString())\n\
-
+\n\
 if __name__ == "__main__":\n\
-    testdocument_pb2BulkRequest()\n\
-)' > test.py
+    testdocument_pb2BulkRequest()' > test.py
 RUN python test.py 
 
 VOLUME /output

--- a/Dockerfile.py
+++ b/Dockerfile.py
@@ -140,7 +140,7 @@ WORKDIR /dist
 
 # Small sanity test script to load and use package
 RUN pip install --no-cache-dir grpcio==$PIP_GRPCIO_VERSION grpcio-tools==$PIP_GRPCIO_TOOLS_VERSION protobuf==$PIP_PROTOBUF_VERSION
-RUN pip install --no-cache-dir /dist/*
+RUN pip install --no-cache-dir *.whl
 RUN echo 'import grpc\n\
 from opensearch_protos.protos.schemas import document_pb2\n\
 \n\
@@ -149,7 +149,7 @@ def testdocument_pb2BulkRequest():\n\
     body = bulk_request.request_body.add()\n\
     body.index.id = "doc1"\n\
     body.index.index = "my_index"\n\
-    body.doc = '{"field1": "value1", "field2": 42}'\n\
+    body.doc = b'"'"'{"field1": "value1", "field2": 42}'"'"'\n\
     print(bulk_request.SerializeToString())\n\
 \n\
 if __name__ == "__main__":\n\

--- a/Dockerfile.py
+++ b/Dockerfile.py
@@ -139,13 +139,13 @@ setup(\n\
     python_requires=">=3.8",\n\
 )' > opensearch_protos_package/setup.py
 
-# # Build the package
-# WORKDIR /build/opensearch_protos_package
-# RUN python -m build
+# Build the package
+WORKDIR /build/opensearch_protos_package
+RUN python -m build
 
-# # Create dist dir and copy wheel
-# RUN mkdir -p /dist && \
-#     cp dist/*.whl /dist/
+# Create dist dir and copy wheel
+RUN mkdir -p /dist && \
+    cp dist/*.whl /dist/
 
 ###############################################################################
 # Stage 4: Helper stage to copy dist from image

--- a/Dockerfile.py
+++ b/Dockerfile.py
@@ -1,6 +1,6 @@
 # Dockerfile must be located at the root of: https://github.com/opensearch-project/opensearch-protobufs
 # Usage:
-# docker build --target package-out -t opensearch-proto-python -f Dockerfile.py .
+# docker build --no-cache --target package-out -t opensearch-proto-python -f Dockerfile.py .
 # docker run --rm -v $(pwd):/output opensearch-proto-python
 
 ###############################################################################
@@ -11,17 +11,15 @@ FROM python:3.10-slim AS base
 
 # Notes on OpenSearch trying to match core proto & gRPC versions: 
 # https://github.com/opensearch-project/OpenSearch/blob/main/gradle/libs.versions.toml
-# - No pip package for grpcio 1.68.2 so we use closest 1.68.1 release.
-# - pip packages bump major versions independently of pensource protobuf repo - in both java & python the minor version corresponds to open source release tags.
-# - pip enforces "grpcio-tools 1.68.1 depends on protobuf<6.0dev and >=5.26.1" so we have to bump proto 25.5 -> 26.1.
+# - pip packages bump major versions independently of opensource protobuf repo - in both java & python the minor version corresponds to open source release tags.
+# - Here I select the same proto version as core - Due to pip package comatibility lastest usable io.grpc version is 1.62.3.
 
-ENV PIP_GRPCIO_VERSION=1.68.1
-ENV PIP_GRPCIO_TOOLS_VERSION=1.68.1
-ENV PIP_PROTOBUF_VERSION=5.26.1
+ENV PROTO_VERSION=25.5
+ENV PIP_GRPC_VERSION=1.62.3
+ENV PIP_PROTOBUF_VERSION=4.$PROTO_VERSION
 
 RUN pip install --upgrade pip
 RUN apt-get update && apt-get install -y \
-    protobuf-compiler \
     git \
     sed \
     findutils \
@@ -33,51 +31,43 @@ RUN apt-get update && apt-get install -y \
 
 FROM base AS proto-build
 WORKDIR /build
-RUN pip install --no-cache-dir grpcio==$PIP_GRPCIO_VERSION grpcio-tools==$PIP_GRPCIO_TOOLS_VERSION protobuf==$PIP_PROTOBUF_VERSION
+RUN pip install --no-cache-dir grpcio==$PIP_GRPC_VERSION grpcio-tools==$PIP_GRPC_VERSION grpcio-reflection==$PIP_GRPC_VERSION protobuf==$PIP_PROTOBUF_VERSION
 
 # Copy entire repository for convenience
 COPY . .
 
-# Discover proto files and run protoc compiler
+ENV ROOT_DIR=/build
+ENV OUTPUT_DIR=$ROOT_DIR/generated/python
+ENV PROTO_DIR=$ROOT_DIR/protos
+
+# Create output directory
+RUN rm -rf $OUTPUT_DIR && \
+    mkdir -p $OUTPUT_DIR && \
+    touch $OUTPUT_DIR/__init__.py
+
+# Discover proto files and build with grpc_tools.protoc
 RUN bash -c 'set -e; \
-    # Set up variables \
-    ROOT_DIR="/build"; \
-    OUTPUT_DIR="$ROOT_DIR/generated/python"; \
-    PROTO_DIR="$ROOT_DIR/protos"; \
+    # Create python package structure \
+    mkdir -p "$OUTPUT_DIR/protos/schemas" && \
+    touch "$OUTPUT_DIR/protos/__init__.py" && \
+    touch "$OUTPUT_DIR/protos/schemas/__init__.py" && \
     \
-    # Create output directory \
-    rm -rf "$OUTPUT_DIR"; \
-    mkdir -p "$OUTPUT_DIR"; \
-    touch "$OUTPUT_DIR/__init__.py"; \
+    # Discover proto files \
+    SCHEMA_PROTO_FILES=$(find "$PROTO_DIR/schemas" -name "*.proto") && \
+    SERVICE_PROTO_FILES=$(find "$ROOT_DIR" -maxdepth 1 -name "*.proto") && \
+    ALL_PROTO_FILES="$SCHEMA_PROTO_FILES $SERVICE_PROTO_FILES" && \
     \
-    echo "Generating Python code from Proto files..."; \
-    \
-    # Find all proto files \
-    SCHEMA_PROTO_FILES=$(find "$PROTO_DIR/schemas" -name "*.proto"); \
-    SERVICE_PROTO_FILES=$(find "$ROOT_DIR" -maxdepth 1 -name "*.proto"); \
-    ALL_PROTO_FILES="$SCHEMA_PROTO_FILES $SERVICE_PROTO_FILES"; \
-    \
-    # Create Python package structure \
-    mkdir -p "$OUTPUT_DIR/protos/schemas"; \
-    touch "$OUTPUT_DIR/protos/__init__.py"; \
-    touch "$OUTPUT_DIR/protos/schemas/__init__.py"; \
-    \
-    # Generate Python code using grpcio-tools package \
+    # Compile proto \
     python -m grpc_tools.protoc \
         --proto_path="$ROOT_DIR" \
         --python_out="$OUTPUT_DIR" \
         --grpc_python_out="$OUTPUT_DIR" \
-        $ALL_PROTO_FILES; \
-    \
-    echo "Python code generation completed!"; \
-    \
-    # Fix imports in generated Python files \
-    find "$OUTPUT_DIR" -name "*.py" -type f -exec sed -i.bak "s/^import protos\./import opensearch_protos.protos./g" {} \; ; \
-    find "$OUTPUT_DIR" -name "*.py" -type f -exec sed -i.bak "s/^from protos\./from opensearch_protos.protos./g" {} \; ; \
-    find "$OUTPUT_DIR" -name "*.bak" -type f -delete; \
-    \
-    echo "Done! Generated Python files are in $OUTPUT_DIR"; \
-'
+        $ALL_PROTO_FILES'
+
+# Cleanup - fix package name in imports
+RUN find "$OUTPUT_DIR" -name "*.py" -type f -exec sed -i.bak "s/^import protos\./import opensearch_protos.protos./g" {} \; && \
+    find "$OUTPUT_DIR" -name "*.py" -type f -exec sed -i.bak "s/^from protos\./from opensearch_protos.protos./g" {} \; && \
+    find "$OUTPUT_DIR" -name "*.bak" -type f -delete
 
 ###############################################################################
 # Stage 2: Construct python package and generate wheel file
@@ -106,9 +96,10 @@ setup(\n\
     url="https://github.com/opensearch-project/opensearch-protobufs",\n\
     packages=find_packages(),\n\
     install_requires=[\n\
-        "grpcio>='${PIP_GRPCIO_VERSION}'",\n\
-        "protobuf>='${PIP_PROTOBUF_VERSION}'",\n\
-        "grpcio-reflection>='${PIP_GRPCIO_VERSION}'",\n\
+        "protobuf=='${PIP_PROTOBUF_VERSION}'",\n\
+        "grpcio=='${PIP_GRPC_VERSION}'",\n\
+        "grpcio-reflection=='${PIP_GRPC_VERSION}'",\n\
+        "grpcio-reflection=='$PIP_GRPC_VERSION'",\n\
     ],\n\
     classifiers=[\n\
         "Development Status :: 3 - Alpha",\n\
@@ -139,7 +130,7 @@ COPY --from=make-package /dist /dist
 WORKDIR /dist
 
 # Small sanity test script to load and use package
-RUN pip install --no-cache-dir grpcio==$PIP_GRPCIO_VERSION grpcio-tools==$PIP_GRPCIO_TOOLS_VERSION protobuf==$PIP_PROTOBUF_VERSION
+RUN pip install --no-cache-dir grpcio==$PIP_GRPC_VERSION grpcio-tools==$PIP_GRPC_VERSION grpcio-reflection==$PIP_GRPC_VERSION protobuf==$PIP_PROTOBUF_VERSION
 RUN pip install --no-cache-dir *.whl
 RUN echo 'import grpc\n\
 from opensearch_protos.protos.schemas import document_pb2\n\

--- a/Dockerfile.py
+++ b/Dockerfile.py
@@ -1,5 +1,7 @@
-# Usage `docker build --target <stage-name> -t opensearch-proto-python -f Dockerfile.py .` 
 # Dockerfile must be located at the root of: https://github.com/opensearch-project/opensearch-protobufs
+# Usage:
+# docker build --target package-out -t opensearch-proto-python -f Dockerfile.py .
+# docker run --rm -v $(pwd):/output opensearch-proto-python
 
 ###############################################################################
 # Stage 0: Setup shared environment/base image

--- a/Dockerfile.py
+++ b/Dockerfile.py
@@ -1,4 +1,5 @@
 # Usage `docker build --target <stage-name> -t opensearch-proto-python -f Dockerfile.py .` 
+# Dockerfile must be located at the root of: https://github.com/opensearch-project/opensearch-protobufs
 
 ###############################################################################
 # Stage 0: Setup shared environment/base image

--- a/Dockerfile.py
+++ b/Dockerfile.py
@@ -154,3 +154,6 @@ RUN mkdir -p /dist && \
 
 FROM base AS package-out
 COPY --from=make-package /dist /dist
+
+VOLUME /output
+CMD ["cp", "/dist", "/output/"]

--- a/protos/schemas/common.proto
+++ b/protos/schemas/common.proto
@@ -576,7 +576,7 @@ message InnerHits {
   repeated SortCombinations sort = 12;
 
   // [optional] Select what fields of the source are returned
-  optional SourceConfig source = 13 [json_name = "_source"];
+  optional SourceConfig source = 13;
 
   // [optional] A list of stored fields to return as part of a hit. If no fields are specified, no stored fields are included in the response. If this option is specified, the _source parameter defaults to false. You can pass _source: true to return both source fields and stored fields in the search response.
   repeated string stored_fields = 14;
@@ -2741,7 +2741,6 @@ message InlineGet {
     .google.protobuf.Struct struct_source = 6;
 
     // Use bytes for better latency/performance, as it reduces payload size over the wire
-    bytes source = 7 [json_name = "_source"];
-
+    bytes source = 7;
   }
 }

--- a/protos/schemas/search.proto
+++ b/protos/schemas/search.proto
@@ -19,7 +19,7 @@ message SearchRequest {
    // [optional] A list of indices to search for documents. If not provided, the default value will be to search through all indexes.
    repeated string index = 1;
    // [optional] Whether to include the _source field in the response.
-   SourceConfigParam source = 2 [json_name = "_source"];
+   SourceConfigParam source = 2;
    // [optional] A list of source fields to exclude from the response. You can also use this parameter to exclude fields from the subset specified in `source_includes` query parameter. If the `source` parameter is `false`, this parameter is ignored.
    repeated string source_excludes = 3;
    // [optional] A list of source fields to include in the response. If this parameter is specified, only these source fields are returned. You can exclude fields from this subset using the `source_excludes` query parameter. If the `source` parameter is `false`, this parameter is ignored.


### PR DESCRIPTION
### Description
Draft to add support for generating a python package from protobuf definitions. Usage:
```
docker build --no-cache --target package-out -t opensearch-proto-python -f Dockerfile.py .
docker run --rm -v $(pwd):/output opensearch-proto-python
```

Initially I was using Bazel in line with java but ran into a couple issues (Probably easily fixable, my familiarity with Bazel is not great).
- https://github.com/bazelbuild does not have a rules_python. Some third party options I looked at and experimented with linked here.
https://github.com/rules-proto-grpc/rules_proto_grpc
https://github.com/bazel-contrib/rules_python 
- Protobuf/gRPC OpenSource repos publish PyPi packages for [grpcio](https://pypi.org/project/grpcio/) & [protobuf](https://pypi.org/project/protobuf/). It ended up being convenient to pull these and use the grpc_tools.protoc utility to compile as it also ensured a compatible runtime environment for testing/running.

Some additional notes:
Some detail of the python libraries causes collisions between the `json_name` and actual proto field names within objects. After removing all `json_name` tags which referenced `_source` or `source` this error went away.

I tried to match the OS core protobuf and gRPC versions exactly to their python versions but grpcio==1.68.2 is not compatible with protobuf 25.5... I don't understand why and thought it best to ensure proto versions matched exactly and as a result had to bump grpcio down to 1.62.3.

### Issues Resolved
Starts on #8 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
