### PR TITLE
Add missing SearchRequestBody and ErrorResponse fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Ignore OpenApi-generator generated unnecessary files and add signoff/label:skip-changelog to generated PR ([#40](https://github.com/opensearch-project/opensearch-protobufs/pull/40))
 - Add release drafter action and jenkins workflow in preparation for 0.1.0 maven release ([#43](https://github.com/opensearch-project/opensearch-protobufs/pull/43))
 - Document steps to cut a release ([#44](https://github.com/opensearch-project/opensearch-protobufs/pull/44))
+- Add missing SearchRequestBody and ErrorResponse fields ([#45](https://github.com/opensearch-project/opensearch-protobufs/pull/45))
 
 ### Removed
 

--- a/protos/schemas/search.proto
+++ b/protos/schemas/search.proto
@@ -16,743 +16,876 @@ import "protos/schemas/common.proto";
 // The Search API operation to perform a search across all indices in the cluster.
 // The Search API operation to perform a search or index search
 message SearchRequest {
-   // [optional] A list of indices to search for documents. If not provided, the default value will be to search through all indexes.
-   repeated string index = 1;
-   // [optional] Whether to include the _source field in the response.
-   SourceConfigParam source = 2 [json_name = "_source"];
-   // [optional] A list of source fields to exclude from the response. You can also use this parameter to exclude fields from the subset specified in `source_includes` query parameter. If the `source` parameter is `false`, this parameter is ignored.
-   repeated string source_excludes = 3;
-   // [optional] A list of source fields to include in the response. If this parameter is specified, only these source fields are returned. You can exclude fields from this subset using the `source_excludes` query parameter. If the `source` parameter is `false`, this parameter is ignored.
-   repeated string source_includes = 4 [json_name = "_source_includes"];
-   // [optional] Whether to ignore wildcards that don't match any indexes. Default is true.
-   optional bool allow_no_indices = 5;
-   // [optional] Whether to return partial results if the request runs into an error or times out. Default is true.
-   optional bool allow_partial_search_results = 6;
-   // [optional] Whether the update operation should include wildcard and prefix queries in the analysis. Default is false.
-   optional bool analyze_wildcard = 7;
-   // [optional] Analyzer to use for the query string. This parameter can only be used when the q query string parameter is specified.
-   optional string analyzer = 8;
-   // [optional] How many shard results to reduce on a node. Default is 512.
-   optional int32 batched_reduce_size = 9;
-   // [optional] The time after which the search request will be canceled. Request-level parameter takes precedence over cancel_after_time_interval cluster setting. Default is -1.
-   optional string cancel_after_time_interval = 10;
-   // [optional] Whether to minimize round-trips between a node and remote clusters. Default is true.
-   optional bool ccs_minimize_roundtrips = 11;
-   // [optional] Indicates whether the default operator for a string query should be AND or OR. Default is OR.
-   optional Operator default_operator = 12;
-   enum Operator {
-     OPERATOR_UNSPECIFIED = 0;
-     // All terms need to match. The string `to be` is interpreted as `to AND be`
-     OPERATOR_AND = 1;
-     // Only one term needs to match. The string `to be` is interpreted as `to OR be`
-     OPERATOR_OR = 2;
-   }
-   // [optional] The default field in case a field prefix is not provided in the query string.
-   optional string df = 13;
-   // [optional] The fields that OpenSearch should return using their docvalue forms.
-   repeated string docvalue_fields = 14;
-   // [optional] Specifies the type of index that wildcard expressions can match. Supports list of values. Default is open.
-   repeated ExpandWildcard expand_wildcards = 15;
-   enum ExpandWildcard {
-     EXPAND_WILDCARD_UNSPECIFIED = 0;
-     // Match any index
-     EXPAND_WILDCARD_ALL = 1;
-     // Match closed, non-hidden indexes
-     EXPAND_WILDCARD_CLOSED = 2;
-     // Match hidden indexes
-     EXPAND_WILDCARD_HIDDEN = 3;
-     // Deny wildcard expressions
-     EXPAND_WILDCARD_NONE = 4;
-     // Match open, non-hidden indexes
-     EXPAND_WILDCARD_OPEN = 5;
-   }
-   // [optional] Whether to return details about how OpenSearch computed the document's score. Default is false.
-   optional bool explain = 16;
-   // [optional] The starting index to search from. Default is 0.
-   optional int32 from = 17;
-   // [optional] Whether to ignore concrete, expanded, or indexes with aliases if indexes are frozen. Default is true.
-   optional bool ignore_throttled = 18;
-   // [optional] Specifies whether to include missing or closed indexes in the response and ignores unavailable shards during the search request. Default is false.
-   optional bool ignore_unavailable = 19;
-   // [optional] Whether to return scores with named queries. Default is false.
-   optional bool include_named_queries_score = 20;
-   // [optional] Specifies whether OpenSearch should accept requests if queries have format errors (for example, querying a text field for an integer). Default is false.
-   optional bool lenient = 21;
-   // [optional] Numbers of concurrent shard requests this request should execute on each node. Default is 5.
-   optional int32 max_concurrent_shard_requests = 22;
-   // [optional] Whether to return phase-level took time values in the response. Default is false.
-   optional bool phase_took = 23;
-   // [optional] A prefilter size threshold that triggers a prefilter operation if the request exceeds the threshold. Default is 128 shards.
-   optional int32 pre_filter_shard_size = 24;
-   // [optional] Specifies the shards or nodes on which OpenSearch should perform the search. For valid values see "https://opensearch.org/docs/latest/api-reference/search/#the-preference-query-parameter"
-   optional string preference = 25;
-   // [optional] Query in the Lucene query string syntax using query parameter search.
-   optional string q = 26;
-   // [optional] Specifies whether OpenSearch should use the request cache. Default is whether it's enabled in the index's settings.
-   optional bool request_cache = 27;
-   // [optional] Indicates whether to return hits.total as an integer. Returns an object otherwise. Default is false.
-   // TODO should we rename this field to remove "rest"?
-   optional bool rest_total_hits_as_int = 28;
-   // [optional] Value used to route the update by query operation to a specific shard.
-   repeated string routing = 29;
-   // [optional] Period to keep the search context open.
-   optional string scroll = 30;
-   // [optional] Customizable sequence of processing stages applied to search queries.
-   optional string search_pipeline = 31;
-   // [optional] Whether OpenSearch should use global term and document frequencies when calculating relevance scores. Default is SEARCH_TYPE_QUERY_THEN_FETCH.
-   // TODO remove these fields from spec?
-   // do not allow 'query_and_fetch' or 'dfs_query_and_fetch' search types
-   // from the REST layer. these modes are an internal optimization and should
-   // not be specified explicitly by the user.
-
-   optional SearchType search_type = 32;
-   enum SearchType {
-     SEARCH_TYPE_UNSPECIFIED = 0;
-     // Scores documents using global term and document frequencies across all shards. It's usually slower but more accurate.
-     SEARCH_TYPE_DFS_QUERY_THEN_FETCH = 1;
-     // Scores documents using local term and document frequencies for the shard. It's usually faster but less accurate.
-     SEARCH_TYPE_QUERY_THEN_FETCH = 2;
-   }
-   // [optional] Whether to return sequence number and primary term of the last operation of each document hit.
-   optional bool seq_no_primary_term = 33;
-   // [optional] Number of results to include in the response.
-   optional int32 size = 34;
-   // [optional] A list of <field> : <direction> pairs to sort by.
-   // TODO use this improvement instead?
-   message SortOrder {
-     // [required]
-     string field = 1;
-     // [optional]
-     optional Direction direction = 2;
-
-     enum Direction {
-       DIRECTION_UNSPECIFIED = 0;
-       DIRECTION_ASC = 1;
-       DIRECTION_DESC = 2;
-     }
-   }
-   repeated SortOrder sort = 35;
-
-   //  repeated string sort = 35;
-   // [optional] Value to associate with the request for additional logging.
-   repeated string stats = 36;
-   // [optional] Whether the get operation should retrieve fields stored in the index. Default is false.
-   repeated string stored_fields = 37;
-   // [optional] Fields OpenSearch can use to look for similar terms.
-   optional string suggest_field = 38;
-   // [optional] The mode to use when searching. This parameter can only be used when the `suggest_field` and `suggest_text` query string parameters are specified.
-   optional SuggestMode suggest_mode = 39;
-   enum SuggestMode {
-     SUGGEST_MODE_UNSPECIFIED = 0;
-     // Use suggestions based on the provided terms
-     SUGGEST_MODE_ALWAYS = 1;
-     // Use suggestions for terms not in the index
-     SUGGEST_MODE_MISSING = 2;
-     // Use suggestions that have more occurrences
-     SUGGEST_MODE_POPULAR = 3;
-   }
-   // [optional] Number of suggestions to return.
-   optional int32 suggest_size = 40;
-   // [optional] The source that suggestions should be based off of.
-   optional string suggest_text = 41;
-   // [optional] The maximum number of documents OpenSearch should process before terminating the request. Default is 0.
-   optional int32 terminate_after = 42;
-   // [optional] Period of time to wait for a response from active shards. Default is 1m.
-   optional string timeout = 43;
-   // [optional] Whether to return document scores. Default is false.
-   optional bool track_scores = 44;
-   // [optional] Whether to return how many documents matched the query.
-   optional TrackHits track_total_hits = 45;
-   // [optional] Whether returned aggregations and suggested terms should include their types in the response. Default is true.
-   optional bool typed_keys = 46;
-   // [optional] Whether to include the document version as a match. Default is false
-   optional bool version = 47;
-   // [optional] Search Request body
-   SearchRequestBody request_body = 48;
-
-   // [optional] The DSL query to use in the request.
- //  optional QueryContainer query = 48;
- }
-
- // TODO do we really need this extra layer?
- message SearchRequestBody {
-   // [optional] The DSL query to use in the request.
-   optional QueryContainer query = 1;
- }
-
- message TrackHits {
-   oneof track_hits{
-     bool bool_value = 1;
-     int32 int32_value = 2;
-   }
- }
-
- // The response from search request.
- message SearchResponse {
- //  oneof response {
- //    // The search success response
- //    ResponseBody response_body = 1;
- //  }
- //}
- //
- //// The response body from a search/index-search request.
- //message ResponseBody {
-
-   // [required] Milliseconds it took Elasticsearch to execute the request.
-   optional int64 took = 1;
-
-   // [required]  If true, the request timed out before completion; returned results may be partial or empty.
-   optional bool timed_out = 2;
-
-   // [required] Contains a count of shards used for the request.
-   ShardStatistics shards = 3;
-
-   // [optional] Phase-level took time values in the response.
-   optional PhaseTook phase_took = 4;
-
-   // [required] Contains returned documents and metadata.
-   HitsMetadata hits = 5;
-
-   // [optional] When you search one or more remote clusters, a `_clusters` section is included to provide information about the search on each cluster.
-   optional ClusterStatistics clusters = 6;
-
-   // [optional] Retrieved specific fields in the search response
-   optional .google.protobuf.Struct fields = 7;
-
-   // [optional] Highest returned document _score.
-   optional float max_score = 8; // TODO where is this used? remove?
-
-   // [optional] The number of times that the coordinating node aggregates results from batches of shard responses
-   optional int32 num_reduce_phases = 9;
-
-   // [optional] Contains profiling information.
-   Profile profile = 10;
-
-   // [optional] The PIT ID.
-   optional string pit_id = 11;
-
-   // [optional] Identifier for the search and its search context.
-   optional string scroll_id = 12;
-
-   // [optional] If the query was terminated early, the terminated_early flag will be set to true in the response
-   optional bool terminated_early = 13;
-
- }
-
- message PhaseTook {
-
-   // [required] Time taken in dfs_pre_query phase.
-   int64 dfs_pre_query = 1;
-   // [required] Time taken in query phase.
-   int64 query = 2;
-   // [required] Time taken in fetch phase.
-   int64 fetch = 3;
-   // [required] Time taken in dfs_query phase.
-   int64 dfs_query = 4;
-   // [required] Time taken in expand phase.
-   int64 expand = 5;
-   // [required] Time taken in can_match phase.
-   int64 can_match = 6;
-
- }
-
- message HitsMetadata {
-   message Total {
-     oneof total{
-       TotalHits total_hits = 1;
-       double double_value = 2;
-     }
-   }
-   // [optional] Metadata about the number of matching documents.
-   Total total = 1;
-
-   // [required] Array of returned document objects.
-   repeated Hit hits = 2;
-
-   message MaxScore{
-     oneof max_score{
-       float float_value = 1;
-       string string_value = 2;
-       NullValue null_value = 3;
-     }
-   }
-
-   // [optional] Highest returned document _score.
-   MaxScore max_score = 3;
-
- }
-
- message TotalHits {
-
-   // [required] Indicates whether the number of matching documents in the value parameter is accurate or a lower bound.
-   TotalHitsRelation relation = 1;
-   enum TotalHitsRelation {
-     TOTAL_HITS_RELATION_UNSPECIFIED = 0;
-     // Accurate
-     TOTAL_HITS_RELATION_EQ = 1;
-     // Lower bound
-     TOTAL_HITS_RELATION_GTE = 2;
-   }
-   // [required] Total number of matching documents.
-   int64 value = 2;
-
- }
-
- message InnerHitsResult {
-
-   // [required] An additional nested hits value.
-   HitsMetadata hits = 1;
-
- }
-
- message Hit {
-
-   optional string type = 1;
-
-   // [required] Name of the index containing the returned document.
-   string index = 2;
-   // [required] Unique identifier for the returned document. This ID is only unique within the returned index.
-   string id = 3;
-
-   message Score {
-     oneof score{
-       float float_value = 1;
-       string string_value = 2;
-       NullValue null_value = 3;
-     }
-   }
-
-   // [optional] Relevance of the returned document.
-   optional Score score = 4;
-
-   // [optional] Explanation of how the relevance score (_score) is calculated for every result.
-   optional Explanation explanation = 5;
-
-   // [optional] Contains field values for the documents.
-   optional .google.protobuf.Struct fields = 6;
-
-   // [optional] An additional highlight element for each search hit that includes the highlighted fields and the highlighted fragments.
-   map<string, StringArray> highlight = 7;
-
-   // [optional] An additional nested hits that caused a search hit to match in a different scope.
-   map<string, InnerHitsResult> inner_hits = 8;
-
-   // [optional] List of matched query names used in the search request.
-   repeated string matched_queries = 9;
-
-   // [optional] Defines from what inner nested object this inner hit came from
-   optional NestedIdentity nested = 10;
-
-   // [optional] List of fields ignored.
-   repeated string ignored = 11;
-
-   // [optional] These values are retrieved from the document’s original JSON source and are raw so will not be formatted or treated in any way, unlike the successfully indexed fields which are returned in the fields section.
-   map<string, StringArray> ignored_field_values = 12;
-
-   // [optional] Shard from which this document was retrieved.
-   optional string shard = 13;
-
-   // [optional] Node from which this document was retrieved.
-   optional string node = 14;
-
-   optional string routing = 15;
-
-   // [optional] Source document.
-   optional bytes source = 16;
-
-   // [optional] Counts the number of operations that happened on the index
-   optional int64 seq_no = 17;
-
-   // [optional] Counts the number of shard has changed.
-   optional int64 primary_term = 18;
-
-   // [optional] Version number of the document.
-   optional int64 version = 19;
-
-   // [optional] Sorted values
-   repeated FieldValueResponse sort = 20;
-
- }
-
-
- message ClusterStatistics {
-
-   // [required] Number of shards that skipped the request because a lightweight check helped realize that no documents could possibly match on this shard. This typically happens when a search request includes a range filter and the shard only has values that fall outside of that range.
-   int32 skipped = 1;
+  // [optional] A list of indices to search for documents. If not provided, the default value will be to search through all indexes.
+  repeated string index = 1;
+  // [optional] Whether to include the _source field in the response.
+  SourceConfigParam source = 2;
+  // [optional] A list of source fields to exclude from the response. You can also use this parameter to exclude fields from the subset specified in `source_includes` query parameter. If the `source` parameter is `false`, this parameter is ignored.
+  repeated string source_excludes = 3;
+  // [optional] A list of source fields to include in the response. If this parameter is specified, only these source fields are returned. You can exclude fields from this subset using the `source_excludes` query parameter. If the `source` parameter is `false`, this parameter is ignored.
+  repeated string source_includes = 4;
+  // [optional] Whether to ignore wildcards that don't match any indexes. Default is true.
+  optional bool allow_no_indices = 5;
+  // [optional] Whether to return partial results if the request runs into an error or times out. Default is true.
+  optional bool allow_partial_search_results = 6;
+  // [optional] Whether the update operation should include wildcard and prefix queries in the analysis. Default is false.
+  optional bool analyze_wildcard = 7;
+  // [optional] Analyzer to use for the query string. This parameter can only be used when the q query string parameter is specified.
+  optional string analyzer = 8;
+  // [optional] How many shard results to reduce on a node. Default is 512.
+  optional int32 batched_reduce_size = 9;
+  // [optional] The time after which the search request will be canceled. Request-level parameter takes precedence over cancel_after_time_interval cluster setting. Default is -1.
+  optional string cancel_after_time_interval = 10;
+  // [optional] Whether to minimize round-trips between a node and remote clusters. Default is true.
+  optional bool ccs_minimize_roundtrips = 11;
+  // [optional] Indicates whether the default operator for a string query should be AND or OR. Default is OR.
+  optional Operator default_operator = 12;
+  enum Operator {
+    OPERATOR_UNSPECIFIED = 0;
+    // All terms need to match. The string `to be` is interpreted as `to AND be`
+    OPERATOR_AND = 1;
+    // Only one term needs to match. The string `to be` is interpreted as `to OR be`
+    OPERATOR_OR = 2;
+  }
+  // [optional] The default field in case a field prefix is not provided in the query string.
+  optional string df = 13;
+  // [optional] The fields that OpenSearch should return using their docvalue forms.
+  repeated string docvalue_fields = 14;
+  // [optional] Specifies the type of index that wildcard expressions can match. Supports list of values. Default is open.
+  repeated ExpandWildcard expand_wildcards = 15;
+  enum ExpandWildcard {
+    EXPAND_WILDCARD_UNSPECIFIED = 0;
+    // Match any index
+    EXPAND_WILDCARD_ALL = 1;
+    // Match closed, non-hidden indexes
+    EXPAND_WILDCARD_CLOSED = 2;
+    // Match hidden indexes
+    EXPAND_WILDCARD_HIDDEN = 3;
+    // Deny wildcard expressions
+    EXPAND_WILDCARD_NONE = 4;
+    // Match open, non-hidden indexes
+    EXPAND_WILDCARD_OPEN = 5;
+  }
+  // [optional] Whether to return details about how OpenSearch computed the document's score. Default is false.
+  optional bool explain = 16;
+  // [optional] The starting index to search from. Default is 0.
+  optional int32 from = 17;
+  // [optional] Whether to ignore concrete, expanded, or indexes with aliases if indexes are frozen. Default is true.
+  optional bool ignore_throttled = 18;
+  // [optional] Specifies whether to include missing or closed indexes in the response and ignores unavailable shards during the search request. Default is false.
+  optional bool ignore_unavailable = 19;
+  // [optional] Whether to return scores with named queries. Default is false.
+  optional bool include_named_queries_score = 20;
+  // [optional] Specifies whether OpenSearch should accept requests if queries have format errors (for example, querying a text field for an integer). Default is false.
+  optional bool lenient = 21;
+  // [optional] Numbers of concurrent shard requests this request should execute on each node. Default is 5.
+  optional int32 max_concurrent_shard_requests = 22;
+  // [optional] Whether to return phase-level took time values in the response. Default is false.
+  optional bool phase_took = 23;
+  // [optional] A prefilter size threshold that triggers a prefilter operation if the request exceeds the threshold. Default is 128 shards.
+  optional int32 pre_filter_shard_size = 24;
+  // [optional] Specifies the shards or nodes on which OpenSearch should perform the search. For valid values see "https://opensearch.org/docs/latest/api-reference/search/#the-preference-query-parameter"
+  optional string preference = 25;
+  // [optional] Query in the Lucene query string syntax using query parameter search.
+  optional string q = 26;
+  // [optional] Specifies whether OpenSearch should use the request cache. Default is whether it's enabled in the index's settings.
+  optional bool request_cache = 27;
+  // [optional] Indicates whether to return hits.total as an integer. Returns an object otherwise. Default is false.
+  // TODO should we rename this field to remove "rest"?
+  optional bool rest_total_hits_as_int = 28;
+  // [optional] Value used to route the update by query operation to a specific shard.
+  repeated string routing = 29;
+  // [optional] Period to keep the search context open.
+  optional string scroll = 30;
+  // [optional] Customizable sequence of processing stages applied to search queries.
+  optional string search_pipeline = 31;
+  // [optional] Whether OpenSearch should use global term and document frequencies when calculating relevance scores. Default is SEARCH_TYPE_QUERY_THEN_FETCH.
+  // TODO remove these fields from spec?
+  // do not allow 'query_and_fetch' or 'dfs_query_and_fetch' search types
+  // from the REST layer. these modes are an internal optimization and should
+  // not be specified explicitly by the user.
+
+  optional SearchType search_type = 32;
+  enum SearchType {
+    SEARCH_TYPE_UNSPECIFIED = 0;
+    // Scores documents using global term and document frequencies across all shards. It's usually slower but more accurate.
+    SEARCH_TYPE_DFS_QUERY_THEN_FETCH = 1;
+    // Scores documents using local term and document frequencies for the shard. It's usually faster but less accurate.
+    SEARCH_TYPE_QUERY_THEN_FETCH = 2;
+  }
+  // [optional] Whether to return sequence number and primary term of the last operation of each document hit.
+  optional bool seq_no_primary_term = 33;
+  // [optional] Number of results to include in the response.
+  optional int32 size = 34;
+  // [optional] A list of <field> : <direction> pairs to sort by.
+  // TODO use this improvement instead?
+  message SortOrder {
+    // [required]
+    string field = 1;
+    // [optional]
+    optional Direction direction = 2;
+
+    enum Direction {
+      DIRECTION_UNSPECIFIED = 0;
+      DIRECTION_ASC = 1;
+      DIRECTION_DESC = 2;
+    }
+  }
+  repeated SortOrder sort = 35;
+
+  //  repeated string sort = 35;
+  // [optional] Value to associate with the request for additional logging.
+  repeated string stats = 36;
+  // [optional] Whether the get operation should retrieve fields stored in the index. Default is false.
+  repeated string stored_fields = 37;
+  // [optional] Fields OpenSearch can use to look for similar terms.
+  optional string suggest_field = 38;
+  // [optional] The mode to use when searching. This parameter can only be used when the `suggest_field` and `suggest_text` query string parameters are specified.
+  optional SuggestMode suggest_mode = 39;
+  enum SuggestMode {
+    SUGGEST_MODE_UNSPECIFIED = 0;
+    // Use suggestions based on the provided terms
+    SUGGEST_MODE_ALWAYS = 1;
+    // Use suggestions for terms not in the index
+    SUGGEST_MODE_MISSING = 2;
+    // Use suggestions that have more occurrences
+    SUGGEST_MODE_POPULAR = 3;
+  }
+  // [optional] Number of suggestions to return.
+  optional int32 suggest_size = 40;
+  // [optional] The source that suggestions should be based off of.
+  optional string suggest_text = 41;
+  // [optional] The maximum number of documents OpenSearch should process before terminating the request. Default is 0.
+  optional int32 terminate_after = 42;
+  // [optional] Period of time to wait for a response from active shards. Default is 1m.
+  optional string timeout = 43;
+  // [optional] Whether to return document scores. Default is false.
+  optional bool track_scores = 44;
+  // [optional] Whether to return how many documents matched the query.
+  optional TrackHits track_total_hits = 45;
+  // [optional] Whether returned aggregations and suggested terms should include their types in the response. Default is true.
+  optional bool typed_keys = 46;
+  // [optional] Whether to include the document version as a match. Default is false
+  optional bool version = 47;
+  // [optional] Search Request body
+  SearchRequestBody request_body = 48;
+}
+
+message SearchRequestBody {
+  // [optional] In the optional aggs parameter, you can define any number of aggregations. Each aggregation is defined by its name and one of the types of aggregations that OpenSearch supports.
+  // TODO not supported yet
+  // map<string, AggregationContainer> aggregations = 1;
+
+  // [optional] The collapse parameter groups search results by a particular field value. This returns only the top document within each group, which helps reduce redundancy by eliminating duplicates.
+  optional FieldCollapse collapse = 2;
+
+  // [optional] Whether to return details about how OpenSearch computed the document's score. Default is false.
+  optional bool explain = 3;
+
+  // [optional] ext object is to contain plugin-specific response fields. For example, in conversational search, the result of Retrieval Augmented Generation (RAG) is a single “hit” (answer). Plugin authors can include this answer in the search response as part of the ext object so that it is separate from the search hits.
+  ObjectMap ext = 4;
+
+  // [optional] The starting index to search from. Default is 0.
+  optional int32 from = 5;
+
+  // [optional] Highlighting emphasizes the search term(s) in the results so you can emphasize the query matches.
+  optional Highlight highlight = 6;
+
+  // [optional] Whether to return how many documents matched the query.
+  optional TrackHits track_total_hits = 7;
+
+  // [optional] Values used to boost the score of specified indexes. Specify in the format of <index> : <boost-multiplier>
+  repeated NumberMap indices_boost = 8;
+
+  // [optional] The fields that OpenSearch should return using their docvalue forms. Specify a format to return results in a certain format, such as date and time.
+  repeated FieldAndFormat docvalue_fields = 9;
+
+  // TODO not supported yet
+  // RankContainer rank = 10;
+
+  // [optional] Specify a score threshold to return only documents above the threshold.
+  optional float min_score = 11;
+
+  // [optional] Use post_filter to refine search hits based on user selections while preserving all aggregation options.
+  optional QueryContainer post_filter = 12;
+
+  // [optional] Profile provides timing information about the execution of individual components of a search request. Using the Profile API, you can debug slow requests and understand how to improve their performance.
+  optional bool profile = 13;
+
+  // [optional] The DSL query to use in the request.
+  optional QueryContainer query = 14;
+
+  // [optional] Can be used to improve precision by reordering just the top (for example 100 - 500) documents returned by the `query` and `post_filter` phases.
+  // TODO not supported yet
+  // repeated Rescore rescore = 15;
+
+  // [optional] The script_fields parameter allows you to include custom fields whose values are computed using scripts in your search results. This can be useful for calculating values dynamically based on the document data. You can also retrieve derived fields by using a similar approach.
+  map<string, ScriptField> script_fields = 16;
+
+  // [optional] The search_after parameter provides a live cursor that uses the previous page's results to obtain the next page's results. It is similar to the scroll operation in that it is meant to scroll many queries in parallel. You can use search_after only when sorting is applied.
+  repeated FieldValue search_after = 17;
+
+  // [optional] The number of results to return. Default is 10.
+  optional int32 size = 18;
+
+  // [optional] You can use the scroll operation to retrieve a large number of results. For example, for machine learning jobs, you can request an unlimited number of results in batches.
+  // TODO not supported yet
+  // optional SlicedScroll slice = 19;
+
+  // [optional] Sorting allows your users to sort results in a way that's most meaningful to them. By default, full-text queries sort results by the relevance score. You can choose to sort the results by any field value in either ascending or descending order by setting the order parameter to asc or desc.
+  repeated SortCombinations sort = 20;
+
+  // [optional] Whether to include the _source field in the response.
+  optional SourceConfig source = 21;
+
+  // [optional] The fields to search for in the request. Specify a format to return results in a certain format, such as date and time.
+  repeated FieldAndFormat fields = 22;
+
+  // [optional] The suggest feature suggests similar looking terms based on a provided text by using a suggester. The suggest request part is defined alongside the query part in a _search request. If the query part is left out, only suggestions are returned.
+  // TODO not supported yet
+  // optional Suggester suggest = 23;
+
+  // [optional] The maximum number of documents OpenSearch should process before terminating the request. If a query reaches this limit, OpenSearch terminates the query early. OpenSearch collects documents before sorting. Use with caution. OpenSearch applies this parameter to each shard handling the request. When possible, let OpenSearch perform early termination automatically. Avoid specifying this parameter for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early. Default is 0.
+  optional int32 terminate_after = 24;
+
+  // [optional] The period of time to wait for a response. Default is no timeout. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.
+  optional string timeout = 25;
+
+  // [optional] Whether to return document scores. Default is false.
+  optional bool track_scores = 26;
+
+  // [optional] Whether to include the document version in the response.
+  optional bool version = 27;
+
+  // [optional] Whether to return sequence number and primary term of the last operation of each document hit.
+  optional bool seq_no_primary_term = 28;
+
+  // [optional] A list of stored fields to return as part of a hit. If no fields are specified, no stored fields are included in the response. If this option is specified, the _source parameter defaults to false. You can pass _source: true to return both source fields and stored fields in the search response.
+  repeated string stored_fields = 29;
+
+  // [optional] Point in Time (PIT) lets you run different queries against a dataset that is fixed in time.
+  optional PointInTimeReference pit = 30;
+
+  // [optional] Value to associate with the request for additional logging.
+  repeated string stats = 31;
+
+  // [optional] Defines the aggregations that are run as part of the search request.
+  // TODO not supported yet
+  // map<string, AggregationContainer> aggs = 32;
+
+}
+
+message TrackHits {
+  oneof track_hits{
+    bool bool_value = 1;
+    int32 int32_value = 2;
+  }
+}
+
+// The response from search request.
+message SearchResponse {
+  oneof response {
+    // The search success response
+    ResponseBody response_body = 1;
+    // The search 4xx error response
+    Error4xxResponseBody error_4xx_response = 2;
+    // The search 5xx error response
+    Error5xxResponse error_5xx_response = 3;
+  }
+}
+
+
+
+// The 4xx error response from search/index-search request.
+message Error4xxResponseBody {
+  // [optional] The search 4xx error response body.
+  Error error = 1;
+  // [optional] The search 4xx error response status code.
+  optional int32 status = 2;
+}
+
+// The 5xx error response from search/index-search request.
+message Error5xxResponse {
+  // [optional] The search 5xx error response status code.
+  optional int32 status_code = 1;
+  // [optional] The search 5xx error content.
+  optional string error = 2;
+  // [optional] The search 5xx error message.
+  optional string message = 3;
+  // [optional] The search 5xx error additional_details.
+  .google.protobuf.Struct additional_details = 4;
+}
+//
+//// The response body from a search/index-search request.
+message ResponseBody {
+
+  // [required] Milliseconds it took Elasticsearch to execute the request.
+  optional int64 took = 1;
+
+  // [required]  If true, the request timed out before completion; returned results may be partial or empty.
+  optional bool timed_out = 2;
+
+  // [required] Contains a count of shards used for the request.
+  ShardStatistics shards = 3;
+
+  // [optional] Phase-level took time values in the response.
+  optional PhaseTook phase_took = 4;
+
+  // [required] Contains returned documents and metadata.
+  HitsMetadata hits = 5;
+
+  // [optional] When you search one or more remote clusters, a `_clusters` section is included to provide information about the search on each cluster.
+  optional ClusterStatistics clusters = 6;
+
+  // [optional] Retrieved specific fields in the search response
+  optional .google.protobuf.Struct fields = 7;
+
+  // [optional] Highest returned document _score.
+  optional float max_score = 8; // TODO where is this used? remove?
+
+  // [optional] The number of times that the coordinating node aggregates results from batches of shard responses
+  optional int32 num_reduce_phases = 9;
+
+  // [optional] Contains profiling information.
+  Profile profile = 10;
+
+  // [optional] The PIT ID.
+  optional string pit_id = 11;
+
+  // [optional] Identifier for the search and its search context.
+  optional string scroll_id = 12;
+
+  // [optional] If the query was terminated early, the terminated_early flag will be set to true in the response
+  optional bool terminated_early = 13;
+
+}
+
+message PhaseTook {
+
+  // [required] Time taken in dfs_pre_query phase.
+  int64 dfs_pre_query = 1;
+  // [required] Time taken in query phase.
+  int64 query = 2;
+  // [required] Time taken in fetch phase.
+  int64 fetch = 3;
+  // [required] Time taken in dfs_query phase.
+  int64 dfs_query = 4;
+  // [required] Time taken in expand phase.
+  int64 expand = 5;
+  // [required] Time taken in can_match phase.
+  int64 can_match = 6;
+
+}
+
+message HitsMetadata {
+  message Total {
+    oneof total{
+      TotalHits total_hits = 1;
+      double double_value = 2;
+    }
+  }
+  // [optional] Metadata about the number of matching documents.
+  Total total = 1;
+
+  // [required] Array of returned document objects.
+  repeated Hit hits = 2;
+
+  message MaxScore{
+    oneof max_score{
+      float float_value = 1;
+      string string_value = 2;
+      NullValue null_value = 3;
+    }
+  }
+
+  // [optional] Highest returned document _score.
+  MaxScore max_score = 3;
+
+}
+
+message TotalHits {
+
+  // [required] Indicates whether the number of matching documents in the value parameter is accurate or a lower bound.
+  TotalHitsRelation relation = 1;
+  enum TotalHitsRelation {
+    TOTAL_HITS_RELATION_UNSPECIFIED = 0;
+    // Accurate
+    TOTAL_HITS_RELATION_EQ = 1;
+    // Lower bound
+    TOTAL_HITS_RELATION_GTE = 2;
+  }
+  // [required] Total number of matching documents.
+  int64 value = 2;
+
+}
+
+message InnerHitsResult {
+
+  // [required] An additional nested hits value.
+  HitsMetadata hits = 1;
+
+}
+
+message Hit {
+
+  optional string type = 1;
+
+  // [required] Name of the index containing the returned document.
+  string index = 2;
+  // [required] Unique identifier for the returned document. This ID is only unique within the returned index.
+  string id = 3;
+
+  message Score {
+    oneof score{
+      float float_value = 1;
+      string string_value = 2;
+      NullValue null_value = 3;
+    }
+  }
+
+  // [optional] Relevance of the returned document.
+  optional Score score = 4;
+
+  // [optional] Explanation of how the relevance score (_score) is calculated for every result.
+  optional Explanation explanation = 5;
+
+  // [optional] Contains field values for the documents.
+  optional .google.protobuf.Struct fields = 6;
+
+  // [optional] An additional highlight element for each search hit that includes the highlighted fields and the highlighted fragments.
+  map<string, StringArray> highlight = 7;
+
+  // [optional] An additional nested hits that caused a search hit to match in a different scope.
+  map<string, InnerHitsResult> inner_hits = 8;
+
+  // [optional] List of matched query names used in the search request.
+  repeated string matched_queries = 9;
+
+  // [optional] Defines from what inner nested object this inner hit came from
+  optional NestedIdentity nested = 10;
+
+  // [optional] List of fields ignored.
+  repeated string ignored = 11;
+
+  // [optional] These values are retrieved from the document’s original JSON source and are raw so will not be formatted or treated in any way, unlike the successfully indexed fields which are returned in the fields section.
+  map<string, StringArray> ignored_field_values = 12;
+
+  // [optional] Shard from which this document was retrieved.
+  optional string shard = 13;
+
+  // [optional] Node from which this document was retrieved.
+  optional string node = 14;
+
+  optional string routing = 15;
+
+  // [optional] Source document.
+  optional bytes source = 16;
+
+  // [optional] Counts the number of operations that happened on the index
+  optional int64 seq_no = 17;
 
-   // [required] Number of shards that executed the request successfully.
-   int32 successful = 2;
+  // [optional] Counts the number of shard has changed.
+  optional int64 primary_term = 18;
 
-   // [required] Total number of shards that require querying, including unallocated shards.
-   int32 total = 3;
+  // [optional] Version number of the document.
+  optional int64 version = 19;
 
+  // [optional] Sorted values
+  repeated FieldValueResponse sort = 20;
+}
 
-   // TODO these fields dont exist in SearchResponse.Clusters class
-   // [required] Number of shards currently executing the search operation
- //  int32 running = 4;
- //
- //  // [required] The number of shards that returned partial results.
- //  int32 partial = 5;
- //
- //  // [required] Number of shards that failed to execute the request. Note that shards that are not allocated will be considered neither successful nor failed. Having failed+successful less than total is thus an indication that some of the shards were not allocated.
- //  int32 failed = 6;
- //
- //  // [optional] Shows metadata about the search on each cluster.
- //  map<string, ClusterDetails> details = 7;
+message ClusterStatistics {
 
- }
+  // [required] Number of shards that skipped the request because a lightweight check helped realize that no documents could possibly match on this shard. This typically happens when a search request includes a range filter and the shard only has values that fall outside of that range.
+  int32 skipped = 1;
 
- message ClusterDetails {
+  // [required] Number of shards that executed the request successfully.
+  int32 successful = 2;
 
-   enum ClusterSearchStatus {
-     CLUSTER_SEARCH_STATUS_UNSPECIFIED = 0;
-     // The search failed on a cluster marked with skip_unavailable=false
-     CLUSTER_SEARCH_STATUS_FAILED = 1;
-     // Searches on at least one shard of the cluster was successful and at least one failed
-     CLUSTER_SEARCH_STATUS_PARTIAL = 2;
-     // Searches on all shards were successful
-     CLUSTER_SEARCH_STATUS_RUNNING = 3;
-     // The search failed on a cluster marked with skip_unavailable=true
-     CLUSTER_SEARCH_STATUS_SKIPPED = 4;
-     // Searches on all shards were successful
-     CLUSTER_SEARCH_STATUS_SUCCESSFUL = 5;
-   }
-   // [required] All possible cluster search states.
-   ClusterSearchStatus status = 1;
+  // [required] Total number of shards that require querying, including unallocated shards.
+  int32 total = 3;
 
-   // [required] The index expression supplied by the user. If you provide a wildcard such as logs-*, this section will show the value with the wildcard, not the concrete indices being searched.
-   string indices = 2;
 
-   // [optional] How long (in milliseconds) the sub-search took on that cluster.
-   optional int64 took = 3;
+  // TODO these fields dont exist in SearchResponse.Clusters class
+  // [required] Number of shards currently executing the search operation
+//  int32 running = 4;
+//
+//  // [required] The number of shards that returned partial results.
+//  int32 partial = 5;
+//
+//  // [required] Number of shards that failed to execute the request. Note that shards that are not allocated will be considered neither successful nor failed. Having failed+successful less than total is thus an indication that some of the shards were not allocated.
+//  int32 failed = 6;
+//
+//  // [optional] Shows metadata about the search on each cluster.
+//  map<string, ClusterDetails> details = 7;
 
-   // [required] If true, the request timed out before completion; returned results may be partial or empty.
-   bool timed_out = 4;
+}
 
-   // [optional] The shard details for the sub-search on that cluster.
-   optional ShardStatistics shards = 5;
+message ClusterDetails {
 
-   // [optional] An array of any shard-specific failures that occurred during the search operation
-   repeated ShardSearchFailure failures = 6;
+  enum ClusterSearchStatus {
+    CLUSTER_SEARCH_STATUS_UNSPECIFIED = 0;
+    // The search failed on a cluster marked with skip_unavailable=false
+    CLUSTER_SEARCH_STATUS_FAILED = 1;
+    // Searches on at least one shard of the cluster was successful and at least one failed
+    CLUSTER_SEARCH_STATUS_PARTIAL = 2;
+    // Searches on all shards were successful
+    CLUSTER_SEARCH_STATUS_RUNNING = 3;
+    // The search failed on a cluster marked with skip_unavailable=true
+    CLUSTER_SEARCH_STATUS_SKIPPED = 4;
+    // Searches on all shards were successful
+    CLUSTER_SEARCH_STATUS_SUCCESSFUL = 5;
+  }
+  // [required] All possible cluster search states.
+  ClusterSearchStatus status = 1;
 
- }
+  // [required] The index expression supplied by the user. If you provide a wildcard such as logs-*, this section will show the value with the wildcard, not the concrete indices being searched.
+  string indices = 2;
 
- message Profile {
+  // [optional] How long (in milliseconds) the sub-search took on that cluster.
+  optional int64 took = 3;
 
-   // [required] A search request can be executed against one or more shards in the index, and a search may involve one or more indexes. Thus, the profile.shards array contains profiling information for each shard that was involved in the search.
-   repeated ShardProfile shards = 1;
+  // [required] If true, the request timed out before completion; returned results may be partial or empty.
+  bool timed_out = 4;
 
- }
+  // [optional] The shard details for the sub-search on that cluster.
+  optional ShardStatistics shards = 5;
 
- message ShardProfile {
+  // [optional] An array of any shard-specific failures that occurred during the search operation
+  repeated ShardSearchFailure failures = 6;
 
-   // [required] Profiling information about the aggregation execution.
-   repeated AggregationProfile aggregations = 1;
+}
 
-   // [required] The shard ID of the shard in the [node-ID][index-name][shard-ID] format.
-   string id = 2;
+message Profile {
 
-   // [required] Search represents a query executed against the underlying Lucene index. Most search requests execute a single search against a Lucene index, but some search requests can execute more than one search. For example, including a global aggregation results in a secondary match_all query for the global context. The profile.shards array contains profiling information about each search execution.
-   repeated SearchProfile searches = 3;
+  // [required] A search request can be executed against one or more shards in the index, and a search may involve one or more indexes. Thus, the profile.shards array contains profiling information for each shard that was involved in the search.
+  repeated ShardProfile shards = 1;
 
-   // [optional] Fetch timing and debug information.
-   optional FetchProfile fetch = 4;
+}
 
- }
+message ShardProfile {
 
- message AggregationProfile {
+  // [required] Profiling information about the aggregation execution.
+  repeated AggregationProfile aggregations = 1;
 
-   optional AggregationBreakdown breakdown = 1;
+  // [required] The shard ID of the shard in the [node-ID][index-name][shard-ID] format.
+  string id = 2;
 
-   optional string description = 2;
+  // [required] Search represents a query executed against the underlying Lucene index. Most search requests execute a single search against a Lucene index, but some search requests can execute more than one search. For example, including a global aggregation results in a secondary match_all query for the global context. The profile.shards array contains profiling information about each search execution.
+  repeated SearchProfile searches = 3;
 
-   // Time unit for nanoseconds
-   optional int64 time_in_nanos = 3;
+  // [optional] Fetch timing and debug information.
+  optional FetchProfile fetch = 4;
 
-   optional string type = 4;
+}
 
-   optional AggregationProfileDebug debug = 5;
+message AggregationProfile {
 
-   repeated AggregationProfile children = 6;
+  optional AggregationBreakdown breakdown = 1;
 
- }
+  optional string description = 2;
 
- message AggregationBreakdown {
+  // Time unit for nanoseconds
+  optional int64 time_in_nanos = 3;
 
-   // [required] Contains the time spent running the aggregation’s buildAggregations() method, which builds the results of this aggregation. For concurrent segment search, the build_aggregation method contains the total elapsed time across all slices (the difference between the last completed slice execution end time and the first slice execution start time).
-   int64 build_aggregation = 1;
+  optional string type = 4;
 
-   // [required] Contains the number of invocations of a build_aggregation.
-   int64 build_aggregation_count = 2;
+  optional AggregationProfileDebug debug = 5;
 
-   // [required] Contains the time spent running the aggregation’s getLeafCollector() method, which creates a new collector to collect the given context. For concurrent segment search, the build_leaf_collector method contains the total elapsed time across all slices (the difference between the last completed slice execution end time and the first slice execution start time).
-   int64 build_leaf_collector = 3;
+  repeated AggregationProfile children = 6;
 
-   // [required] Contains the number of invocations of a build_leaf_collector.
-   int64 build_leaf_collector_count = 4;
+}
 
-   // [required] Contains the time spent collecting the documents into buckets. For concurrent segment search, the collect method contains the total elapsed time across all slices (the difference between the last completed slice execution end time and the first slice execution start time).
-   int64 collect = 5;
+message AggregationBreakdown {
 
-   // [required] Contains the number of invocations of a collect.
-   int64 collect_count = 6;
+  // [required] Contains the time spent running the aggregation’s buildAggregations() method, which builds the results of this aggregation. For concurrent segment search, the build_aggregation method contains the total elapsed time across all slices (the difference between the last completed slice execution end time and the first slice execution start time).
+  int64 build_aggregation = 1;
 
-   // [required] Contains the amount of time taken to execute the preCollection() callback method during AggregationCollectorManager creation. For concurrent segment search, the initialize method contains the total elapsed time across all slices (the difference between the last completed slice execution end time and the first slice execution start time).
-   int64 initialize = 7;
+  // [required] Contains the number of invocations of a build_aggregation.
+  int64 build_aggregation_count = 2;
 
-   // [required] Contains the number of invocations of a initialize.
-   int64 initialize_count = 8;
+  // [required] Contains the time spent running the aggregation’s getLeafCollector() method, which creates a new collector to collect the given context. For concurrent segment search, the build_leaf_collector method contains the total elapsed time across all slices (the difference between the last completed slice execution end time and the first slice execution start time).
+  int64 build_leaf_collector = 3;
 
-   // [optional] Contains the time spent running the aggregation’s postCollection() callback method. For concurrent segment search, the post_collection method contains the total elapsed time across all slices (the difference between the last completed slice execution end time and the first slice execution start time).
-   optional int64 post_collection = 9;
+  // [required] Contains the number of invocations of a build_leaf_collector.
+  int64 build_leaf_collector_count = 4;
 
-   // [optional] Contains the number of invocations of a post_collection.
-   optional int64 post_collection_count = 10;
+  // [required] Contains the time spent collecting the documents into buckets. For concurrent segment search, the collect method contains the total elapsed time across all slices (the difference between the last completed slice execution end time and the first slice execution start time).
+  int64 collect = 5;
 
-   // [required] Contains the time spent in the reduce phase. For concurrent segment search, the reduce method contains the total elapsed time across all slices (the difference between the last completed slice execution end time and the first slice execution start time).
-   int64 reduce = 11;
+  // [required] Contains the number of invocations of a collect.
+  int64 collect_count = 6;
 
-   // [required] Contains the number of invocations of a reduce.
-   int64 reduce_count = 12;
+  // [required] Contains the amount of time taken to execute the preCollection() callback method during AggregationCollectorManager creation. For concurrent segment search, the initialize method contains the total elapsed time across all slices (the difference between the last completed slice execution end time and the first slice execution start time).
+  int64 initialize = 7;
 
- }
+  // [required] Contains the number of invocations of a initialize.
+  int64 initialize_count = 8;
 
- message SearchProfile {
+  // [optional] Contains the time spent running the aggregation’s postCollection() callback method. For concurrent segment search, the post_collection method contains the total elapsed time across all slices (the difference between the last completed slice execution end time and the first slice execution start time).
+  optional int64 post_collection = 9;
 
-   // [required] Profiling information about the Lucene collectors that ran the search.
-   repeated Collector collector = 1;
+  // [optional] Contains the number of invocations of a post_collection.
+  optional int64 post_collection_count = 10;
 
-   // [required] Profiling information about the query execution.
-   repeated QueryProfile query = 2;
+  // [required] Contains the time spent in the reduce phase. For concurrent segment search, the reduce method contains the total elapsed time across all slices (the difference between the last completed slice execution end time and the first slice execution start time).
+  int64 reduce = 11;
 
-   // [required] All Lucene queries are rewritten. A query and its children may be rewritten more than once, until the query stops changing. The rewriting process involves performing optimizations, such as removing redundant clauses or replacing a query path with a more efficient one. After the rewriting process, the original query may change significantly. The rewrite_time field contains the cumulative total rewrite time for the query and all its children, in nanoseconds.
-   int64 rewrite_time = 3;
+  // [required] Contains the number of invocations of a reduce.
+  int64 reduce_count = 12;
 
- }
+}
 
- message Collector {
+message SearchProfile {
 
-   // [required] The collector name.
-   string name = 1;
+  // [required] Profiling information about the Lucene collectors that ran the search.
+  repeated Collector collector = 1;
 
-   // [required] Contains a description of the collector.
-   string reason = 2;
+  // [required] Profiling information about the query execution.
+  repeated QueryProfile query = 2;
 
-   // [required] The total elapsed time for this collector, in nanoseconds. For concurrent segment search, time_in_nanos is the total amount of time across all slices (the difference between the last completed slice execution end time and the first slice execution start time).
-   int64 time_in_nanos = 3;
+  // [required] All Lucene queries are rewritten. A query and its children may be rewritten more than once, until the query stops changing. The rewriting process involves performing optimizations, such as removing redundant clauses or replacing a query path with a more efficient one. After the rewriting process, the original query may change significantly. The rewrite_time field contains the cumulative total rewrite time for the query and all its children, in nanoseconds.
+  int64 rewrite_time = 3;
 
-   // [optional] If a collector has subcollectors (children), this field contains information about the subcollectors.
-   repeated Collector children = 4;
+}
+ 
+message NumberMap {
+  map<string, float> number_map = 1;
+}
 
- }
 
- message QueryProfile {
+message PointInTimeReference {
+  // [required] ID for the PIT to search. If you provide a pit object, this parameter is required.
+  optional string id = 1;
 
-   // [required] Contains timing statistics about low-level Lucene execution.
-   QueryBreakdown breakdown = 1;
+  // [optional] Period of time used to extend the life of the PIT. Units can be `nanos`, `micros`, `ms` (milliseconds), `s` (seconds), `m` (minutes), `h` (hours) and `d` (days). Also accepts \"0\" without a unit and \"-1\" to indicate an unspecified value.
+  optional string keep_alive = 2;
 
-   // [required] Contains a Lucene explanation of the query. Helps differentiate queries with the same type.
-   string description = 2;
+}
 
-   // [required] The total elapsed time for this query, in nanoseconds. For concurrent segment search, time_in_nanos is the total time spent across all the slices (the difference between the last completed slice execution end time and the first slice execution start time).
-   int64 time_in_nanos = 3;
+message Collector {
 
-   // [required] The Lucene query type into which the search query was rewritten. Corresponds to the Lucene class name (which often has the same name in OpenSearch).
-   string type = 4;
+  // [required] The collector name.
+  string name = 1;
 
-   // [optional] If a query has subqueries (children), this field contains information about the subqueries.
-   repeated QueryProfile children = 5;
+  // [required] Contains a description of the collector.
+  string reason = 2;
 
- }
+  // [required] The total elapsed time for this collector, in nanoseconds. For concurrent segment search, time_in_nanos is the total amount of time across all slices (the difference between the last completed slice execution end time and the first slice execution start time).
+  int64 time_in_nanos = 3;
 
- message QueryBreakdown {
+  // [optional] If a collector has subcollectors (children), this field contains information about the subcollectors.
+  repeated Collector children = 4;
 
-   // [required] The advance method is a lower-level version of the next_doc method in Lucene. It also finds the next matching document but necessitates that the calling query perform additional tasks, such as identifying skips. Some queries, such as conjunctions (must clauses in Boolean queries), cannot use next_doc. For those queries, advance is timed.
-   int64 advance = 1;
-   // [required] Contains the number of invocations of the advance method. Different invocations of the same method occur because the method is called on different documents. You can determine the selectivity of a query by comparing counts in different query components.
-   int64 advance_count = 2;
-   // [required] A Scorer iterates over matching documents and generates a score for each document. The build_scorer field contains the amount of time spent generating the Scorer object. This does not include the time spent scoring the documents. The Scorer initialization time depends on the optimization and complexity of a particular query. The build_scorer parameter also includes the amount of time associated with caching, if caching is applicable and enabled for the query.
-   int64 build_scorer = 3;
-   // [required] Build_scorer_count contains the number of invocations of the build_scorer method. Different invocations of the same method occur because the method is called on different documents. You can determine the selectivity of a query by comparing counts in different query components.
-   int64 build_scorer_count = 4;
-   // [required] A Query object in Lucene is immutable. Yet, Lucene should be able to reuse Query objects in multiple IndexSearcher objects. Thus, Query objects need to keep temporary state and statistics associated with the index in which the query is executed. To achieve reuse, every Query object generates a Weight object, which keeps the temporary context (state) associated with the <IndexSearcher, Query> tuple. The create_weight field contains the amount of time spent creating the Weight object.
-   int64 create_weight = 5;
-   // [required] Create_weight_count contains the number of invocations of the create_weight method. Different invocations of the same method occur because the method is called on different documents. You can determine the selectivity of a query by comparing counts in different query components.
-   int64 create_weight_count = 6;
-   // [required] For some queries, document matching is performed in two steps. First, the document is matched approximately. Second, those documents that are approximately matched are examined through a more comprehensive process. For example, a phrase query first checks whether a document contains all terms in the phrase. Next, it verifies that the terms are in order (which is a more expensive process). The match field is non-zero only for those queries that use the two-step verification process.
-   int64 match = 7;
-   // [required] Match_count contains the number of invocations of the match method. Different invocations of the same method occur because the method is called on different documents. You can determine the selectivity of a query by comparing counts in different query components.
-   int64 match_count = 8;
-   // [required] Contains the amount of time required to execute the advanceShallow Lucene method.
-   int64 shallow_advance = 9;
-   // [required] Shallow_advance_count contains the number of invocations of the shallow_advance method. Different invocations of the same method occur because the method is called on different documents. You can determine the selectivity of a query by comparing counts in different query components.
-   int64 shallow_advance_count = 10;
-   // [required] The next_doc Lucene method returns the document ID of the next document that matches the query. This method is a special type of the advance method and is equivalent to advance(docId() + 1). The next_doc method is more convenient for many Lucene queries. The next_doc field contains the amount of time required to determine the next matching document, which varies depending on the query type.
-   int64 next_doc = 11;
-   // [required] Next_doc_count contains the number of invocations of the next_doc method. Different invocations of the same method occur because the method is called on different documents. You can determine the selectivity of a query by comparing counts in different query components.
-   int64 next_doc_count = 12;
-   // [required] Contains the time taken for a Scorer to score a particular document.
-   int64 score = 13;
-   // [required] Score_count contains the number of invocations of the score method. Different invocations of the same method occur because the method is called on different documents. You can determine the selectivity of a query by comparing counts in different query components.
-   int64 score_count = 14;
-   // [required] Contains the amount of time required to execute the getMaxScore Lucene method.
-   int64 compute_max_score = 15;
-   // [required] Compute_max_score_count contains the number of invocations of the compute_max_score method. Different invocations of the same method occur because the method is called on different documents. You can determine the selectivity of a query by comparing counts in different query components.
-   int64 compute_max_score_count = 16;
-   // [required] Contains the amount of time required to execute the setMinCompetitiveScore Lucene method.
-   int64 set_min_competitive_score = 17;
-   // [required] Set_min_competitive_score_count contains the number of invocations of the set_min_competitive_score method. Different invocations of the same method occur because the method is called on different documents. You can determine the selectivity of a query by comparing counts in different query components.
-   int64 set_min_competitive_score_count = 18;
+}
 
- }
+message QueryProfile {
 
- message FetchProfileDebug {
+  // [required] Contains timing statistics about low-level Lucene execution.
+  QueryBreakdown breakdown = 1;
 
-   repeated string stored_fields = 1;
+  // [required] Contains a Lucene explanation of the query. Helps differentiate queries with the same type.
+  string description = 2;
 
-   optional int32 fast_path = 2;
+  // [required] The total elapsed time for this query, in nanoseconds. For concurrent segment search, time_in_nanos is the total time spent across all the slices (the difference between the last completed slice execution end time and the first slice execution start time).
+  int64 time_in_nanos = 3;
 
- }
+  // [required] The Lucene query type into which the search query was rewritten. Corresponds to the Lucene class name (which often has the same name in OpenSearch).
+  string type = 4;
 
- message FetchProfile {
+  // [optional] If a query has subqueries (children), this field contains information about the subqueries.
+  repeated QueryProfile children = 5;
 
-   optional string type = 1;
+}
 
-   optional string description = 2;
+message QueryBreakdown {
 
-   // Time unit for nanoseconds
-   optional int64 time_in_nanos = 3;
+  // [required] The advance method is a lower-level version of the next_doc method in Lucene. It also finds the next matching document but necessitates that the calling query perform additional tasks, such as identifying skips. Some queries, such as conjunctions (must clauses in Boolean queries), cannot use next_doc. For those queries, advance is timed.
+  int64 advance = 1;
+  // [required] Contains the number of invocations of the advance method. Different invocations of the same method occur because the method is called on different documents. You can determine the selectivity of a query by comparing counts in different query components.
+  int64 advance_count = 2;
+  // [required] A Scorer iterates over matching documents and generates a score for each document. The build_scorer field contains the amount of time spent generating the Scorer object. This does not include the time spent scoring the documents. The Scorer initialization time depends on the optimization and complexity of a particular query. The build_scorer parameter also includes the amount of time associated with caching, if caching is applicable and enabled for the query.
+  int64 build_scorer = 3;
+  // [required] Build_scorer_count contains the number of invocations of the build_scorer method. Different invocations of the same method occur because the method is called on different documents. You can determine the selectivity of a query by comparing counts in different query components.
+  int64 build_scorer_count = 4;
+  // [required] A Query object in Lucene is immutable. Yet, Lucene should be able to reuse Query objects in multiple IndexSearcher objects. Thus, Query objects need to keep temporary state and statistics associated with the index in which the query is executed. To achieve reuse, every Query object generates a Weight object, which keeps the temporary context (state) associated with the <IndexSearcher, Query> tuple. The create_weight field contains the amount of time spent creating the Weight object.
+  int64 create_weight = 5;
+  // [required] Create_weight_count contains the number of invocations of the create_weight method. Different invocations of the same method occur because the method is called on different documents. You can determine the selectivity of a query by comparing counts in different query components.
+  int64 create_weight_count = 6;
+  // [required] For some queries, document matching is performed in two steps. First, the document is matched approximately. Second, those documents that are approximately matched are examined through a more comprehensive process. For example, a phrase query first checks whether a document contains all terms in the phrase. Next, it verifies that the terms are in order (which is a more expensive process). The match field is non-zero only for those queries that use the two-step verification process.
+  int64 match = 7;
+  // [required] Match_count contains the number of invocations of the match method. Different invocations of the same method occur because the method is called on different documents. You can determine the selectivity of a query by comparing counts in different query components.
+  int64 match_count = 8;
+  // [required] Contains the amount of time required to execute the advanceShallow Lucene method.
+  int64 shallow_advance = 9;
+  // [required] Shallow_advance_count contains the number of invocations of the shallow_advance method. Different invocations of the same method occur because the method is called on different documents. You can determine the selectivity of a query by comparing counts in different query components.
+  int64 shallow_advance_count = 10;
+  // [required] The next_doc Lucene method returns the document ID of the next document that matches the query. This method is a special type of the advance method and is equivalent to advance(docId() + 1). The next_doc method is more convenient for many Lucene queries. The next_doc field contains the amount of time required to determine the next matching document, which varies depending on the query type.
+  int64 next_doc = 11;
+  // [required] Next_doc_count contains the number of invocations of the next_doc method. Different invocations of the same method occur because the method is called on different documents. You can determine the selectivity of a query by comparing counts in different query components.
+  int64 next_doc_count = 12;
+  // [required] Contains the time taken for a Scorer to score a particular document.
+  int64 score = 13;
+  // [required] Score_count contains the number of invocations of the score method. Different invocations of the same method occur because the method is called on different documents. You can determine the selectivity of a query by comparing counts in different query components.
+  int64 score_count = 14;
+  // [required] Contains the amount of time required to execute the getMaxScore Lucene method.
+  int64 compute_max_score = 15;
+  // [required] Compute_max_score_count contains the number of invocations of the compute_max_score method. Different invocations of the same method occur because the method is called on different documents. You can determine the selectivity of a query by comparing counts in different query components.
+  int64 compute_max_score_count = 16;
+  // [required] Contains the amount of time required to execute the setMinCompetitiveScore Lucene method.
+  int64 set_min_competitive_score = 17;
+  // [required] Set_min_competitive_score_count contains the number of invocations of the set_min_competitive_score method. Different invocations of the same method occur because the method is called on different documents. You can determine the selectivity of a query by comparing counts in different query components.
+  int64 set_min_competitive_score_count = 18;
 
-   optional FetchProfileBreakdown breakdown = 4;
+}
 
-   optional FetchProfileDebug debug = 5;
+message FetchProfileDebug {
 
-   repeated FetchProfile children = 6;
+  repeated string stored_fields = 1;
 
- }
+  optional int32 fast_path = 2;
 
+}
 
- message FetchProfileBreakdown {
+message FetchProfile {
 
-   optional int32 load_stored_fields = 1;
+  optional string type = 1;
 
-   optional int32 load_stored_fields_count = 2;
+  optional string description = 2;
 
-   optional int32 next_reader = 3;
+  // Time unit for nanoseconds
+  optional int64 time_in_nanos = 3;
 
-   optional int32 next_reader_count = 4;
+  optional FetchProfileBreakdown breakdown = 4;
 
-   optional int32 process_count = 5;
+  optional FetchProfileDebug debug = 5;
 
-   optional int32 process = 6;
+  repeated FetchProfile children = 6;
 
- }
+}
 
- message AggregationProfileDebug {
 
-   optional int32 segments_with_multi_valued_ords = 1;
+message FetchProfileBreakdown {
 
-   optional string collection_strategy = 2;
+  optional int32 load_stored_fields = 1;
 
-   optional int32 segments_with_single_valued_ords = 3;
+  optional int32 load_stored_fields_count = 2;
 
-   optional int32 total_buckets = 4;
+  optional int32 next_reader = 3;
 
-   optional int32 built_buckets = 5;
+  optional int32 next_reader_count = 4;
 
-   optional string result_strategy = 6;
+  optional int32 process_count = 5;
 
-   optional bool has_filter = 7;
+  optional int32 process = 6;
 
-   optional string delegate = 8;
+}
 
-   optional AggregationProfileDebug delegate_debug = 9;
+message AggregationProfileDebug {
 
-   optional int32 chars_fetched = 10;
+  optional int32 segments_with_multi_valued_ords = 1;
 
-   optional int32 extract_count = 11;
+  optional string collection_strategy = 2;
 
-   optional int32 extract_ns = 12;
+  optional int32 segments_with_single_valued_ords = 3;
 
-   optional int32 values_fetched = 13;
+  optional int32 total_buckets = 4;
 
-   optional int32 collect_analyzed_ns = 14;
+  optional int32 built_buckets = 5;
 
-   optional int32 collect_analyzed_count = 15;
+  optional string result_strategy = 6;
 
-   optional int32 surviving_buckets = 16;
+  optional bool has_filter = 7;
 
-   optional int32 ordinals_collectors_used = 17;
+  optional string delegate = 8;
 
-   optional int32 ordinals_collectors_overhead_too_high = 18;
+  optional AggregationProfileDebug delegate_debug = 9;
 
-   optional int32 string_hashing_collectors_used = 19;
+  optional int32 chars_fetched = 10;
 
-   optional int32 numeric_collectors_used = 20;
+  optional int32 extract_count = 11;
 
-   optional int32 empty_collectors_used = 21;
+  optional int32 extract_ns = 12;
 
-   repeated string deferred_aggregators = 22;
+  optional int32 values_fetched = 13;
 
-   optional int32 segments_with_doc_count_field = 23;
+  optional int32 collect_analyzed_ns = 14;
 
-   optional int32 segments_with_deleted_docs = 24;
+  optional int32 collect_analyzed_count = 15;
 
-   repeated AggregationProfileDelegateDebugFilter filters = 25;
+  optional int32 surviving_buckets = 16;
 
-   optional int32 segments_counted = 26;
+  optional int32 ordinals_collectors_used = 17;
 
-   optional int32 segments_collected = 27;
+  optional int32 ordinals_collectors_overhead_too_high = 18;
 
-   optional string map_reducer = 28;
+  optional int32 string_hashing_collectors_used = 19;
 
- }
+  optional int32 numeric_collectors_used = 20;
 
- message AggregationProfileDelegateDebugFilter {
+  optional int32 empty_collectors_used = 21;
 
-   optional int32 results_from_metadata = 1;
+  repeated string deferred_aggregators = 22;
 
-   optional string query = 2;
+  optional int32 segments_with_doc_count_field = 23;
 
-   optional string specialized_for = 3;
+  optional int32 segments_with_deleted_docs = 24;
 
-   optional int32 segments_counted_in_constant_time = 4;
+  repeated AggregationProfileDelegateDebugFilter filters = 25;
 
- }
+  optional int32 segments_counted = 26;
 
- message Explanation {
+  optional int32 segments_collected = 27;
 
-   // [required] Explains what type of calculation is performed
-   string description = 1;
-   // [optional] Shows any subcalculations performed.
-   repeated ExplanationDetail details = 2;
-   // [required] Shows the result of the calculation,
-   double value = 3;
+  optional string map_reducer = 28;
 
- }
+}
 
- message ExplanationDetail {
+message AggregationProfileDelegateDebugFilter {
 
-   // [required] Explains what type of calculation is performed
-   string description = 1;
+  optional int32 results_from_metadata = 1;
 
-   // [required] Shows any subcalculations performed.
-   repeated ExplanationDetail details = 2;
+  optional string query = 2;
 
-   // [required] Shows the result of the calculation,
-   double value = 3;
+  optional string specialized_for = 3;
 
- }
+  optional int32 segments_counted_in_constant_time = 4;
 
- message NestedIdentity {
+}
 
-   // [required] The name of the nested field.
-   string field = 1;
+message Explanation {
 
-   // [required] Indicates the position or index of the nested document.
-   int32 offset = 2;
+  // [required] Explains what type of calculation is performed
+  string description = 1;
+  // [optional] Shows any subcalculations performed.
+  repeated ExplanationDetail details = 2;
+  // [required] Shows the result of the calculation,
+  double value = 3;
 
-   // [optional] Inner nested object.
-   optional NestedIdentity nested = 3;
+}
 
- }
+message ExplanationDetail {
+
+  // [required] Explains what type of calculation is performed
+  string description = 1;
+
+  // [required] Shows any subcalculations performed.
+  repeated ExplanationDetail details = 2;
+
+  // [required] Shows the result of the calculation,
+  double value = 3;
+
+}
+
+message NestedIdentity {
+
+  // [required] The name of the nested field.
+  string field = 1;
+
+  // [required] Indicates the position or index of the nested document.
+  int32 offset = 2;
+
+  // [optional] Inner nested object.
+  optional NestedIdentity nested = 3;
+
+}

--- a/protos/schemas/search.proto
+++ b/protos/schemas/search.proto
@@ -165,10 +165,12 @@ message SearchRequest {
   optional TrackHits track_total_hits = 45;
   // [optional] Whether returned aggregations and suggested terms should include their types in the response. Default is true.
   optional bool typed_keys = 46;
+  // [optional] Enables or disables verbose mode for the search pipeline.
+  optional bool verbose_pipeline = 47;
   // [optional] Whether to include the document version as a match. Default is false
-  optional bool version = 47;
+  optional bool version = 48;
   // [optional] Search Request body
-  SearchRequestBody request_body = 48;
+  SearchRequestBody request_body = 49;
 }
 
 message SearchRequestBody {


### PR DESCRIPTION
### Description
Update search protos 

1. SearchRequestBody was missing many fields
2. SearchResponse was missing ErrorResponses 
3. Remove extra space in front of improperly indented fields 


The git diff is a bit mismatched due to the indentation changes.  Selecting "Hide whitespace" will make this easier to review. 
<img width="240" alt="Screenshot 2025-04-01 at 10 57 18 PM" src="https://github.com/user-attachments/assets/a7b794cf-c927-4a35-9b73-c9b472c6e4f7" />


### Issues Resolved
#30 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
