### PR TITLE
Fix missing `optional` keywords in IndexDocument, UpdateDocument, GetDocument, DeleteDocument protos and use ObjectMap instead of Struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,5 +11,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 
 ### Fixed
+- Fix missing `optional` keywords in IndexDocument, UpdateDocument, GetDocument, DeleteDocument protos ([#75](https://github.com/opensearch-project/opensearch-protobufs/pull/75)))
 
 ### Security

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -25,13 +25,28 @@ This script will:
 - Install the JAR to your local Maven repository
 
 2. To use the JAR in a Gradle project, add the following to your build.gradle:
-```groovy
+where VERSION is the number set in [version.properties](./version.properties)
+
+If using local Maven: 
+```
 repositories {
     mavenLocal()
 }
 
 dependencies {
-    implementation 'org.opensearch.protobufs:opensearch-protobufs:1.0.0'
+    implementation 'org.opensearch.protobufs:opensearch-protobufs:{VERSION}-SNAPSHOT'
+}
+```
+If using snapshot jar uploaded to sonatype: 
+```
+repositories {
+  maven {
+    url = 'https://aws.oss.sonatype.org/content/repositories/snapshots'
+  }
+}
+
+dependencies {
+    implementation 'org.opensearch.protobufs:opensearch-protobufs:{VERSION}-SNAPSHOT'
 }
 ```
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -25,7 +25,7 @@ This script will:
 - Install the JAR to your local Maven repository
 
 2. To use the JAR in a Gradle project, add the following to your build.gradle:
-where VERSION is the number set in [version.properties](./version.properties)
+where VERSION is the number set in [version.properties](./version.properties) (e.g. 0.3.0)
 
 If using local Maven: 
 ```

--- a/protos/schemas/document.proto
+++ b/protos/schemas/document.proto
@@ -240,7 +240,7 @@ message BulkResponse {
 
 message BulkErrorResponse {
   // [optional] The bulk error
-  Error error = 1;
+  optional Error error = 1;
   // [optional] HTTP response status code
   optional int32 status = 2;
 }
@@ -310,9 +310,9 @@ message ResponseItem {
 
 message InlineGetDictUserDefined {
   // [optional]
-  .google.protobuf.Struct metadata_fields = 1;
+  ObjectMap metadata_fields = 1;
   // [optional]
-  .google.protobuf.Struct fields = 2;
+  ObjectMap fields = 2;
   // [required] Whether the document exists.
   bool found = 3;
   // [optional] The sequence number assigned to the document for the operation. Sequence numbers are used to ensure an older version of a document doesn't overwrite a newer version
@@ -344,7 +344,7 @@ message IndexDocumentRequest {
     OP_TYPE_INDEX = 2;
   }
   // [optional] Set to create to only index the document if it does not already exist (put if absent). If a document with the specified `_id` already exists, the indexing operation will fail. Same as using the `<index>/_create` endpoint. Valid values: `index`, `create`. If document id is specified, it defaults to `index`. Otherwise, it defaults to `create`.
-  OpType op_type = 5;
+  optional OpType op_type = 5;
   // [optional] ID of the pipeline to use to preprocess incoming documents. If the index has a default ingest pipeline specified, then setting the value to `_none` disables the default ingest pipeline for this request. If a final pipeline is configured it will always run, regardless of the value of this parameter.
   optional string pipeline = 6;
   enum Refresh {
@@ -357,11 +357,11 @@ message IndexDocumentRequest {
     REFRESH_WAIT_FOR = 3;
   }
   // [optional] enum of whether to refresh the affected shards after performing the indexing operations. Default is false
-  Refresh refresh = 7;
+  optional Refresh refresh = 7;
   // [optional] If `true`, the request's actions must target an index alias. Defaults to false. Can not be set if op_type=create.
   optional bool require_alias = 8;
   // [optional] Custom value used to route operations to a specific shard.
-  repeated string routing = 9;
+  optional string routing = 9;
   // [optional] Period each action waits for the following operations: automatic index creation, dynamic mapping updates, waiting for active shards.
   // Pattern: ^([0-9\.]+)(?:d|h|m|s|ms|micros|nanos)$
   // Defaults to 1m (one minute). This guarantees OpenSearch waits for at least the timeout before failing. The actual wait time could be longer, particularly when multiple waits occur.
@@ -376,9 +376,9 @@ message IndexDocumentRequest {
     VERSION_TYPE_EXTERNAL_GTE = 2;
   }
   // [optional] Assigns a specific type to the document.
-  VersionType version_type = 12;
+  optional VersionType version_type = 12;
   // [optional] The number of active shards that must be available before OpenSearch processes the request. Default is 1 (only the primary shard). Set to all or a positive integer. Values greater than 1 require replicas. For example, if you specify a value of 3, the index must have two replicas distributed across two additional nodes for the operation to succeed.
-  WaitForActiveShards wait_for_active_shards = 13;
+  optional WaitForActiveShards wait_for_active_shards = 13;
   // [required] contain the information you want to index.
   // Provide document either as ObjectMap or bytes
   oneof index_document_request_request_body {
@@ -391,7 +391,7 @@ message IndexDocumentRequest {
   // - If not set, source is returned as bytes (default, recommended for better performance)
   // - If set to SOURCE_TYPE_STRUCT: source is returned as a structured protobuf message
   // Note: Using SOURCE_TYPE_STRUCT may impact performance due to additional serialization overhead
-  SourceType source_type = 16;
+  optional SourceType source_type = 16;
 }
 
 // The response from index document request
@@ -407,7 +407,7 @@ message IndexDocumentResponse {
 // The error response from index document request
 message IndexDocumentErrorResponse {
   // [optional]
-  Error error = 1;
+  optional Error error = 1;
   // [optional] HTTP response status code
   optional int32 status = 2;
 }
@@ -431,7 +431,7 @@ message IndexDocumentResponseBody {
     RESULT_UPDATED = 5;
   }
   // [optional] The result of the index operation.
-  Result result = 5;
+  optional Result result = 5;
   // [optional] The sequence number assigned when the document was indexed.
   optional int64 seq_no = 6 [json_name = "_seq_no"];
   // [optional] Detailed information about the cluster's shards.
@@ -463,9 +463,9 @@ message DeleteDocumentRequest {
     REFRESH_WAIT_FOR = 3;
   }
   // [optional] enum of whether to refresh the affected shards after performing the indexing operations. Default is false
-  Refresh refresh = 5;
+  optional Refresh refresh = 5;
   // Custom value used to route operations to a specific shard.
-  repeated string routing = 6;
+  optional string routing = 6;
   // [optional] Period each action waits for the following operations: automatic index creation, dynamic mapping updates, waiting for active shards.
   // Pattern: ^([0-9\.]+)(?:d|h|m|s|ms|micros|nanos)$
   // Defaults to 1m (one minute). This guarantees OpenSearch waits for at least the timeout before failing. The actual wait time could be longer, particularly when multiple waits occur.
@@ -480,9 +480,9 @@ message DeleteDocumentRequest {
     VERSION_TYPE_EXTERNAL_GTE = 2;
   }
   // [optional] Assigns a specific type to the document.
-  VersionType version_type = 9;
+  optional VersionType version_type = 9;
   // [optional] The number of active shards that must be available before OpenSearch processes the request. Default is 1 (only the primary shard). Set to all or a positive integer. Values greater than 1 require replicas. For example, if you specify a value of 3, the index must have two replicas distributed across two additional nodes for the operation to succeed.
-  WaitForActiveShards wait_for_active_shards = 10;
+  optional WaitForActiveShards wait_for_active_shards = 10;
 }
 
 message DeleteDocumentResponseBody {
@@ -495,7 +495,6 @@ message DeleteDocumentResponseBody {
   // [optional] The primary term assigned when the document was indexed.
   optional int64 primary_term = 4 [json_name = "_primary_term"];
 
-
   enum Result {
     RESULT_INVALID = 0;
     RESULT_CREATED = 1;
@@ -505,7 +504,7 @@ message DeleteDocumentResponseBody {
     RESULT_UPDATED = 5;
   }
   // [optional] The result of the index operation.
-  Result result = 5;
+  optional Result result = 5;
   // [optional] The sequence number assigned when the document was indexed.
   optional int64 seq_no = 6 [json_name = "_seq_no"];
   // [optional] Detailed information about the cluster's shards.
@@ -527,7 +526,7 @@ message DeleteDocumentResponse {
 // The error response from delete index document with Id request
 message DeleteDocumentErrorResponse {
   // [optional]
-  Error error = 1;
+  optional Error error = 1;
   // [optional] HTTP response status code
   optional int32 status = 2;
 }
@@ -539,7 +538,7 @@ message UpdateDocumentRequest {
   // [optional] Name of the data stream or index to target. If the target doesn't exist and matches the name or wildcard (`*`) pattern of an index template with a `data_stream` definition, this request creates the data stream. If the target doesn't exist and doesn't match a data stream template, this request creates the index.
   optional string index = 2;
   // [optional] Set to false to disable source retrieval. You can also specify a comma-separated list of the fields you want to retrieve.
-  SourceConfigParam source = 3 [json_name = "_source"];
+  optional SourceConfigParam source = 3 [json_name = "_source"];
   // [optional] A comma-separated list of source fields to exclude from the response.
   repeated string source_excludes = 4 [json_name = "_source_excludes"];
   // [optional] A comma-separated list of source fields to include in the response.
@@ -560,18 +559,18 @@ message UpdateDocumentRequest {
     REFRESH_WAIT_FOR = 3;
   }
   // [optional] enum of whether to refresh the affected shards after performing the indexing operations. Default is false
-  Refresh refresh = 9;
+  optional Refresh refresh = 9;
   // [optional] If `true`, the request's actions must target an index alias. Defaults to false.
   optional bool require_alias = 10;
   // Specify how many times should the operation be retried when a conflict occurs.
   optional int32 retry_on_conflict = 11;
   // Custom value used to route operations to a specific shard.
-  repeated string routing = 12;
+  optional string routing = 12;
   // Period to wait for dynamic mapping updates and active shards. This guarantees OpenSearch waits for at least the timeout before failing. The actual wait time could be longer, particularly when multiple waits occur.
   // Pattern: ^([0-9\.]+)(?:d|h|m|s|ms|micros|nanos)$
-  string timeout = 13;
+  optional string timeout = 13;
   // [optional] The number of active shards that must be available before OpenSearch processes the request. Default is 1 (only the primary shard). Set to all or a positive integer. Values greater than 1 require replicas. For example, if you specify a value of 3, the index must have two replicas distributed across two additional nodes for the operation to succeed.
-  WaitForActiveShards wait_for_active_shards = 14;
+  optional WaitForActiveShards wait_for_active_shards = 14;
   // [required] The update document request body
   UpdateDocumentRequestBody request_body = 15;
 
@@ -579,7 +578,7 @@ message UpdateDocumentRequest {
   // - If not set, source is returned as bytes (default, recommended for better performance)
   // - If set to SOURCE_TYPE_STRUCT: source is returned as a structured protobuf message
   // Note: Using SOURCE_TYPE_STRUCT may impact performance due to additional serialization overhead
-  SourceType source_type = 16;
+  optional SourceType source_type = 16;
 }
 
 message UpdateDocumentRequestBody {
@@ -598,12 +597,12 @@ message UpdateDocumentRequestBody {
   // [optional] Set to true to use the contents of 'doc' as the value of 'upsert'
   optional bool doc_as_upsert = 3;
   // [optional] Script for more complex document updates by defining the script with the `source` or `id` from a document
-  Script script = 4;
+  optional Script script = 4;
 
   //[optional] Set to true to execute the script whether or not the document exists.
   optional bool scripted_upsert = 5;
   // [optional] Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered.
-  SourceConfig source = 6 [json_name = "_source"];
+  optional SourceConfig source = 6 [json_name = "_source"];
 
   // [optional] If the document does not already exist, the contents of 'upsert' are inserted as a new document. If the document exists, the 'script' is executed.
   // Provide document either as ObjectMap or bytes
@@ -625,7 +624,7 @@ message UpdateDocumentResponse {
 // The error response from update index document with Id request
 message UpdateDocumentErrorResponse {
   // [optional]
-  Error error = 1;
+  optional Error error = 1;
   // [optional]  HTTP response status code
   optional int32 status = 2;
 }
@@ -649,17 +648,17 @@ message UpdateDocumentResponseBody {
     RESULT_UPDATED = 5;
   }
   // [optional] The result of the index operation.
-  Result result = 5;
+  optional Result result = 5;
   // [optional] The sequence number assigned when the document was indexed.
   optional int64 seq_no = 6 [json_name = "_seq_no"];
   // [optional] Detailed information about the cluster's shards.
-  ShardStatistics shards = 7 [json_name = "_shards"];
+  optional ShardStatistics shards = 7 [json_name = "_shards"];
   // [optional] The document's version.
   optional int64 version = 8 [json_name = "_version"];
   // [optional] if `true`, it requires immediate visibility of the document
   optional bool forced_refresh = 9;
   // [optional]
-  InlineGet get = 10;
+  optional InlineGet get = 10;
 }
 
 // Get document request with document ID specified
@@ -669,7 +668,7 @@ message GetDocumentRequest {
   // [required] Name of the data stream or index to target. If the target doesn't exist and matches the name or wildcard (`*`) pattern of an index template with a `data_stream` definition, this request creates the data stream. If the target doesn't exist and doesn't match a data stream template, this request creates the index.
   string index = 2;
   // [optional] Set to false to disable source retrieval. You can also specify a comma-separated list of the fields you want to retrieve. Default is true.
-  SourceConfigParam source = 3 [json_name = "_source"];
+  optional SourceConfigParam source = 3 [json_name = "_source"];
   // [optional] A comma-separated list of source fields to exclude from the response.
   repeated string source_excludes = 4 [json_name = "_source_excludes"];
   // [optional] A comma-separated list of source fields to include in the response.
@@ -681,7 +680,7 @@ message GetDocumentRequest {
   // [optional] If true, OpenSearch refreshes shards to make the get operation available to search results. Valid options are true, false, and wait_for, which tells OpenSearch to wait for a refresh before executing the operation. Default is false.
   optional bool refresh = 8;
   // [optional] A value used to route the operation to a specific shard.
-  repeated string routing = 9;
+  optional string routing = 9;
   // [optional] List of stored fields to return as part of a hit. If no fields are specified, no stored fields are included in the response. If this field is specified, the `_source` parameter defaults to false.
   repeated string stored_fields = 10;
   // [optional] Explicit version number for concurrency control. The specified version must match the current version of the document for the request to succeed.
@@ -694,14 +693,13 @@ message GetDocumentRequest {
     VERSION_TYPE_EXTERNAL_GTE = 2;
   }
   // [optional] Assigns a specific type to the document.
-  VersionType version_type = 12;
+  optional VersionType version_type = 12;
 
   // [optional] Controls how document source fields are returned in the response.
   // - If not set, source is returned as bytes (default, recommended for better performance)
   // - If set to SOURCE_TYPE_STRUCT: source is returned as a structured protobuf message
   // Note: Using SOURCE_TYPE_STRUCT may impact performance due to additional serialization overhead
-  SourceType source_type = 13;
-
+  optional SourceType source_type = 13;
 }
 
 message GetDocumentResponseBody {
@@ -710,7 +708,7 @@ message GetDocumentResponseBody {
   // [optional] The name of the index.
   optional string index = 2 [json_name = "_index"];
   // [optional] Contains the document's data that's stored in the index. Only returned if both stored_fields and found are true.
-  .google.protobuf.Struct fields = 3;
+  ObjectMap fields = 3;
   // [optional] Whether the document exists.
   optional bool found = 4;
   // [optional] The document's ID.
@@ -745,7 +743,7 @@ message GetDocumentResponse {
 // The error response from get document request with document ID specified request
 message GetDocumentErrorResponse {
   // [optional]
-  Error error = 1;
+  optional Error error = 1;
   // [optional] HTTP response status code
   optional int32 status = 2;
 }


### PR DESCRIPTION
### Description
1. Fix missing `optional` keywords in IndexDocument, UpdateDocument, GetDocument, DeleteDocument protos 
2. Use ObjectMap instead of google.protobuf.Struct 
3. Update testing guide 

### Related Issues
#28 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
