### PR TITLE
Move some shared enums to top level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Preprocessing spec for changing const to boolean. ([#72](https://github.com/opensearch-project/opensearch-protobufs/pull/72))
 - Add IndexDocument, UpdateDocument, GetDocument, DeleteDocument protos and move services to protos/services folder ([#73](https://github.com/opensearch-project/opensearch-protobufs/pull/73)))
 - Preprocessing oneof by aggregating array of item and single item ([#76](https://github.com/opensearch-project/opensearch-protobufs/pull/76))
+- Move some shared enums to top level ([#80](https://github.com/opensearch-project/opensearch-protobufs/pull/80))
 
 ### Removed
 

--- a/protos/schemas/common.proto
+++ b/protos/schemas/common.proto
@@ -843,13 +843,14 @@ message SortOptions {
 message ScoreSort {
   // Specifies the sort order (asc or dsc) for the score.
   SortOrder order = 1;
-  enum SortOrder {
-    SORT_ORDER_UNSPECIFIED = 0;
-    // Sort in ascending order.
-    SORT_ORDER_ASC = 1;
-    // Sort in descending order
-    SORT_ORDER_DESC = 2;
-  }
+}
+
+enum SortOrder {
+  SORT_ORDER_UNSPECIFIED = 0;
+  // Sort in ascending order.
+  SORT_ORDER_ASC = 1;
+  // Sort in descending order
+  SORT_ORDER_DESC = 2;
 }
 
 message GeoDistanceSort {
@@ -887,14 +888,6 @@ message GeoDistanceSort {
   // [optional] Specifies the sort order (asc or dsc) for the score.
   SortOrder order = 4;
 
-  enum SortOrder {
-    SORT_ORDER_UNSPECIFIED = 0;
-    // Sort in ascending order.
-    SORT_ORDER_ASC = 1;
-    // Sort in descending order
-    SORT_ORDER_DESC = 2;
-  }
-
   // [optional] Specifies the units used to compute sort values. Default is meters (m).
   DistanceUnit unit = 5;
 
@@ -916,13 +909,6 @@ message ScriptSort {
 
   // [optional] Specifies the sort order (asc or dsc) for the score.
   SortOrder order = 1;
-  enum SortOrder {
-    SORT_ORDER_UNSPECIFIED = 0;
-    // Sort in ascending order.
-    SORT_ORDER_ASC = 1;
-    // Sort in descending order
-    SORT_ORDER_DESC = 2;
-  }
 
   // [optional] The script to execute for custom sorting.
   Script script = 2;
@@ -1033,6 +1019,12 @@ message ExistsQuery {
 
 }
 
+enum Operator {
+  OPERATOR_UNSPECIFIED = 0;
+  OPERATOR_AND = 1;
+  OPERATOR_OR = 2;
+}
+
 message SimpleQueryStringQuery {
 
   // Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
@@ -1050,11 +1042,6 @@ message SimpleQueryStringQuery {
   bool auto_generate_synonyms_phrase_query = 5;
 
   Operator default_operator = 6;
-  enum Operator {
-    OPERATOR_UNSPECIFIED = 0;
-    OPERATOR_AND = 1;
-    OPERATOR_OR = 2;
-  }
 
   repeated string fields = 7;
 
@@ -1263,13 +1250,6 @@ message MatchQuery {
   // If the query string contains multiple search terms, whether all terms need to match (AND) or only one term needs to match (OR) for a document to be considered a match.
   // Default is OR.
   Operator operator = 12;
-  enum Operator {
-    OPERATOR_UNSPECIFIED = 0;
-    // All terms need to match. The string `to be` is interpreted as `to AND be`
-    OPERATOR_AND = 1;
-    // Only one term needs to match. The string `to be` is interpreted as `to OR be`
-    OPERATOR_OR = 2;
-  }
 
   // [optional]
   // The number of leading characters that are not considered in fuzziness.
@@ -1712,11 +1692,6 @@ message QueryStringQuery {
   string default_field = 7;
 
   Operator default_operator = 8;
-  enum Operator {
-    OPERATOR_UNSPECIFIED = 0;
-    OPERATOR_AND = 1;
-    OPERATOR_OR = 2;
-  }
 
   // If `true`, enable position increments in queries constructed from a `query_string` search.
   bool enable_position_increments = 9;
@@ -2149,14 +2124,7 @@ message MatchBoolPrefixQuery {
   // If the query string contains multiple search terms, whether all terms need to match (and) or only one term needs to match (or) for a document to be considered a match.
   // Default is or.
   Operator operator = 9;
-  enum Operator {
-    OPERATOR_UNSPECIFIED = 0;
-    // All terms need to match. The string `to be` is interpreted as `to AND be`
-    OPERATOR_AND = 1;
-    // Only one term needs to match. The string `to be` is interpreted as `to OR be`
-    OPERATOR_OR = 2;
-  }
-
+  
   // [optional]
   // The number of leading characters that are not considered in fuzziness.
   // Default is 0.
@@ -2172,6 +2140,15 @@ message MatchNoneQuery {
   optional float boost = 1;
 
   optional string name = 2 [json_name = "_name"];
+}
+
+
+enum ZeroTermsQuery {
+  ZERO_TERMS_QUERY_UNSPECIFIED = 0;
+  // zero_terms_query specifies whether to match all documents (all).
+  ZERO_TERMS_QUERY_ALL = 1;
+  // zero_terms_query specifies whether to match no documents (none)
+  ZERO_TERMS_QUERY_NONE = 2;
 }
 
 message MatchPhrasePrefixQuery {
@@ -2206,13 +2183,6 @@ message MatchPhrasePrefixQuery {
   // In some cases, the analyzer removes all terms from a query string. For example, the stop analyzer removes all terms from the string an but this. In those cases, zero_terms_query specifies whether to match no documents (none) or all documents (all). Valid values are none and all.
   // Default is none.
   ZeroTermsQuery zero_terms_query = 7;
-  enum ZeroTermsQuery {
-    ZERO_TERMS_QUERY_UNSPECIFIED = 0;
-    // zero_terms_query specifies whether to match all documents (all).
-    ZERO_TERMS_QUERY_ALL = 1;
-    // zero_terms_query specifies whether to match no documents (none)
-    ZERO_TERMS_QUERY_NONE = 2;
-  }
 
 }
 
@@ -2243,13 +2213,6 @@ message MatchPhraseQuery {
   // In some cases, the analyzer removes all terms from a query string. For example, the stop analyzer removes all terms from the string an but this. In those cases, zero_terms_query specifies whether to match no documents (none) or all documents (all). Valid values are none and all.
   // Default is none.
   ZeroTermsQuery zero_terms_query = 6;
-  enum ZeroTermsQuery {
-    ZERO_TERMS_QUERY_UNSPECIFIED = 0;
-    // zero_terms_query specifies whether to match all documents (all).
-    ZERO_TERMS_QUERY_ALL = 1;
-    // zero_terms_query specifies whether to match no documents (none)
-    ZERO_TERMS_QUERY_NONE = 2;
-  }
 
 }
 
@@ -2295,12 +2258,7 @@ message MultiMatchQuery {
   MinimumShouldMatch minimum_should_match = 12;
 
   Operator operator = 13;
-  enum Operator {
-    OPERATOR_UNSPECIFIED = 0;
-    OPERATOR_AND = 1;
-    OPERATOR_OR = 2;
-  }
-
+  
   // Number of beginning characters left unchanged for fuzzy matching.
   int32 prefix_length = 14;
 

--- a/protos/schemas/document.proto
+++ b/protos/schemas/document.proto
@@ -305,7 +305,7 @@ message InlineGetDictUserDefined {
 }
 
 enum Refresh {
-  REFRESH_INVALID = 0;
+  REFRESH_UNSPECIFIED = 0;
   // `REFRESH_FALSE` do nothing with refreshes.
   REFRESH_FALSE = 1;
   // `REFRESH_TRUE` makes the changes show up in search results immediately, but hurts cluster performance.
@@ -381,7 +381,7 @@ message IndexDocumentErrorResponse {
 }
 
 enum Result {
-  RESULT_INVALID = 0;
+  RESULT_UNSPECIFIED = 0;
   RESULT_CREATED = 1;
   RESULT_DELETED = 2;
   RESULT_NOOP = 3;

--- a/protos/schemas/document.proto
+++ b/protos/schemas/document.proto
@@ -25,15 +25,6 @@ message BulkRequest {
   // [optional] ID of the pipeline to use to preprocess incoming documents. If the index has a default ingest pipeline specified, then setting the value to `_none` disables the default ingest pipeline for this request. If a final pipeline is configured it will always run, regardless of the value of this parameter.
   optional string pipeline = 5;
 
-  enum Refresh {
-    REFRESH_UNSPECIFIED = 0;
-    // `REFRESH_FALSE` do nothing with refreshes.
-    REFRESH_FALSE = 1;
-    // `REFRESH_TRUE` makes the changes show up in search results immediately, but hurts cluster performance.
-    REFRESH_TRUE = 2;
-    // `REFRESH_WAIT_FOR` waits for a refresh. Requests take longer to return, but cluster performance doesn't suffer.
-    REFRESH_WAIT_FOR = 3;
-  }
   // [optional] The enum of whether to refresh the affected shards after performing the indexing operations. Default is false
   optional Refresh refresh = 6;
   // [optional] If `true`, the request's actions must target an index alias. Defaults to false.
@@ -97,6 +88,22 @@ message BulkRequestBody {
   optional bytes object = 17;
 }
 
+enum OpType {
+  OP_TYPE_UNSPECIFIED = 0;
+  // Index a document only if it doesn't exist. Similarly as PUT <index>/_create/<_id>, will throw error if the document exist
+  OP_TYPE_CREATE = 1;
+  // A document ID is included in the request. default value.
+  OP_TYPE_INDEX = 2;
+}
+
+enum VersionType {
+  VERSION_TYPE_UNSPECIFIED = 0;
+  // Retrieve the document if the specified version number is greater than the document's current version
+  VERSION_TYPE_EXTERNAL = 1;
+  // Retrieve the document if the specified version number is greater than or equal to the document's current version
+  VERSION_TYPE_EXTERNAL_GTE = 2;
+}
+
 message IndexOperation {
   // [optional] The document ID. If no ID is specified, a document ID is automatically generated.
   optional string id = 1;
@@ -111,25 +118,11 @@ message IndexOperation {
   // [optional] Only perform the operation if the document has this sequence number
   optional int64 if_seq_no = 5;
 
-  enum OpType {
-    OP_TYPE_UNSPECIFIED = 0;
-    // Index a document only if it doesn't exist. Similarly as PUT <index>/_create/<_id>, will throw error if the document exist
-    OP_TYPE_CREATE = 1;
-    // A document ID is included in the request. default value.
-    OP_TYPE_INDEX = 2;
-  }
   // [optional] Set to create to only index the document if it does not already exist (put if absent). If a document with the specified `_id` already exists, the indexing operation will fail. Same as using the `<index>/_create` endpoint. Valid values: `index`, `create`. If document id is specified, it defaults to `index`. Otherwise, it defaults to `create`.
   optional OpType op_type = 6;
   // [optional] Explicit version number for concurrency control. The specified version must match the current version of the document for the request to succeed.
   optional int64 version = 7;
 
-  enum VersionType {
-    VERSION_TYPE_UNSPECIFIED = 0;
-    // Retrieve the document if the specified version number is greater than the document's current version
-    VERSION_TYPE_EXTERNAL = 1;
-    // Retrieve the document if the specified version number is greater than or equal to the document's current version
-    VERSION_TYPE_EXTERNAL_GTE = 2;
-  }
   // [optional] Assigns a specific type to the document.
   optional VersionType version_type = 8;
 
@@ -160,13 +153,6 @@ message CreateOperation {
   // [optional] Explicit version number for concurrency control. The specified version must match the current version of the document for the request to succeed.
   optional int64 version = 6;
 
-  enum VersionType {
-    VERSION_TYPE_UNSPECIFIED = 0;
-    // Retrieve the document if the specified version number is greater than the document's current version
-    VERSION_TYPE_EXTERNAL = 1;
-    // Retrieve the document if the specified version number is greater than or equal to the document's current version
-    VERSION_TYPE_EXTERNAL_GTE = 2;
-  }
   // [optional] Assigns a specific type to the document.
   optional VersionType version_type = 7;
 
@@ -216,13 +202,6 @@ message DeleteOperation {
   // [optional] Explicit version number for concurrency control. The specified version must match the current version of the document for the request to succeed.
   optional int64 version = 6;
 
-  enum VersionType {
-    VERSION_TYPE_UNSPECIFIED = 0;
-    // Retrieve the document if the specified version number is greater than the document's current version
-    VERSION_TYPE_EXTERNAL = 1;
-    // Retrieve the document if the specified version number is greater than or equal to the document's current version
-    VERSION_TYPE_EXTERNAL_GTE = 2;
-  }
   // [optional] Assigns a specific type to the document.
   optional VersionType version_type = 7;
 
@@ -325,6 +304,16 @@ message InlineGetDictUserDefined {
   optional bytes source = 7;
 }
 
+enum Refresh {
+  REFRESH_INVALID = 0;
+  // `REFRESH_FALSE` do nothing with refreshes.
+  REFRESH_FALSE = 1;
+  // `REFRESH_TRUE` makes the changes show up in search results immediately, but hurts cluster performance.
+  REFRESH_TRUE = 2;
+  // `REFRESH_WAIT_FOR` waits for a refresh. Requests take longer to return, but cluster performance doesn't suffer.
+  REFRESH_WAIT_FOR = 3;
+}
+
 // index document.
 message IndexDocumentRequest {
   // [optional] Creates or indexes a specific ID.
@@ -336,26 +325,11 @@ message IndexDocumentRequest {
   // [optional] Only perform the operation if the document has this sequence number. Can not be set if op_type=create.
   optional int64 if_seq_no = 4;
 
-  enum OpType {
-    OP_TYPE_INVALID = 0;
-    // Index a document only if it doesn't exist. Similarly as PUT <index>/_create/<_id>, will throw error if the document exist
-    OP_TYPE_CREATE = 1;
-    // A document ID is included in the request. default value.
-    OP_TYPE_INDEX = 2;
-  }
   // [optional] Set to create to only index the document if it does not already exist (put if absent). If a document with the specified `_id` already exists, the indexing operation will fail. Same as using the `<index>/_create` endpoint. Valid values: `index`, `create`. If document id is specified, it defaults to `index`. Otherwise, it defaults to `create`.
   optional OpType op_type = 5;
   // [optional] ID of the pipeline to use to preprocess incoming documents. If the index has a default ingest pipeline specified, then setting the value to `_none` disables the default ingest pipeline for this request. If a final pipeline is configured it will always run, regardless of the value of this parameter.
   optional string pipeline = 6;
-  enum Refresh {
-    REFRESH_INVALID = 0;
-    // `REFRESH_FALSE` do nothing with refreshes.
-    REFRESH_FALSE = 1;
-    // `REFRESH_TRUE` makes the changes show up in search results immediately, but hurts cluster performance.
-    REFRESH_TRUE = 2;
-    // `REFRESH_WAIT_FOR` waits for a refresh. Requests take longer to return, but cluster performance doesn't suffer.
-    REFRESH_WAIT_FOR = 3;
-  }
+
   // [optional] enum of whether to refresh the affected shards after performing the indexing operations. Default is false
   optional Refresh refresh = 7;
   // [optional] If `true`, the request's actions must target an index alias. Defaults to false. Can not be set if op_type=create.
@@ -368,13 +342,7 @@ message IndexDocumentRequest {
   optional string timeout = 10;
   // [optional] Explicit version number for concurrency control. The specified version must match the current version of the document for the request to succeed.
   optional int64 version = 11;
-  enum VersionType {
-    VERSION_TYPE_INVALID = 0;
-    // Retrieve the document if the specified version number is greater than the document's current version
-    VERSION_TYPE_EXTERNAL = 1;
-    // Retrieve the document if the specified version number is greater than or equal to the document's current version
-    VERSION_TYPE_EXTERNAL_GTE = 2;
-  }
+
   // [optional] Assigns a specific type to the document.
   optional VersionType version_type = 12;
   // [optional] The number of active shards that must be available before OpenSearch processes the request. Default is 1 (only the primary shard). Set to all or a positive integer. Values greater than 1 require replicas. For example, if you specify a value of 3, the index must have two replicas distributed across two additional nodes for the operation to succeed.
@@ -412,6 +380,15 @@ message IndexDocumentErrorResponse {
   optional int32 status = 2;
 }
 
+enum Result {
+  RESULT_INVALID = 0;
+  RESULT_CREATED = 1;
+  RESULT_DELETED = 2;
+  RESULT_NOOP = 3;
+  RESULT_NOT_FOUND = 4;
+  RESULT_UPDATED = 5;
+}
+
 message IndexDocumentResponseBody {
   // [optional] The document type.
   optional string type = 1 [json_name = "_type"];
@@ -422,14 +399,6 @@ message IndexDocumentResponseBody {
   // [optional] The primary term assigned when the document was indexed.
   optional int64 primary_term = 4 [json_name = "_primary_term"];
 
-  enum Result {
-    RESULT_INVALID = 0;
-    RESULT_CREATED = 1;
-    RESULT_DELETED = 2;
-    RESULT_NOOP = 3;
-    RESULT_NOT_FOUND = 4;
-    RESULT_UPDATED = 5;
-  }
   // [optional] The result of the index operation.
   optional Result result = 5;
   // [optional] The sequence number assigned when the document was indexed.
@@ -453,15 +422,6 @@ message DeleteDocumentRequest {
   // [optional] Only perform the operation if the document has this sequence number.
   optional int64 if_seq_no = 4;
 
-  enum Refresh {
-    REFRESH_INVALID = 0;
-    // `REFRESH_FALSE` do nothing with refreshes.
-    REFRESH_FALSE = 1;
-    // `REFRESH_TRUE` makes the changes show up in search results immediately, but hurts cluster performance.
-    REFRESH_TRUE = 2;
-    // `REFRESH_WAIT_FOR` waits for a refresh. Requests take longer to return, but cluster performance doesn't suffer.
-    REFRESH_WAIT_FOR = 3;
-  }
   // [optional] enum of whether to refresh the affected shards after performing the indexing operations. Default is false
   optional Refresh refresh = 5;
   // Custom value used to route operations to a specific shard.
@@ -472,13 +432,6 @@ message DeleteDocumentRequest {
   optional string timeout = 7;
   // [optional] Explicit version number for concurrency control. The specified version must match the current version of the document for the request to succeed.
   optional int64 version = 8;
-  enum VersionType {
-    VERSION_TYPE_INVALID = 0;
-    // Retrieve the document if the specified version number is greater than the document's current version
-    VERSION_TYPE_EXTERNAL = 1;
-    // Retrieve the document if the specified version number is greater than or equal to the document's current version
-    VERSION_TYPE_EXTERNAL_GTE = 2;
-  }
   // [optional] Assigns a specific type to the document.
   optional VersionType version_type = 9;
   // [optional] The number of active shards that must be available before OpenSearch processes the request. Default is 1 (only the primary shard). Set to all or a positive integer. Values greater than 1 require replicas. For example, if you specify a value of 3, the index must have two replicas distributed across two additional nodes for the operation to succeed.
@@ -494,15 +447,6 @@ message DeleteDocumentResponseBody {
   optional string index = 3 [json_name = "_index"];
   // [optional] The primary term assigned when the document was indexed.
   optional int64 primary_term = 4 [json_name = "_primary_term"];
-
-  enum Result {
-    RESULT_INVALID = 0;
-    RESULT_CREATED = 1;
-    RESULT_DELETED = 2;
-    RESULT_NOOP = 3;
-    RESULT_NOT_FOUND = 4;
-    RESULT_UPDATED = 5;
-  }
   // [optional] The result of the index operation.
   optional Result result = 5;
   // [optional] The sequence number assigned when the document was indexed.
@@ -549,15 +493,7 @@ message UpdateDocumentRequest {
   optional int64 if_seq_no = 7;
   // [optional] The script language.
   optional string lang = 8;
-  enum Refresh {
-    REFRESH_INVALID = 0;
-    // `REFRESH_FALSE` do nothing with refreshes.
-    REFRESH_FALSE = 1;
-    // `REFRESH_TRUE` makes the changes show up in search results immediately, but hurts cluster performance.
-    REFRESH_TRUE = 2;
-    // `REFRESH_WAIT_FOR` waits for a refresh. Requests take longer to return, but cluster performance doesn't suffer.
-    REFRESH_WAIT_FOR = 3;
-  }
+
   // [optional] enum of whether to refresh the affected shards after performing the indexing operations. Default is false
   optional Refresh refresh = 9;
   // [optional] If `true`, the request's actions must target an index alias. Defaults to false.
@@ -638,15 +574,6 @@ message UpdateDocumentResponseBody {
   optional string index = 3 [json_name = "_index"];
   // [optional] The primary term assigned when the document was indexed.
   optional int64 primary_term = 4 [json_name = "_primary_term"];
-
-  enum Result {
-    RESULT_INVALID = 0;
-    RESULT_CREATED = 1;
-    RESULT_DELETED = 2;
-    RESULT_NOOP = 3;
-    RESULT_NOT_FOUND = 4;
-    RESULT_UPDATED = 5;
-  }
   // [optional] The result of the index operation.
   optional Result result = 5;
   // [optional] The sequence number assigned when the document was indexed.
@@ -685,13 +612,6 @@ message GetDocumentRequest {
   repeated string stored_fields = 10;
   // [optional] Explicit version number for concurrency control. The specified version must match the current version of the document for the request to succeed.
   optional int64 version = 11;
-  enum VersionType {
-    VERSION_TYPE_INVALID = 0;
-    // Retrieve the document if the specified version number is greater than the document's current version
-    VERSION_TYPE_EXTERNAL = 1;
-    // Retrieve the document if the specified version number is greater than or equal to the document's current version
-    VERSION_TYPE_EXTERNAL_GTE = 2;
-  }
   // [optional] Assigns a specific type to the document.
   optional VersionType version_type = 12;
 

--- a/protos/schemas/search.proto
+++ b/protos/schemas/search.proto
@@ -610,7 +610,7 @@ message RescoreQuery {
   optional float rescore_query_weight = 3;
 
   enum ScoreMode {
-    SCORE_MODE_INVALID = 0;
+    SCORE_MODE_UNSPECIFIED = 0;
     // Average the original score and the rescore query score.
     SCORE_MODE_AVG = 1;
     // Take the max of original score and the rescore query score.


### PR DESCRIPTION
### Description
1. Move some shared enums to top level to simplify protobuf conversion in core repo
2. Use UNSPECIFIED instead of INVALID for the first enum value  according to https://protobuf.dev/best-practices/dos-donts/#unspecified-enum 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
