### PR TITLE
Generate javadoc jar and sources jar for Maven Central publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add release drafter action and jenkins workflow in preparation for 0.1.0 maven release ([#43](https://github.com/opensearch-project/opensearch-protobufs/pull/43))
 - Document steps to cut a release ([#44](https://github.com/opensearch-project/opensearch-protobufs/pull/44))
 - Add missing SearchRequestBody and ErrorResponse fields ([#45](https://github.com/opensearch-project/opensearch-protobufs/pull/45))
-- Generate javadocs jar and sources jar  ([#4](https://github.com/opensearch-project/opensearch-protobufs/pull/48))
+- Generate javadoc jar and sources jar ([#49](https://github.com/opensearch-project/opensearch-protobufs/pull/49))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add release drafter action and jenkins workflow in preparation for 0.1.0 maven release ([#43](https://github.com/opensearch-project/opensearch-protobufs/pull/43))
 - Document steps to cut a release ([#44](https://github.com/opensearch-project/opensearch-protobufs/pull/44))
 - Add missing SearchRequestBody and ErrorResponse fields ([#45](https://github.com/opensearch-project/opensearch-protobufs/pull/45))
+- Generate javadocs jar and sources jar  ([#4](https://github.com/opensearch-project/opensearch-protobufs/pull/48))
 
 ### Removed
 


### PR DESCRIPTION
### Description
Generate a javadoc and sources jar, to provide a complete Maven-compatible artifact set that includes the compiled classes, source code, and documentation.

Address this error from Jenkins release job: 
https://build.ci.opensearch.org/job/opensearch-protobufs-release/2/console

```
[ERROR] Repository "orgopensearch-1263" failures
[ERROR]   Rule "sources-staging" failures
[ERROR]     * Missing: no sources jar found in folder '/org/opensearch/protobufs/0.1.0'
[ERROR]   Rule "javadoc-staging" failures
[ERROR]     * Missing: no javadoc jar found in folder '/org/opensearch/protobufs/0.1.0'
```
### Test Plan 
Ran this locally
```
rm -rf generated && bazel build //... && ./tools/java/package_proto_jar.sh
```

Verified: 
1. Jars are generated
```
~/opensearch-protobufs on [generateJars] % ls -ltr generated/maven/publish 
total 7964
-rw-r--r-- 1 karenx user    1076 Apr  2 21:21 protobufs-0.1.0-SNAPSHOT.pom
-rw-r--r-- 1 karenx user 2415113 Apr  2 21:21 protobufs-0.1.0-SNAPSHOT.jar
-rw-r--r-- 1 karenx user 1209989 Apr  2 21:21 protobufs-0.1.0-SNAPSHOT-sources.jar
-rw-r--r-- 1 karenx user 4519292 Apr  2 21:21 protobufs-0.1.0-SNAPSHOT-javadoc.jar
```
<img width="397" alt="Screenshot 2025-04-02 at 5 29 49 PM" src="https://github.com/user-attachments/assets/1bcc47d2-74f0-43d7-89b1-1fd80c09d1ad" />

2. Javadoc jar contents: 
```
~/opensearch-protobufs/generated/maven/publish/javadoc on [generateJars] % jar xf protobufs-0.1.0-SNAPSHOT-javadoc.jar

~/opensearch-protobufs/generated/maven/publish/javadoc on [generateJars] % ls -ltr
total 17248
drwxr-xr-x 3 karenx user    4096 Apr  2 21:31 org
-rw-r--r-- 1 karenx user  207263 Apr  2 21:31 serialized-form.html
-rw-r--r-- 1 karenx user  209345 Apr  2 21:31 overview-tree.html
-rw-r--r-- 1 karenx user      59 Apr  2 21:31 element-list
-rw-r--r-- 1 karenx user  673887 Apr  2 21:31 constant-values.html
-rw-r--r-- 1 karenx user    3360 Apr  2 21:31 type-search-index.zip
-rw-r--r-- 1 karenx user   39740 Apr  2 21:31 type-search-index.js
-rw-r--r-- 1 karenx user   22360 Apr  2 21:31 stylesheet.css
-rw-r--r-- 1 karenx user   13309 Apr  2 21:31 search.js
-rw-r--r-- 1 karenx user    6040 Apr  2 21:31 script.js
drwxr-xr-x 2 karenx user    4096 Apr  2 21:31 resources
-rw-r--r-- 1 karenx user     251 Apr  2 21:31 package-search-index.zip
-rw-r--r-- 1 karenx user     149 Apr  2 21:31 package-search-index.js
-rw-r--r-- 1 karenx user     687 Apr  2 21:31 overview-summary.html
drwxr-xr-x 2 karenx user    4096 Apr  2 21:31 META-INF
-rw-r--r-- 1 karenx user  132470 Apr  2 21:31 member-search-index.zip
-rw-r--r-- 1 karenx user 2396038 Apr  2 21:31 member-search-index.js
drwxr-xr-x 2 karenx user    4096 Apr  2 21:31 legal
-rw-r--r-- 1 karenx user    1498 Apr  2 21:31 jquery-ui.overrides.css
drwxr-xr-x 5 karenx user    4096 Apr  2 21:31 jquery
-rw-r--r-- 1 karenx user    4924 Apr  2 21:31 index.html
-rw-r--r-- 1 karenx user 8983370 Apr  2 21:31 index-all.html
-rw-r--r-- 1 karenx user    9470 Apr  2 21:31 help-doc.html
-rw-r--r-- 1 karenx user   65806 Apr  2 21:31 deprecated-list.html
-rw-r--r-- 1 karenx user    5088 Apr  2 21:31 allpackages-index.html
-rw-r--r-- 1 karenx user  192578 Apr  2 21:31 allclasses-index.html
-rw-r--r-- 1 karenx user   97618 Apr  2 21:31 allclasses.html
-rw-r--r-- 1 karenx user 4516377 Apr  2 21:31 protobufs-0.1.0-SNAPSHOT-javadoc.jar
``` 
<img width="631" alt="Screenshot 2025-04-02 at 5 39 49 PM" src="https://github.com/user-attachments/assets/caf26b46-4a93-4a56-a749-bc9b2386e776" />
<img width="529" alt="Screenshot 2025-04-02 at 5 40 02 PM" src="https://github.com/user-attachments/assets/9c0544d0-868c-46b6-89f6-ada04c609fe1" />


Compared to the unzipped contents of [analysis-icu-client-3.0.0-alpha1-javadoc.jar](https://repo1.maven.org/maven2/org/opensearch/plugin/analysis-icu-client/3.0.0-alpha1/analysis-icu-client-3.0.0-alpha1-javadoc.jar) , contents look similar: 
<img width="413" alt="Screenshot 2025-04-02 at 5 41 15 PM" src="https://github.com/user-attachments/assets/5494d407-2121-44fd-b49b-dc8924c65319" />


3. Sources jar contents: 
```
~/opensearch-protobufs/generated/maven/publish/sources on [generateJars] % jar xf protobufs-0.1.0-SNAPSHOT-sources.jar 
~/opensearch-protobufs/generated/maven/publish/sources on [generateJars] % ls -ltr
total 1196
drwxr-xr-x 3 karenx user    4096 Apr  2 21:31 org
drwxr-xr-x 3 karenx user    4096 Apr  2 21:31 com
drwxr-xr-x 2 karenx user    4096 Apr  2 21:31 META-INF
-rw-r--r-- 1 karenx user 1208517 Apr  2 21:31 protobufs-0.1.0-SNAPSHOT-sources.jar
```
<img width="376" alt="Screenshot 2025-04-02 at 5 34 06 PM" src="https://github.com/user-attachments/assets/c20aa87e-0085-45a1-b47d-ccc6d9c6f2d7" />


Compared to the unzipped contents of [analysis-icu-client-3.0.0-alpha1-sources.jar](https://repo1.maven.org/maven2/org/opensearch/plugin/analysis-icu-client/3.0.0-alpha1/analysis-icu-client-3.0.0-alpha1-sources.jar) , contents look similar: 
<img width="401" alt="Screenshot 2025-04-02 at 5 42 11 PM" src="https://github.com/user-attachments/assets/3d655853-9ff6-4b78-b89c-21ab717297ed" />


### Issues Resolved
https://github.com/opensearch-project/opensearch-protobufs/issues/9 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
