### PR TITLE
Fix slice id type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,5 +12,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 - Fix derived type ([#57](https://github.com/opensearch-project/opensearch-protobufs/pull/57))
+- Fix slice id type ([#58](https://github.com/opensearch-project/opensearch-protobufs/pull/58))
 
 ### Security

--- a/protos/schemas/search.proto
+++ b/protos/schemas/search.proto
@@ -640,7 +640,7 @@ message SlicedScroll {
   optional string field = 1;
 
   // [required] The id of the slice
-  string id = 2;
+  int32 id = 2;
 
   // [required] The maximum number of slices
   int32 max = 3;


### PR DESCRIPTION
### Description
`id` field is an integer according to both the [spec](https://github.com/opensearch-project/opensearch-api-specification/blob/34d71face243365b48677ad86a5e800b24cf4cd3/spec/schemas/_common.yaml#L885) and [code](https://github.com/opensearch-project/OpenSearch/blob/1937f5f06271cd70522c4d7391140b01070a16db/server/src/main/java/org/opensearch/search/slice/SliceBuilder.java#L90). 

### Issues Resolved
#30

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
