### PR TITLE
Add server-side streaming GRPC Search endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Preprocessing spec for deduplicating enum values. ([#93](https://github.com/opensearch-project/opensearch-protobufs/pull/93))
 - Address Generator Build Failure. ([#95](https://github.com/opensearch-project/opensearch-protobufs/pull/95))
 - Add http code at the end of response. ([#97](https://github.com/opensearch-project/opensearch-protobufs/pull/97))
+- Add GRPC Search server-side streaming endpoint ([#98](https://github.com/opensearch-project/opensearch-protobufs/pull/98))
+
 ### Removed
 
 ### Fixed

--- a/protos/services/search_service.proto
+++ b/protos/services/search_service.proto
@@ -20,4 +20,7 @@ import "protos/schemas/search.proto";
 
 service SearchService {
   rpc Search(SearchRequest) returns (SearchResponse) {}
+
+  // Server side grpc stream endpoint
+  rpc ServerStreamSearch(SearchRequest) returns (stream SearchResponse) {}
 }


### PR DESCRIPTION
### Description
Add a server-side streaming endpoint for Search

### Issues Resolved
Part of https://github.com/opensearch-project/OpenSearch/issues/18293

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
