### PR TITLE
Upload javadoc and sources jar to maven

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Document steps to cut a release ([#44](https://github.com/opensearch-project/opensearch-protobufs/pull/44))
 - Add missing SearchRequestBody and ErrorResponse fields ([#45](https://github.com/opensearch-project/opensearch-protobufs/pull/45))
 - Generate javadoc jar and sources jar ([#49](https://github.com/opensearch-project/opensearch-protobufs/pull/49))
+- Upload javadoc and sources jar to maven ([#50](https://github.com/opensearch-project/opensearch-protobufs/pull/50))
 
 ### Removed
 

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,8 @@ publishing {
             groupId = group
             artifactId = artifactName
             artifact "./generated/maven/publish/${artifactName}-${version}.jar"
-
+            artifact(source: "./generated/maven/publish/${artifactName}-${version}-sources.jar", classifier: 'sources')
+            artifact(source: "./generated/maven/publish/${artifactName}-${version}-javadoc.jar", classifier: 'javadoc')
         }
     }
 


### PR DESCRIPTION
### Description
Upload the 2 newly generated javadoc and sources jars in #49 to SONATYPE/Maven as well https://aws.oss.sonatype.org/content/repositories/snapshots/org/opensearch/protobufs/0.1.0-SNAPSHOT/  

```
Generated JAR files:
  Main JAR: /home/user/opensearch-protobufs/tools/java/../../generated/maven/protobufs-0.1.0-SNAPSHOT.jar
  Sources JAR: /home/user/opensearch-protobufs/tools/java/../../generated/maven/protobufs-0.1.0-SNAPSHOT-sources.jar
  Javadoc JAR: /home/user/opensearch-protobufs/tools/java/../../generated/maven/protobufs-0.1.0-SNAPSHOT-javadoc.jar
```
 
### Issues Resolved
#9 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
