### PR TITLE
Add bi-directional streaming Bulk GRPC endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Address Generator Build Failure. ([#95](https://github.com/opensearch-project/opensearch-protobufs/pull/95))
 - Add http code at the end of response. ([#97](https://github.com/opensearch-project/opensearch-protobufs/pull/97))
 - Add GRPC Search server-side streaming endpoint ([#98](https://github.com/opensearch-project/opensearch-protobufs/pull/98))
+- Add bi-directional streaming Bulk GRPC endpoint ([#101](https://github.com/opensearch-project/opensearch-protobufs/pull/101))
 
 ### Removed
 

--- a/protos/services/document_service.proto
+++ b/protos/services/document_service.proto
@@ -22,6 +22,9 @@ service DocumentService {
   // Bulk add, update, or delete multiple documents in a single request.
   rpc Bulk(BulkRequest) returns (BulkResponse) {}
   
+  // Stream bulk requests to add, update, or delete multiple documents, and receive responses in a stream.
+  rpc StreamBulk(stream BulkRequest) returns (stream BulkResponse) {}
+  
   // Ingest a single document to an index
   rpc IndexDocument(IndexDocumentRequest) returns (IndexDocumentResponse) {}
 


### PR DESCRIPTION
### Description
Add the bulk bi-directional streaming endpoint to the GRPC DocumentService. 

### Issues Resolved
Related to https://github.com/opensearch-project/OpenSearch/issues/18293 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
