### PR TITLE
remove extra ExplanationDetails

### DIFF
--- a/protos/schemas/search.proto
+++ b/protos/schemas/search.proto
@@ -953,20 +953,7 @@ message Explanation {
   // [required] Explains what type of calculation is performed
   string description = 1;
   // [optional] Shows any subcalculations performed.
-  repeated ExplanationDetail details = 2;
-  // [required] Shows the result of the calculation,
-  double value = 3;
-
-}
-
-message ExplanationDetail {
-
-  // [required] Explains what type of calculation is performed
-  string description = 1;
-
-  // [required] Shows any subcalculations performed.
-  repeated ExplanationDetail details = 2;
-
+  repeated Explanation details = 2;
   // [required] Shows the result of the calculation,
   double value = 3;
 


### PR DESCRIPTION
### Description
ExplanationDetails and Explanation are the exact same message. No need to define twice under different names. Will also fix the spec in https://github.com/opensearch-project/opensearch-api-specification/pull/860/files 

### Issues Resolved
#30 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
