### PR TITLE
Preprocessing spec for collapse oneOf if childComplexOneOf property contains child simpleOneOf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Add search API to generated proto ([#82](https://github.com/opensearch-project/opensearch-protobufs/pull/82))
 - Replace required property name from _* to underscore_* and remove duplicate __ from modified title ([#88](https://github.com/opensearch-project/opensearch-protobufs/pull/88))
+- Preprocessing spec for collapse oneOf if childComplexOneOf property contains child SimpleOneOf. ([#89](https://github.com/opensearch-project/opensearch-protobufs/pull/80))
 
 ### Removed
 

--- a/tools/proto-convert/src/PreProcessing.ts
+++ b/tools/proto-convert/src/PreProcessing.ts
@@ -5,6 +5,7 @@ import { Sanitizer } from './Sanitizer';
 import Logger from './utils/logger';
 import * as path from 'path';
 import {SchemaModifier} from "./SchemaModifier";
+import type {OpenAPIV3} from "openapi-types";
 
 let config_filtered_path: string[] | undefined;
 try {
@@ -41,15 +42,13 @@ type PreprocessingOpts = {
 const opts = command.opts() as PreprocessingOpts;
 
 const logger = new Logger();
-const filter = new Filter(logger);
-const sanitizer = new Sanitizer();
-const schema_modifier = new SchemaModifier();
+
 try {
   logger.info(`PreProcessing ${opts.filtered_path.join(', ')} into ${opts.output} ...`)
-  const original_spec = read_yaml(opts.input);
-  const filtered_spec = filter.filter_spec(original_spec, opts.filtered_path);
-  const sanitized_spec = sanitizer.sanitize(filtered_spec);
-  const schema_modified_spec = schema_modifier.modify(sanitized_spec);
+  const original_spec = read_yaml(opts.input)
+  const filtered_spec = new Filter().filter_spec(original_spec, opts.filtered_path);
+  const sanitized_spec = new Sanitizer().sanitize(filtered_spec);
+  const schema_modified_spec = new SchemaModifier(sanitized_spec).modify();
   write_yaml(opts.output, schema_modified_spec);
 
 } catch (err) {

--- a/tools/proto-convert/src/SchemaModifier.ts
+++ b/tools/proto-convert/src/SchemaModifier.ts
@@ -1,24 +1,32 @@
 import type {OpenAPIV3} from "openapi-types";
-import { traverse } from './utils/OpenApiTraverser';
+import {traverse} from './utils/OpenApiTraverser';
 import isEqual from 'lodash.isequal';
-import { compressMultipleUnderscores } from './utils/helper';
+import {compressMultipleUnderscores, resolveObj} from './utils/helper';
+import Logger from "./utils/logger";
 
 
 export class SchemaModifier {
-    public modify(OpenApiSpec: OpenAPIV3.Document): any {
-        traverse(OpenApiSpec, {
+    logger: Logger
+    root: OpenAPIV3.Document;
+    constructor(root: OpenAPIV3.Document, logger: Logger = new Logger()) {
+        this.root = root;
+        this.logger = logger;
+    }
+    public modify(): OpenAPIV3.Document {
+        traverse(this.root, {
             onSchemaProperty: (schema) => {
                 this.handleAdditionalPropertiesUndefined(schema)
                 this.collapseOrMergeOneOfArray(schema)
             },
             onSchema: (schema, schemaName) => {
                 if (!schema || this.isReferenceObject(schema)) return;
+                this.handleAdditionalPropertiesUndefined(schema)
                 this.handleOneOfConst(schema, schemaName)
                 this.collapseOrMergeOneOfArray(schema)
-                this.handleAdditionalPropertiesUndefined(schema)
-            }
+                this.CollapseOneOfObjectPropContainsTitleSchema(schema)
+            },
         });
-        return OpenApiSpec;
+        return this.root
     }
 
     // Converts `additionalProperties: true` or `additionalProperties: {}` to `type: object`.
@@ -102,5 +110,83 @@ export class SchemaModifier {
             schema.type === 'array' &&
             'items' in schema
         );
+    }
+
+    /**
+     * Collapses a `oneOf` schema if one of the objects contains a title schema that matches
+     * a property in the other object.
+     *
+     * Example:
+     *  Input:
+     *  {
+     *    oneOf: [
+     *      { title: "exampleTitle", type: "string" },
+     *      { type: "object", properties: { exampleTitle: { type: "string" } } }
+     *    ]
+     *  }
+     *
+     *  Output:
+     *  {
+     *    type: "object",
+     *    properties: { exampleTitle: { type: "string" } }
+     *  }
+     **/
+    CollapseOneOfObjectPropContainsTitleSchema(schema: OpenAPIV3.SchemaObject): void {
+        // TODO: might need to handle oneOf more than 2
+        if (!Array.isArray(schema.oneOf) || schema.oneOf.length !== 2) {
+            return;
+        }
+        const[first, second] = schema.oneOf;
+        if (this.tryCollapseIfMatching(schema, first, second, 0)) return;
+        if (this.tryCollapseIfMatching(schema, second, first, 1)) return;
+    }
+    /**
+     * Attempts to collapse a `oneOf` schema by checking if a simple schema (with a title)
+     * matches a property in a complex schema. If a match is found, the parent schema
+     * is reconstructed by assigning the complex schema to it.
+     *
+     * */
+    private tryCollapseIfMatching(schema: OpenAPIV3.SchemaObject, maybeSimple: OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject,
+        maybeComplex: OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject, indexOfSimple: number): boolean {
+        let foundMath = false;
+        if (! ('title' in maybeSimple && typeof (maybeSimple.title) === 'string')) {
+            return false;
+        }
+        let titleContent = JSON.stringify(maybeSimple);
+        let nameStr = maybeSimple.title;
+
+        const complexObject = resolveObj(maybeComplex, this.root);
+        if (!complexObject) {
+            return false;
+        }
+        if (Array.isArray(complexObject.allOf)) {
+            for (const allOf of complexObject.allOf) {
+                const allOfObject = resolveObj(allOf, this.root);
+                if (allOfObject && allOfObject.properties && allOfObject.properties[nameStr]) {
+                    const propSchema =  allOfObject.properties[nameStr];
+                    if (('$ref' in propSchema && titleContent.includes(propSchema.$ref)) ||
+                        ('type' in propSchema && propSchema.type && titleContent.includes(propSchema.type))) {
+                        foundMath = true;
+                    }
+                }
+            }
+        } else if (complexObject.type === 'object' && complexObject.properties) {
+            if(complexObject.properties[nameStr] && '$ref' in complexObject.properties[nameStr]) {
+                const propSchema =  complexObject.properties[nameStr];
+                if (('$ref' in propSchema && titleContent.includes(propSchema.$ref)) ||
+                    ('type' in propSchema && typeof propSchema.type ==="string" && titleContent.includes(propSchema.type))) {
+                    foundMath = true;
+                }
+            }
+        }
+        // if complexSchema contains simpleSchema, reconstruct parent schema by assign complexSchema to parent schema.
+        if (foundMath) {
+            schema.oneOf?.splice(indexOfSimple, 1);
+            const [remaining] = schema.oneOf || [];
+            delete schema.oneOf;
+            Object.assign(schema, remaining);
+            return true;
+        }
+        return false;
     }
 }


### PR DESCRIPTION
### Description
Collapse oneOf if childComplexOneOf property contains child simpleOneOf

### Test Plan
```
Before:
    FuzzyQuery:
      oneOf:
        - title: value
          $ref: '#/components/schemas/FieldValue'
        - allOf:
            - $ref: '#/components/schemas/QueryBase'
            - type: object
              properties:
                max_expansions:
                  description: Maximum number of variations created.
                  type: integer
                  format: int32
                prefix_length:
                  description: Number of beginning characters left unchanged when creating expansions.
                  type: integer
                  format: int32
                rewrite:
                  $ref: '#/components/schemas/MultiTermQueryRewrite'
                transpositions:
                  description: Indicates whether edits include transpositions of two adjacent characters (for example, `ab` to `ba`).
                  type: boolean
                fuzziness:
                  $ref: '#/components/schemas/Fuzziness'
                value:
                  description: Term you wish to find in the provided field.
                  $ref: '#/components/schemas/FieldValue'
              required:
                - value
```
After:
```
    FuzzyQuery:
      allOf:
        - $ref: '#/components/schemas/QueryBase'
        - type: object
          properties:
            max_expansions:
              description: Maximum number of variations created.
              type: integer
              format: int32
            prefix_length:
              description: Number of beginning characters left unchanged when creating expansions.
              type: integer
              format: int32
            rewrite:
              $ref: '#/components/schemas/MultiTermQueryRewrite'
            transpositions:
              description: Indicates whether edits include transpositions of two adjacent characters (for example, `ab` to `ba`).
              type: boolean
            fuzziness:
              $ref: '#/components/schemas/Fuzziness'
            value:
              description: Term you wish to find in the provided field.
              $ref: '#/components/schemas/FieldValue'
          required:
            - value
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
