### PR TITLE
Document steps to cut a release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add GHA to convert from spec to proto ([#39](https://github.com/opensearch-project/opensearch-protobufs/pull/39))
 - Ignore OpenApi-generator generated unnecessary files and add signoff/label:skip-changelog to generated PR ([#40](https://github.com/opensearch-project/opensearch-protobufs/pull/40))
 - Add release drafter action and jenkins workflow in preparation for 0.1.0 maven release ([#43](https://github.com/opensearch-project/opensearch-protobufs/pull/43))
+- Document steps to cut a release ([#44](https://github.com/opensearch-project/opensearch-protobufs/pull/44))
 
 ### Removed
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,1 +1,15 @@
-TODO
+# Steps to cut a release
+
+**DO NOT cut a tag by going to release section of Github UI. It will mess up the Github Action.**
+
+1. Run these commands from the upstream opensearch-protobufs repository, not a forked one: 
+```
+git checkout main
+git fetch origin
+git rebase origin/main
+git tag <version>
+git push origin <version> 
+```
+2. Wait for Github Actions to run and open the newly created issue. Two maintainers should comment `approve` in the issue.
+3. Wait for Jenkins to be triggered, pull the artifacts built by Actions, push to sonatype release channel on remote. Wait for an hour or so for Sonatype to copy it into Maven Central.
+4. Bump [version.properties](./version.properties) via a PR.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,6 +2,7 @@
 
 **DO NOT cut a tag by going to release section of Github UI. It will mess up the Github Action.**
 
+Note: A maintainer must remember to perform steps 1, 2 and 4.
 1. Run these commands from the upstream opensearch-protobufs repository, not a forked one: 
 ```
 git checkout main


### PR DESCRIPTION
### Description
Document the steps to cut a release, from @peterzhuamazon on Slack. 

These steps are to be done once the 1st release is out. All new releases can then be processed with these steps.

### Issues Resolved
https://github.com/opensearch-project/opensearch-protobufs/issues/9
https://github.com/opensearch-project/.github/issues/305

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
