### PR TITLE
Fix QueryContainer protos for matchall, match none, and term query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,5 +13,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Fix derived type ([#57](https://github.com/opensearch-project/opensearch-protobufs/pull/57))
 - Fix slice id type ([#58](https://github.com/opensearch-project/opensearch-protobufs/pull/58))
+- Fix QueryContainer protos for matchall, match none, and term query ([#60](https://github.com/opensearch-project/opensearch-protobufs/pull/60))
 
 ### Security

--- a/protos/schemas/common.proto
+++ b/protos/schemas/common.proto
@@ -404,7 +404,7 @@ message QueryContainer {
   // Term query is to search for an exact term in a field. The term query does not analyze the search term. The term query only searches for the exact term you provide.
   // If provided, no other fields should be provided inside QueryContainer
   // Only 1 entry can be provided in the map
-  map<string, TermQueryFieldValue> term = 12;
+  map<string, TermQuery> term = 12;
 
   // [optional]
   // Terms query field is to search for documents containing one or more terms in a specific field. Use the terms query to search for multiple terms in the same field.
@@ -1670,21 +1670,14 @@ message TermsSetQuery {
 
 }
 
-message TermQueryFieldValue {
-  oneof term_query_field_value{
-    TermQuery term_query = 1;
-    FieldValue field_value = 2;
-  }
-}
-
 message TermQuery {
   // [optional]
   // Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
-  float boost = 1;
+  optional float boost = 1;
 
   // [optional]
   // Query name for query tagging
-  string name = 2 [json_name = "_name"];
+  optional string name = 2 [json_name = "_name"];
 
   // [required]
   // Term you wish to find in the provided <field>. To return a document, the term must exactly match the field value, including whitespace and capitalization.
@@ -1692,7 +1685,7 @@ message TermQuery {
 
   // [optional]
   // Allows ASCII case insensitive matching of the value with the indexed field values when set to `true`. When `false`, the case sensitivity of matching depends on the underlying field's mapping.
-  bool case_insensitive = 4;
+  optional bool case_insensitive = 4;
 
 }
 
@@ -2093,11 +2086,11 @@ message MatchAllQuery {
 
   // [optional]
   // Boosts the clause by the given multiplier. Useful for weighing clauses in compound queries. Values in the [0, 1) range decrease relevance, and values greater than 1 increase relevance. Default is 1.
-  float boost = 1;
+  optional float boost = 1;
 
   // [optional]
   // Query name for query tagging
-  string name = 2 [json_name = "_name"];
+  optional string name = 2 [json_name = "_name"];
 }
 
 message MatchBoolPrefixQuery {
@@ -2185,12 +2178,9 @@ message MatchBoolPrefixQuery {
 }
 
 message MatchNoneQuery {
+  optional float boost = 1;
 
-  float boost = 1;
-
-  string name = 2 [json_name = "_name"];
-
-  ObjectMap object = 3;
+  optional string name = 2 [json_name = "_name"];
 }
 
 message MatchPhrasePrefixQuery {


### PR DESCRIPTION
### Description
1. remove TermQueryFieldValue
2. Add optional keyword to various query message types 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
