### PR TITLE
Add bi-directional streaming Bulk GRPC endpoint

### DIFF
--- a/protos/services/document_service.proto
+++ b/protos/services/document_service.proto
@@ -22,6 +22,9 @@ service DocumentService {
   // Bulk add, update, or delete multiple documents in a single request.
   rpc Bulk(BulkRequest) returns (BulkResponse) {}
   
+  // Stream bulk requests to add, update, or delete multiple documents, and receive responses in a stream.
+  rpc StreamBulk(stream BulkRequest) returns (stream SearchResponse) {}
+  
   // Ingest a single document to an index
   rpc IndexDocument(IndexDocumentRequest) returns (IndexDocumentResponse) {}
 


### PR DESCRIPTION
### Description
Add the bulk bi-directional streaming endpoint to the GRPC DocumentService. 

### Issues Resolved
Related to https://github.com/opensearch-project/OpenSearch/issues/18293 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
