### PR TITLE
Add missing 'meta_fields' field and fix type of 'sort' in search protos

### DIFF
--- a/protos/schemas/common.proto
+++ b/protos/schemas/common.proto
@@ -2016,15 +2016,6 @@ message FieldValue {
   }
 }
 
-message FieldValueResponse {
-  oneof value{
-    double double_value = 1;
-    string string_value = 2;
-    .google.protobuf.Struct object = 3;
-    bool bool_value = 4;
-  }
-}
-
 message IdsQuery {
 
   float boost = 1;

--- a/protos/schemas/search.proto
+++ b/protos/schemas/search.proto
@@ -369,7 +369,7 @@ message ResponseBody {
   optional ClusterStatistics clusters = 6;
 
   // [optional] Retrieved specific fields in the search response
-  optional .google.protobuf.Struct fields = 7;
+  optional ObjectMap fields = 7;
 
   // [optional] Highest returned document _score.
   optional float max_score = 8; // TODO where is this used? remove?
@@ -481,7 +481,7 @@ message Hit {
   optional Explanation explanation = 5;
 
   // [optional] Contains field values for the documents.
-  optional .google.protobuf.Struct fields = 6;
+  optional ObjectMap fields = 6;
 
   // [optional] An additional highlight element for each search hit that includes the highlighted fields and the highlighted fragments.
   map<string, StringArray> highlight = 7;
@@ -526,7 +526,7 @@ message Hit {
   
   // [optional] Contains field values for the documents.
   // TODO: No field named "meta_fields" in the spec. Needs adaptor_unnest.
-  optional .google.protobuf.Struct meta_fields = 21;
+  ObjectMap meta_fields = 21;
 }
 
 message ClusterStatistics {

--- a/protos/schemas/search.proto
+++ b/protos/schemas/search.proto
@@ -526,7 +526,7 @@ message Hit {
   
   // [optional] Contains field values for the documents.
   // TODO: No field named "meta_fields" in the spec. Needs adaptor_unnest.
-  ObjectMap meta_fields = 21;
+  optional ObjectMap meta_fields = 21;
 }
 
 message ClusterStatistics {

--- a/protos/schemas/search.proto
+++ b/protos/schemas/search.proto
@@ -524,7 +524,7 @@ message Hit {
   // [optional] Sorted values
   repeated FieldValue sort = 20;
   
-  // [optional] Contains field values for the documents.
+  // [optional] Contains metadata values for the documents.
   // TODO: No field named "meta_fields" in the spec. Needs adaptor_unnest.
   optional ObjectMap meta_fields = 21;
 }

--- a/protos/schemas/search.proto
+++ b/protos/schemas/search.proto
@@ -522,7 +522,11 @@ message Hit {
   optional int64 version = 19;
 
   // [optional] Sorted values
-  repeated FieldValueResponse sort = 20;
+  repeated FieldValue sort = 20;
+  
+  // [optional] Contains field values for the documents.
+  // TODO: No field named "meta_fields" in the spec. Needs adaptor_unnest.
+  optional .google.protobuf.Struct meta_fields = 21;
 }
 
 message ClusterStatistics {


### PR DESCRIPTION
### Description
1. Fix the type of the field `sort` to match the spec. 
2. Add a missing field `meta_fields` which is also missing from the spec but is in the code. 
3. Use ObjectMap instead of google.protobuf.Struct in response side as well


### Issues Resolved
#30 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
