### PR TITLE
Add http code at the end of response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Using official protobuf generator. ([#91](https://github.com/opensearch-project/opensearch-protobufs/pull/91))
 - Preprocessing spec for deduplicating enum values. ([#93](https://github.com/opensearch-project/opensearch-protobufs/pull/93))
 - Address Generator Build Failure. ([#95](https://github.com/opensearch-project/opensearch-protobufs/pull/95))
+- Add http code at the end of response. ([#97](https://github.com/opensearch-project/opensearch-protobufs/pull/97))
 ### Removed
 
 ### Fixed

--- a/tools/proto-convert/src/config/protobuf-schema-template/api.mustache
+++ b/tools/proto-convert/src/config/protobuf-schema-template/api.mustache
@@ -35,7 +35,7 @@ message {{operationId}}Response {
 
     oneof response {
     {{#responses}}
-        {{{vendorExtensions.x-oneOf-response-type}}} {{vendorExtensions.x-oneOf-response-name}} = {{vendorExtensions.x-oneOf-response-index}};
+        {{{vendorExtensions.x-oneOf-response-type}}} {{vendorExtensions.x-oneOf-response-name}}_{{code}} = {{vendorExtensions.x-oneOf-response-index}};
     {{/responses}}
     }
 


### PR DESCRIPTION
### Description
Add http code at the end of response
### Issues Resolved
Tested in fork repository.
<img width="560" alt="image" src="https://github.com/user-attachments/assets/08cbd1cf-7b20-412c-9aaf-8497a06f86e8" />


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
