### PR TITLE
Preprocessing spec by removing oneof if only one item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Preprocessing spec for changing const to boolean. ([#72](https://github.com/opensearch-project/opensearch-protobufs/pull/72))
 - Add IndexDocument, UpdateDocument, GetDocument, DeleteDocument protos and move services to protos/services folder ([#73](https://github.com/opensearch-project/opensearch-protobufs/pull/73)))
 - Preprocessing oneof by aggregating array of item and single item ([#76](https://github.com/opensearch-project/opensearch-protobufs/pull/76))
+- Preprocessing oneof by removing oneOf if only one item ([#77](https://github.com/opensearch-project/opensearch-protobufs/pull/77))
+
 
 ### Removed
 

--- a/tools/proto-convert/src/PreProcessing.ts
+++ b/tools/proto-convert/src/PreProcessing.ts
@@ -4,7 +4,7 @@ import Filter from './Filter';
 import { Sanitizer } from './Sanitizer';
 import Logger from './utils/logger';
 import * as path from 'path';
-import {TypeModifier} from "./TypeModifier";
+import {SchemaModifier} from "./SchemaModifier";
 
 let config_filtered_path: string[] | undefined;
 try {
@@ -43,14 +43,14 @@ const opts = command.opts() as PreprocessingOpts;
 const logger = new Logger();
 const filter = new Filter(logger);
 const sanitizer = new Sanitizer();
-const type_modifier = new TypeModifier();
+const schema_modifier = new SchemaModifier();
 try {
   logger.info(`PreProcessing ${opts.filtered_path.join(', ')} into ${opts.output} ...`)
   const original_spec = read_yaml(opts.input);
   const filtered_spec = filter.filter_spec(original_spec, opts.filtered_path);
   const sanitized_spec = sanitizer.sanitize(filtered_spec);
-  const type_modified_spec = type_modifier.modify(sanitized_spec);
-  write_yaml(opts.output, type_modified_spec);
+  const schema_modified_spec = schema_modifier.modify(sanitized_spec);
+  write_yaml(opts.output, schema_modified_spec);
 
 } catch (err) {
   logger.error(`Error in preprocessing: ${err}`);


### PR DESCRIPTION
### Description
Preprocessing spec by removing oneof if only one item

### Test Plan
Before:
```
        test:
          oneOf:
            - type: string
```
After:
```
        test:
          type: string
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
