### PR TITLE
Add missing jar build step before release publish

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -38,6 +38,7 @@ jobs:
           cache: gradle
       - name: Build with Gradle
         run: |
+          ./tools/java/package_proto_jar.sh -c true -s false
           ./gradlew --no-daemon -Dbuild.snapshot=false publishCreatePublicationToLocalRepoRepository && tar -C build -cvf artifacts.tar.gz repository
       - name: Draft a release
         uses: softprops/action-gh-release@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fix ErrorCause and InlineGetDictUserDefined protos ([#29](https://github.com/opensearch-project/opensearch-protobufs/pull/29))
 - Add missing 'header' field to ErrorCause and fix type of 'metadata' field ([#33](https://github.com/opensearch-project/opensearch-protobufs/pull/33))
 - Fix 'Value' fields ([#38](https://github.com/opensearch-project/opensearch-protobufs/pull/38))
+- Add missing jar build step before release publish ([#47](https://github.com/opensearch-project/opensearch-protobufs/pull/47))
 
 ### Security
 - Resolve CVE-2023-36665 protobufjs ([#32](https://github.com/opensearch-project/opensearch-protobufs/pull/32))


### PR DESCRIPTION
### Description
Add missing jar build step before release publish

### Issues Resolved
https://github.com/opensearch-project/opensearch-protobufs/actions/runs/14228543546

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
