### PR TITLE
Fix `fuzzy_transpositions` in MultiMatchQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,5 +10,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 
 ### Fixed
+- Fix `fuzzy_transpositions` in MultiMatchQuery ([#120](https://github.com/opensearch-project/opensearch-protobufs/pull/120)
 
 ### Security

--- a/protos/schemas/common.proto
+++ b/protos/schemas/common.proto
@@ -2237,16 +2237,7 @@ message MultiMatchQuery {
   optional string fuzzy_rewrite = 7;
 
   // [optional] Setting fuzzy_transpositions to true (default) adds swaps of adjacent characters to the insert, delete, and substitute operations of the fuzziness option. For example, the distance between wind and wnid is 1 if fuzzy_transpositions is true (swap “n” and “i”) and 2 if it is false (delete “n”, insert “n”). If fuzzy_transpositions is false, rewind and wnid have the same distance (2) from wind, despite the more human-centric opinion that wnid is an obvious typo. The default is a good choice for most use cases.
-  optional MultiTermQueryRewrite fuzzy_transpositions = 8;
-  enum MultiTermQueryRewrite {
-    MULTI_TERM_QUERY_REWRITE_UNSPECIFIED = 0;
-    MULTI_TERM_QUERY_REWRITE_CONSTANT_SCORE = 1;
-    MULTI_TERM_QUERY_REWRITE_CONSTANT_SCORE_BOOLEAN = 2;
-    MULTI_TERM_QUERY_REWRITE_SCORING_BOOLEAN = 3;
-    MULTI_TERM_QUERY_REWRITE_TOP_TERMS_N = 4;
-    MULTI_TERM_QUERY_REWRITE_TOP_TERMS_BLENDED_FREQS_N = 5;
-    MULTI_TERM_QUERY_REWRITE_TOP_TERMS_BOOST_N = 6;
-  }
+  optional bool fuzzy_transpositions = 8;
 
   // [optional] Setting lenient to true ignores data type mismatches between the query and the document field. For example, a query string of "8.2" could match a field of type float. Default is false.
   optional bool lenient = 9;


### PR DESCRIPTION
### Description
Fix `fuzzy_transpositions` in MultiMatchQuery
According to the code, it is a boolean: https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/index/query/MultiMatchQueryBuilder.java#L117

### Issues Resolved
#30 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
