### PR TITLE
Fix `derived` type in search protos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,5 +11,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 
 ### Fixed
+- Fix derived type ([#57](https://github.com/opensearch-project/opensearch-protobufs/pull/57))
 
 ### Security

--- a/protos/schemas/search.proto
+++ b/protos/schemas/search.proto
@@ -286,7 +286,7 @@ message SearchRequestBody {
     
   // [optional] 
   // TODO add to spec (since 2.14)
-  map<string, ObjectMap> derived = 35;
+  map<string, DerivedField> derived = 35;
 }
 
 message DerivedField {


### PR DESCRIPTION
### Description
Used the wrong type in the map 

### Issues Resolved
#30 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
