### PR TITLE
Record spec commit id and change Struct to ObjectMap.

### DIFF
--- a/.github/workflows/convert-proto.yml
+++ b/.github/workflows/convert-proto.yml
@@ -33,7 +33,23 @@ jobs:
           fileName: 'opensearch-openapi.yaml'
           tag: 'main-latest'
           preRelease: true
-
+      - name: Get Latest Commit ID
+        id: get_commit
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const owner = "opensearch-project";
+            const repo = "opensearch-api-specification";
+            const commits = await github.rest.repos.listCommits({
+              owner,
+              repo,
+              sha: "main",
+              per_page: 1
+            });
+            const latestCommit = commits.data[0].sha;
+            core.setOutput("latest_commit", latestCommit);
+            console.log("Latest commit: " + latestCommit);
       - name: Run Proto Conversion
         run: npm ci && npm run preprocessing
 
@@ -74,7 +90,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: auto-pr-branch
           commit-message: "Protobuf schema change detected"
-          title: "[Automated PR]: Update generated protobuf schema"
+          title: "[Automated PR]: Update generated protobuf schema (spec commit: ${{ steps.get_commit.outputs.latest_commit }})"
           signoff: true
           base: main
           delete-branch: true

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ bazel-opensearch-protos
 .bazelrc.user
 
 # Generated files
-generated/
+/generated/
 
 # Maven output
 maven_output/
@@ -67,6 +67,7 @@ maven_output/
 Thumbs.db
 
 # proto conversion
-protos/tools/.openapi-generator/
-protos/tools/.openapi-generator-ignore
+protos/generated/.openapi-generator/
+protos/generated/.openapi-generator-ignore
 /cloned-repo
