### PR TITLE
preprocessing spec for changing const to boolean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 ### Added
 - Preprocessing specification for additionalProperties ([#70](https://github.com/opensearch-project/opensearch-protobufs/pull/70)))
+- Preprocessing spec for changing const to boolean. ([#72](https://github.com/opensearch-project/opensearch-protobufs/pull/72))
 
 ### Removed
 

--- a/tools/proto-convert/src/TypeModifier.ts
+++ b/tools/proto-convert/src/TypeModifier.ts
@@ -5,17 +5,33 @@ export class TypeModifier {
         traverse(OpenApiSpec, {
             // change additionalProperties: true or additionalProperties:object to object
             onSchemaProperty: (schema) => {
-                if (schema.additionalProperties === true || (
-                    typeof schema.additionalProperties === 'object' &&
-                    this.isEmptyObjectSchema(schema.additionalProperties as OpenAPIV3.SchemaObject)
-                )) {
+                if (schema.additionalProperties === true || ( typeof schema.additionalProperties === 'object' &&  this.isEmptyObjectSchema(schema.additionalProperties as OpenAPIV3.SchemaObject))) {
                     schema.type = 'object';
                     delete schema.additionalProperties;
+                }
+            },
+            onSchema: (schema, schemaName) => {
+                if (!schema || this.isReferenceObject(schema)) return;
+                // chang const to boolean under oneof.
+                // title: schemaName + const
+                if (schema.oneOf) {
+                    for (const item of schema.oneOf) {
+                        if (item && !('$ref' in item) && item.type === 'string' && 'const' in item) {
+                            item.type = 'boolean';
+                            item.title = `${schemaName}_${item.const}`;
+                            delete item.const;
+                        }
+                    }
                 }
             }
         });
         return OpenApiSpec;
     }
+
+    isReferenceObject(schema: any): schema is OpenAPIV3.ReferenceObject {
+        return schema !== null && typeof schema === 'object' && '$ref' in schema;
+    }
+
     isEmptyObjectSchema(schema: OpenAPIV3.SchemaObject): boolean {
         return (
             schema.type === 'object' &&


### PR DESCRIPTION
### Description
Preprocessing cons type under oneof.
if const under oneof, changing its type to boolean and add title schemaName + const

###  Test Plan
Tested locally. 
```
Before:
    VersionType:
      oneOf:
        - type: string
          const: external
          description: The version number must be higher than the current version.
        - type: string
          const: external_gte
          description: The version number must be higher than or equal to the current version.
        - type: string
          const: force
          description: The version number is forced to be the given value.
        - type: string
          const: internal
          description: The version number is managed internally by OpenSearch.
```
After:
```
    VersionType:
      oneOf:
        - type: boolean
          description: The version number must be higher than the current version.
          title: VersionType_external
        - type: boolean
          description: The version number must be higher than or equal to the current version.
          title: VersionType_external_gte
        - type: boolean
          description: The version number is forced to be the given value.
          title: VersionType_force
        - type: boolean
          description: The version number is managed internally by OpenSearch.
          title: VersionType_internal
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
