### PR TITLE
Preprocessing oneof by aggregating array of item and single item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Preprocessing specification for additionalProperties ([#70](https://github.com/opensearch-project/opensearch-protobufs/pull/70)))
 - Preprocessing spec for changing const to boolean. ([#72](https://github.com/opensearch-project/opensearch-protobufs/pull/72))
 - Add IndexDocument, UpdateDocument, GetDocument, DeleteDocument protos and move services to protos/services folder ([#73](https://github.com/opensearch-project/opensearch-protobufs/pull/73)))
+- Preprocessing oneof by aggregating array of item and single item ([#76](https://github.com/opensearch-project/opensearch-protobufs/pull/76))
 
 ### Removed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "json-diff-ts": "^4.0.1",
         "json-schema-to-typescript": "^14.0.4",
         "lodash": "^4.17.21",
+        "lodash.isequal": "^4.5.0",
         "protobufjs": "^6.11.4",
         "qs": "^6.12.1",
         "smile-js": "^0.7.0",
@@ -55,6 +56,7 @@
       },
       "devDependencies": {
         "@types/jest": "^29.5.14",
+        "@types/lodash.isequal": "^4.5.8",
         "jest": "^29.7.0",
         "ts-jest": "^29.3.0",
         "typescript": "^5.8.2"
@@ -3452,6 +3454,16 @@
       "version": "4.17.4",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.4.tgz",
       "integrity": "sha512-wYCP26ZLxaT3R39kiN2+HcJ4kTd3U1waI/cY7ivWYqFP6pW3ZNpvi6Wd6PHZx7T/t8z0vlkXMg3QYLa7DZ/IJQ=="
+    },
+    "node_modules/@types/lodash.isequal": {
+      "version": "4.5.8",
+      "resolved": "https://registry.npmjs.org/@types/lodash.isequal/-/lodash.isequal-4.5.8.tgz",
+      "integrity": "sha1-swu2/2pfbBmz2vOJ1kmsf3olBJk=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash": "*"
+      }
     },
     "node_modules/@types/long": {
       "version": "4.0.2",
@@ -7861,6 +7873,13 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -12566,6 +12585,15 @@
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.4.tgz",
       "integrity": "sha512-wYCP26ZLxaT3R39kiN2+HcJ4kTd3U1waI/cY7ivWYqFP6pW3ZNpvi6Wd6PHZx7T/t8z0vlkXMg3QYLa7DZ/IJQ=="
     },
+    "@types/lodash.isequal": {
+      "version": "4.5.8",
+      "resolved": "https://registry.npmjs.org/@types/lodash.isequal/-/lodash.isequal-4.5.8.tgz",
+      "integrity": "sha1-swu2/2pfbBmz2vOJ1kmsf3olBJk=",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/long": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
@@ -15626,6 +15654,11 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
     },
     "lodash.memoize": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "json-diff-ts": "^4.0.1",
     "json-schema-to-typescript": "^14.0.4",
     "lodash": "^4.17.21",
+    "lodash.isequal": "^4.5.0",
     "protobufjs": "^6.11.4",
     "qs": "^6.12.1",
     "smile-js": "^0.7.0",
@@ -56,6 +57,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",
+    "@types/lodash.isequal": "^4.5.8",
     "jest": "^29.7.0",
     "ts-jest": "^29.3.0",
     "typescript": "^5.8.2"

--- a/tools/proto-convert/src/TypeModifier.ts
+++ b/tools/proto-convert/src/TypeModifier.ts
@@ -1,37 +1,50 @@
 import type {OpenAPIV3} from "openapi-types";
 import { traverse } from './utils/OpenApiTraverser';
+import isEqual from 'lodash.isequal';
+
+
 export class TypeModifier {
     public modify(OpenApiSpec: OpenAPIV3.Document): any {
         traverse(OpenApiSpec, {
-            // change additionalProperties: true or additionalProperties:object to object
             onSchemaProperty: (schema) => {
-                if (schema.additionalProperties === true || ( typeof schema.additionalProperties === 'object' &&  this.isEmptyObjectSchema(schema.additionalProperties as OpenAPIV3.SchemaObject))) {
-                    schema.type = 'object';
-                    delete schema.additionalProperties;
-                }
+                this.handleAdditionalPropertiesUndefined(schema)
             },
             onSchema: (schema, schemaName) => {
                 if (!schema || this.isReferenceObject(schema)) return;
-                // chang const to boolean under oneof.
-                // title: schemaName + const
-                if (schema.oneOf) {
-                    for (const item of schema.oneOf) {
-                        if (item && !('$ref' in item) && item.type === 'string' && 'const' in item) {
-                            item.type = 'boolean';
-                            item.title = `${schemaName}_${item.const}`;
-                            delete item.const;
-                        }
-                    }
-                }
+                this.handleOneOfConst(schema, schemaName)
+                this.handleOneOfSimplification(schema)
+                this.handleAdditionalPropertiesUndefined(schema)
             }
         });
         return OpenApiSpec;
+    }
+
+    // Converts `additionalProperties: true` or `additionalProperties: {}` to `type: object`.
+    // Example: { additionalProperties: true } -> { type: 'object' }
+    handleAdditionalPropertiesUndefined(schema: OpenAPIV3.SchemaObject): void {
+        if (schema.additionalProperties === true || ( typeof schema.additionalProperties === 'object' &&  this.isEmptyObjectSchema(schema.additionalProperties as OpenAPIV3.SchemaObject))) {
+            schema.type = 'object';
+            delete schema.additionalProperties;
+        }
     }
 
     isReferenceObject(schema: any): schema is OpenAPIV3.ReferenceObject {
         return schema !== null && typeof schema === 'object' && '$ref' in schema;
     }
 
+    // Converts `oneOf` schemas with `const` values to boolean types.
+    // Example: oneof: [ {type: 'string', const: 'a'} ] to type: 'boolean' with title: 'schemaName_a'
+    handleOneOfConst(schema: OpenAPIV3.SchemaObject, schemaName: string): void {
+        if (schema.oneOf) {
+            for (const item of schema.oneOf) {
+                if (item && !('$ref' in item) && item.type === 'string' && 'const' in item) {
+                    item.type = 'boolean';
+                    item.title = `${schemaName}_${item.const}`;
+                    delete item.const;
+                }
+            }
+        }
+    }
     isEmptyObjectSchema(schema: OpenAPIV3.SchemaObject): boolean {
         return (
             schema.type === 'object' &&
@@ -40,6 +53,46 @@ export class TypeModifier {
             !schema.anyOf &&
             !schema.oneOf &&
             !('$ref' in schema)
+        );
+    }
+
+    // Simplify schemas with `oneOf` by aggregating items.
+    // If there are only two `oneOf` items and one matches an array schema, remove oneOf type and set type to array.
+    // If there are more than two `oneOf` items and one matches an array schema, remove that item from `oneOf`.
+    handleOneOfSimplification(schema: OpenAPIV3.SchemaObject): void{
+        if (!('$ref' in schema) && Array.isArray(schema.oneOf)) {
+            const oneOfs = schema.oneOf;
+
+            const arraySet = new Set<string>();
+            var deleteIndx = -1;
+
+            for (const oneOf of oneOfs) {
+                if (this.isArraySchemaObject(oneOf)) {
+                    arraySet.add(JSON.stringify(oneOf.items))
+                }
+            }
+            for (const oneOf of oneOfs) {
+                const oneOfStr = JSON.stringify(oneOf);
+                if (arraySet.has(oneOfStr)) {
+                    if(oneOfs.length == 2) {
+                        schema.type = 'array';
+                        (schema as OpenAPIV3.ArraySchemaObject).items = oneOf
+                        delete schema.oneOf;
+                    } else if (oneOfs.length > 2) {
+                        deleteIndx = oneOfs.findIndex(item => isEqual(item, oneOf));
+                        oneOfs.splice(deleteIndx, 1);
+                    }
+                }
+            }
+        }
+    }
+
+    isArraySchemaObject(schema: any): schema is OpenAPIV3.ArraySchemaObject {
+        return (
+            typeof schema === 'object' &&
+            schema !== null &&
+            schema.type === 'array' &&
+            'items' in schema
         );
     }
 }


### PR DESCRIPTION
### Description
Preprocessing oneof by aggregating array of item and single item.

### Test Plan
Example I: only single item and array of same item. remove oneof and change type to array of item.
Before: 
```
    StringOrStringArray:
      oneOf:
        - type: string
        - type: array
          items:
            type: string
```
After: 
```
    StringOrStringArray:
      type: array
      items:
        type: string
```

ExampleII: multiple items under oneof with combination of single item and array of items. removing single items from oneof.
Before
```
    Fields:
      oneOf:
        - $ref: '#/components/schemas/Field'
        - type: array
          items:
            $ref: '#/components/schemas/Field'
        - type: array
          items:
            type: boolean
        - type: boolean
        - type: float
```
After:
```
    Fields:
      oneOf:
        - type: array
          items:
            $ref: '#/components/schemas/Field'
        - type: array
          items:
            type: boolean
        - type: float
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
