### PR TITLE
Bump version to 0.5.0 after release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,21 +4,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### Added
-- Add search API to generated proto ([#82](https://github.com/opensearch-project/opensearch-protobufs/pull/82))
-- Replace required property name from _* to underscore_* and remove duplicate __ from modified title ([#88](https://github.com/opensearch-project/opensearch-protobufs/pull/88))
-- Preprocessing spec for collapse oneOf if childComplexOneOf property contains child SimpleOneOf. ([#89](https://github.com/opensearch-project/opensearch-protobufs/pull/89))
-- Preprocessing spec for reconstructing a standard schema from single-key map. ([#90](https://github.com/opensearch-project/opensearch-protobufs/pull/90))
-- Using official protobuf generator. ([#91](https://github.com/opensearch-project/opensearch-protobufs/pull/91))
-- Preprocessing spec for deduplicating enum values. ([#93](https://github.com/opensearch-project/opensearch-protobufs/pull/93))
-- Address Generator Build Failure. ([#95](https://github.com/opensearch-project/opensearch-protobufs/pull/95))
-- Add http code at the end of response. ([#97](https://github.com/opensearch-project/opensearch-protobufs/pull/97))
-- Add GRPC Search server-side streaming endpoint ([#98](https://github.com/opensearch-project/opensearch-protobufs/pull/98))
-- Add bi-directional streaming Bulk GRPC endpoint ([#101](https://github.com/opensearch-project/opensearch-protobufs/pull/101))
-- Update KNN protos ([#103](https://github.com/opensearch-project/opensearch-protobufs/pull/103))
-- Update BoolQuery protos ([#105](https://github.com/opensearch-project/opensearch-protobufs/pull/105)
-- Update the maven snapshot publish endpoint and credential ([#107](https://github.com/opensearch-project/opensearch-protobufs/pull/107))  
-- Add oneof to QueryContainer and convert single-element maps to dedicated messages ([#106](https://github.com/opensearch-project/opensearch-protobufs/pull/106)
-- Update maven publishing workflow to accommodate nexus EOL ([#112](https://github.com/opensearch-project/opensearch-protobufs/pull/112)
 - Fix WildcardQuery protos ([#117](https://github.com/opensearch-project/opensearch-protobufs/pull/117)
 
 ### Removed

--- a/release-notes/opensearch-protobufs.release-notes-0.2.0.md
+++ b/release-notes/opensearch-protobufs.release-notes-0.2.0.md
@@ -1,4 +1,4 @@
-## Version 0.1.0 (2025-04-08) Release Notes
+## Version 0.2.0 (2025-04-07) Release Notes
 
 ### Added
 - Bump version.properties and update changelog after 0.1.0 release  ([#51](https://github.com/opensearch-project/opensearch-protobufs/pull/51))

--- a/release-notes/opensearch-protobufs.release-notes-0.3.0.md
+++ b/release-notes/opensearch-protobufs.release-notes-0.3.0.md
@@ -1,4 +1,4 @@
-## Version 0.1.0 (2025-04-08) Release Notes
+## Version 0.3.0 (2025-04-10) Release Notes
 
 ### Added
 - Preprocessing specification for additionalProperties ([#70](https://github.com/opensearch-project/opensearch-protobufs/pull/70)))

--- a/release-notes/opensearch-protobufs.release-notes-0.4.0.md
+++ b/release-notes/opensearch-protobufs.release-notes-0.4.0.md
@@ -1,0 +1,24 @@
+## Version 0.1.0 (2025-04-08) Release Notes
+
+### Added
+- Add search API to generated proto ([#82](https://github.com/opensearch-project/opensearch-protobufs/pull/82))
+- Replace required property name from _* to underscore_* and remove duplicate __ from modified title ([#88](https://github.com/opensearch-project/opensearch-protobufs/pull/88))
+- Preprocessing spec for collapse oneOf if childComplexOneOf property contains child SimpleOneOf. ([#89](https://github.com/opensearch-project/opensearch-protobufs/pull/89))
+- Preprocessing spec for reconstructing a standard schema from single-key map. ([#90](https://github.com/opensearch-project/opensearch-protobufs/pull/90))
+- Using official protobuf generator. ([#91](https://github.com/opensearch-project/opensearch-protobufs/pull/91))
+- Preprocessing spec for deduplicating enum values. ([#93](https://github.com/opensearch-project/opensearch-protobufs/pull/93))
+- Address Generator Build Failure. ([#95](https://github.com/opensearch-project/opensearch-protobufs/pull/95))
+- Add http code at the end of response. ([#97](https://github.com/opensearch-project/opensearch-protobufs/pull/97))
+- Add GRPC Search server-side streaming endpoint ([#98](https://github.com/opensearch-project/opensearch-protobufs/pull/98))
+- Add bi-directional streaming Bulk GRPC endpoint ([#101](https://github.com/opensearch-project/opensearch-protobufs/pull/101))
+- Update KNN protos ([#103](https://github.com/opensearch-project/opensearch-protobufs/pull/103))
+- Update BoolQuery protos ([#105](https://github.com/opensearch-project/opensearch-protobufs/pull/105)
+- Update the maven snapshot publish endpoint and credential ([#107](https://github.com/opensearch-project/opensearch-protobufs/pull/107))  
+- Add oneof to QueryContainer and convert single-element maps to dedicated messages ([#106](https://github.com/opensearch-project/opensearch-protobufs/pull/106)
+- Update maven publishing workflow to accommodate nexus EOL ([#112](https://github.com/opensearch-project/opensearch-protobufs/pull/112)
+
+### Removed
+
+### Fixed
+
+### Security

--- a/release-notes/opensearch-protobufs.release-notes-0.4.0.md
+++ b/release-notes/opensearch-protobufs.release-notes-0.4.0.md
@@ -1,4 +1,4 @@
-## Version 0.1.0 (2025-04-08) Release Notes
+## Version 0.4.0 (2025-07-13) Release Notes
 
 ### Added
 - Add search API to generated proto ([#82](https://github.com/opensearch-project/opensearch-protobufs/pull/82))

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=0.4.0
+version=0.5.0


### PR DESCRIPTION
### Description
After 0.4.0 release, do chore to bump version and update release notes.

Fix dates and version numbers in previous release notes as well.

### Issues Resolved
Chore 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