+opensearch-openapi.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bump version.properties and update changelog after 0.1.0 release  ([#51](https://github.com/opensearch-project/opensearch-protobufs/pull/51))
 - Address vulnerability issues([#54](https://github.com/opensearch-project/opensearch-protobufs/pull/54/))
 - Add missing derived, verbose_pipeline, and other fields to SearchRequestBody protos and fix optional fields ([#55](https://github.com/opensearch-project/opensearch-protobufs/pull/55))
+- Record source file commit id and change Struct to ObjectMap type for generated protos. ([#61](https://github.com/opensearch-project/opensearch-protobufs/pull/61))
 
 ### Removed
 

--- a/tools/proto-convert/src/config/protobuf-generator-config.yaml
+++ b/tools/proto-convert/src/config/protobuf-generator-config.yaml
@@ -12,8 +12,6 @@ additionalProperties:
 inlineSchemaOptions:
   RESOLVE_INLINE_ENUMS: true
   SKIP_SCHEMA_REUSE: true
-importMappings:
-  ObjectMap: "google/protobuf/struct"
 typeMappings:
   object: "ObjectMap"
   AnyType: "ObjectMap"

--- a/tools/proto-convert/src/config/protobuf-generator-config.yaml
+++ b/tools/proto-convert/src/config/protobuf-generator-config.yaml
@@ -1,8 +1,9 @@
 generatorName: protobuf-schema
-outputDir: protos/tools
+outputDir: protos/generated
 inputSpec: build/processed-opensearch-openapi.yaml
 templateDir: tools/proto-convert/src/config/protobuf-schema-template/
 additionalProperties:
+  packageName: org.opensearch.protobufs
   addJsonNameAnnotation: true
   flattenComplexType: true
   numberedFieldNumberList: true
@@ -12,9 +13,9 @@ inlineSchemaOptions:
   RESOLVE_INLINE_ENUMS: true
   SKIP_SCHEMA_REUSE: true
 importMappings:
-  google.protobuf.Struct: "google/protobuf/struct"
+  ObjectMap: "google/protobuf/struct"
 typeMappings:
-  object: "google.protobuf.Struct"
-  AnyType: "google.protobuf.Struct"
+  object: "ObjectMap"
+  AnyType: "ObjectMap"
 openapiGeneratorIgnoreList:
   - "README.md"

--- a/tools/proto-convert/src/config/protobuf-schema-template/api.mustache
+++ b/tools/proto-convert/src/config/protobuf-schema-template/api.mustache
@@ -1,12 +1,11 @@
 {{>partial_header}}
 syntax = "proto3";
 
-package {{#lambda.lowercase}}{{{packageName}}}.{{{apiPackage}}}.{{{classname}}};{{/lambda.lowercase}}
+package {{#lambda.lowercase}}{{{packageName}}}.{{{apiPackage}}};{{/lambda.lowercase}}
 
-import "google/protobuf/empty.proto";
 {{#imports}}
 {{#import}}
-import public "{{{.}}}.proto";
+import "{{{.}}}.proto";
 {{/import}}
 {{/imports}}
 
@@ -19,6 +18,7 @@ message {{operationId}}Request {
   // {{{.}}}
   {{/description}}
   {{#vendorExtensions.x-protobuf-type}}{{.}} {{/vendorExtensions.x-protobuf-type}}{{^isMap}}{{^required}}{{^vendorExtensions.x-protobuf-type}}optional {{/vendorExtensions.x-protobuf-type}}{{/required}}{{/isMap}}{{vendorExtensions.x-protobuf-data-type}} {{paramName}} = {{vendorExtensions.x-protobuf-index}}{{#vendorExtensions.x-protobuf-json-name}} [json_name="{{vendorExtensions.x-protobuf-json-name}}"]{{/vendorExtensions.x-protobuf-json-name}};
+
   {{/allParams}}
 
 }
@@ -33,11 +33,13 @@ message {{operationId}}Response {
 
 {{#supportMultipleResponses}}
 message {{operationId}}Response {
+
     oneof response {
     {{#responses}}
         {{{vendorExtensions.x-oneOf-response-type}}} {{vendorExtensions.x-oneOf-response-name}} = {{vendorExtensions.x-oneOf-response-index}};
     {{/responses}}
     }
+
 }
 {{/supportMultipleResponses}}
 {{/operation}}

--- a/tools/proto-convert/src/config/protobuf-schema-template/model.mustache
+++ b/tools/proto-convert/src/config/protobuf-schema-template/model.mustache
@@ -5,13 +5,37 @@ package {{#lambda.lowercase}}{{{packageName}}};{{/lambda.lowercase}}
 
 {{#imports}}
 {{#import}}
-import public "{{{import}}}.proto";
+import "{{{import}}}.proto";
 {{/import}}
 {{/imports}}
 
+message ObjectMap {
+  map<string, Value> fields = 1;
+
+  message Value {
+    oneof value {
+      int32 int32 = 1;
+      int64 int64 = 2;
+      float float = 3;
+      double double = 4;
+      string string = 5;
+      bool bool = 6;
+      ObjectMap object_map = 7;
+      ListValue list_value = 8;
+    }
+  }
+
+  // `ListValue` is a wrapper around a repeated field of values.
+  // The JSON representation for `ListValue` is JSON array.
+  message ListValue {
+    // Repeated field of dynamically typed values.
+    repeated Value value = 1;
+  }
+}
+
 {{#models}}
 {{#model}}
-{{#isEnum}}{{>enum}}{{/isEnum}}{{^isEnum}}message {{classname}} {
+{{^isAlias}}{{#isEnum}}{{>enum}}{{/isEnum}}{{^isEnum}}message {{classname}} {
 
 {{#oneOf}}
 {{#-first}}
@@ -20,7 +44,7 @@ import public "{{{import}}}.proto";
         {{#description}}
         // {{{.}}}
         {{/description}}
-        {{#vendorExtensions.x-protobuf-type}}{{{.}}} {{/vendorExtensions.x-protobuf-type}}{{{vendorExtensions.x-protobuf-data-type}}} {{{name}}} = {{vendorExtensions.x-protobuf-index}}{{#vendorExtensions.x-protobuf-packed}} [packed=true]{{/vendorExtensions.x-protobuf-packed}};
+        {{#vendorExtensions.x-protobuf-type}}{{{.}}}{{/vendorExtensions.x-protobuf-type}}{{{vendorExtensions.x-protobuf-data-type}}} {{{name}}} = {{vendorExtensions.x-protobuf-index}}{{#vendorExtensions.x-protobuf-packed}} [packed=true]{{/vendorExtensions.x-protobuf-packed}};
 
         {{/vars}}
     }
@@ -51,5 +75,6 @@ import public "{{{import}}}.proto";
 {{/oneOf}}
 }
 {{/isEnum}}
+{{/isAlias}}
 {{/model}}
 {{/models}}

--- a/tools/proto-convert/src/config/target_api.yaml
+++ b/tools/proto-convert/src/config/target_api.yaml
@@ -1,11 +1,3 @@
 paths:
   - /_bulk
-  - /_search
   - /{index}/_bulk
-  - /{index}/_create/{id}
-  - /{index}/_doc
-  - /{index}/_doc/{id}
-  - /{index}/_explain/{id}
-  - /{index}/_search
-  - /{index}/_source/{id}
-  - /{index}/_update/{id}


### PR DESCRIPTION
### Description

- change generated protos package name.
- Replace struct to objectmap.
- Only generate bulk API.
- Record commit id as title for PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
