### PR TITLE
Fix 'Value' fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fix sourcefiles not found ([#18](https://github.com/opensearch-project/opensearch-protobufs/pull/18))
 - Fix ErrorCause and InlineGetDictUserDefined protos ([#29](https://github.com/opensearch-project/opensearch-protobufs/pull/29))
 - Add missing 'header' field to ErrorCause and fix type of 'metadata' field ([#33](https://github.com/opensearch-project/opensearch-protobufs/pull/33))
+- Fix 'Value' fields ([#38](https://github.com/opensearch-project/opensearch-protobufs/pull/38))
 
 ### Security
 - Resolve CVE-2023-36665 protobufjs ([#32](https://github.com/opensearch-project/opensearch-protobufs/pull/32))

--- a/protos/schemas/common.proto
+++ b/protos/schemas/common.proto
@@ -94,7 +94,7 @@ message ObjectMap {
   // The JSON representation for `ListValue` is JSON array.
   message ListValue {
     // Repeated field of dynamically typed values.
-    repeated Value value_without_wrappers = 1;
+    repeated Value value = 1;
   }
 }
 
@@ -260,7 +260,7 @@ message ErrorCause {
   optional string index_uuid = 9;
 
   // [optional] The spec actually does not have a field named 'metadata'. This should have adaptor_unnest. 
-  map<string, .google.protobuf.Value> metadata = 10;
+  map<string, ObjectMap.Value> metadata = 10;
 
   // [optional] 
   map<string, StringOrStringArray> header = 11;


### PR DESCRIPTION
### Description
Use the correct `ObjectMap.Value` type not the `google.protobuf.Value` type. 
Also fix a misnamed field. 

### Issues Resolved
#28 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
