### PR TITLE
Fix terms query `routing` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,5 +15,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 - Fix missing `optional` keywords in IndexDocument, UpdateDocument, GetDocument, DeleteDocument protos ([#75](https://github.com/opensearch-project/opensearch-protobufs/pull/75)))
+- Fix terms query `routing` parameter ([#84](https://github.com/opensearch-project/opensearch-protobufs/pull/84))
 
 ### Security

--- a/protos/schemas/common.proto
+++ b/protos/schemas/common.proto
@@ -1637,7 +1637,7 @@ message TermsLookupField {
 
   // [optional]
   // Custom routing value of the document from which to fetch term values. If a custom routing value was provided when the document was indexed, this parameter is required.
-  repeated string routing = 4;
+  optional string routing = 4;
   
   // [optional] 
   optional bool store = 5;


### PR DESCRIPTION
### Description
Routing is a string not array of string, according to spec

### Issues Resolved
#30 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
