### PR TITLE
Wrap ScriptLanguage fields into a 'oneof' and mark as 'required'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,5 +24,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fix sourcefiles not found ([#18](https://github.com/opensearch-project/opensearch-protobufs/pull/18))
 - Fix ErrorCause and InlineGetDictUserDefined protos ([#29](https://github.com/opensearch-project/opensearch-protobufs/pull/29))
 - Add missing 'header' field to ErrorCause and fix type of 'metadata' field ([#33](https://github.com/opensearch-project/opensearch-protobufs/pull/33))
+- Add 'optional' keyword to ScriptLanguage fields ([#335](https://github.com/opensearch-project/opensearch-protobufs/pull/35))
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add proto convert preprocessing scripts. ([#7](https://github.com/opensearch-project/opensearch-protobufs/pull/7)
 - Remove maven pom dependencies ([#26](https://github.com/opensearch-project/opensearch-protobufs/pull/26))
 - Resolve CVE-2023-36665 protobufjs ([#32](https://github.com/opensearch-project/opensearch-protobufs/pull/32))
+- Wrap ScriptLanguage fields into a oneof and mark as required ([#335](https://github.com/opensearch-project/opensearch-protobufs/pull/35))
 
 ### Removed
 
@@ -24,6 +25,5 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fix sourcefiles not found ([#18](https://github.com/opensearch-project/opensearch-protobufs/pull/18))
 - Fix ErrorCause and InlineGetDictUserDefined protos ([#29](https://github.com/opensearch-project/opensearch-protobufs/pull/29))
 - Add missing 'header' field to ErrorCause and fix type of 'metadata' field ([#33](https://github.com/opensearch-project/opensearch-protobufs/pull/33))
-- Add 'optional' keyword to ScriptLanguage fields ([#335](https://github.com/opensearch-project/opensearch-protobufs/pull/35))
 
 ### Security

--- a/protos/schemas/common.proto
+++ b/protos/schemas/common.proto
@@ -36,7 +36,7 @@ message Script {
 message InlineScript {
   // [optional]
   // The parameters that can be passed to the script.
-  ObjectMap params = 1;
+  map<string, .google. params = 1;
 
   // [optional]
   // The script's language. Default is painless.
@@ -66,7 +66,7 @@ message ScriptLanguage {
 message StoredScriptId {
   // [optional]
   // The parameters that can be passed to the script.
-  map<string, .google.protobuf.Value> params = 1;
+  ObjectMap params = 1;
   // [required]
   // The ID of a stored script previously created using the Create Stored Script API.
   string id = 2;

--- a/protos/schemas/common.proto
+++ b/protos/schemas/common.proto
@@ -57,14 +57,16 @@ message ScriptLanguage {
     BUILTIN_SCRIPT_LANGUAGE_MUSTACHE = 3;
     BUILTIN_SCRIPT_LANGUAGE_PAINLESS = 4;
   }
-  BuiltinScriptLanguage builtin_script_language = 1;
-  string string_value = 2;
+  // [optional] one of string_vaue or builtin_script_language must be specified.
+  optional BuiltinScriptLanguage builtin_script_language = 1;
+  // [optional] one of string_vaue or builtin_script_language must be specified.
+  optional string string_value = 2;
 }
 
 message StoredScriptId {
   // [optional]
   // The parameters that can be passed to the script.
-  ObjectMap params = 1;
+  map<string, .google.protobuf.Value> params = 1;
   // [required]
   // The ID of a stored script previously created using the Create Stored Script API.
   string id = 2;

--- a/protos/schemas/common.proto
+++ b/protos/schemas/common.proto
@@ -57,11 +57,10 @@ message ScriptLanguage {
     BUILTIN_SCRIPT_LANGUAGE_MUSTACHE = 3;
     BUILTIN_SCRIPT_LANGUAGE_PAINLESS = 4;
   }
-  oneof {
-    // [optional] one of string_vaue or builtin_script_language must be specified.
-    optional BuiltinScriptLanguage builtin_script_language = 1;
-    // [optional] one of string_vaue or builtin_script_language must be specified.
-    optional string string_value = 2;
+  // [required]
+  oneof script_language {
+    BuiltinScriptLanguage builtin_script_language = 1;
+    string string_value = 2;
   }
 }
 

--- a/protos/schemas/common.proto
+++ b/protos/schemas/common.proto
@@ -36,7 +36,7 @@ message Script {
 message InlineScript {
   // [optional]
   // The parameters that can be passed to the script.
-  map<string, .google. params = 1;
+  ObjectMap params = 1;
 
   // [optional]
   // The script's language. Default is painless.
@@ -57,10 +57,12 @@ message ScriptLanguage {
     BUILTIN_SCRIPT_LANGUAGE_MUSTACHE = 3;
     BUILTIN_SCRIPT_LANGUAGE_PAINLESS = 4;
   }
-  // [optional] one of string_vaue or builtin_script_language must be specified.
-  optional BuiltinScriptLanguage builtin_script_language = 1;
-  // [optional] one of string_vaue or builtin_script_language must be specified.
-  optional string string_value = 2;
+  oneof {
+    // [optional] one of string_vaue or builtin_script_language must be specified.
+    optional BuiltinScriptLanguage builtin_script_language = 1;
+    // [optional] one of string_vaue or builtin_script_language must be specified.
+    optional string string_value = 2;
+  }
 }
 
 message StoredScriptId {


### PR DESCRIPTION
### Description
Both are optional fields, but one must be provided. 
(Corresponding spec fix in https://github.com/opensearch-project/opensearch-api-specification/pull/843/files)

### Issues Resolved
https://github.com/opensearch-project/opensearch-protobufs/issues/28

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
