### PR TITLE
Force form-data 4.0.4 to resolve CVE-2025-7783

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,5 +12,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 - Fix `fuzzy_transpositions` in MultiMatchQuery ([#120](https://github.com/opensearch-project/opensearch-protobufs/pull/120)
+- Bump form-data to 4.0.4 for CVE-2025-7783 ([#123](https://github.com/opensearch-project/opensearch-protobufs/pull/123)
 
 ### Security

--- a/package-lock.json
+++ b/package-lock.json
@@ -5112,13 +5112,15 @@
       }
     },
     "node_modules/es-set-tostringtag": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
-      "integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
       "dependencies": {
-        "get-intrinsic": "^1.2.4",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
         "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.1"
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6133,12 +6135,15 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -12982,7 +12987,7 @@
       "integrity": "sha1-eJkLtLxj0srgcpUtN0g1lQqC9Ec=",
       "requires": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -13747,13 +13752,14 @@
       }
     },
     "es-set-tostringtag": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
-      "integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
       "requires": {
-        "get-intrinsic": "^1.2.4",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
         "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.1"
+        "hasown": "^2.0.2"
       }
     },
     "es-shim-unscopables": {
@@ -14448,12 +14454,14 @@
       }
     },
     "form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       }
     },

--- a/package.json
+++ b/package.json
@@ -61,5 +61,8 @@
     "jest": "^29.7.0",
     "ts-jest": "^29.3.0",
     "typescript": "^5.8.2"
+  },
+  "overrides": {
+    "form-data": "4.0.4"
   }
 }


### PR DESCRIPTION
### Description
Forces form-data 4.0.4.

```
npm ls form-data
opensearch_api_tools@1.0.0
└─┬ axios@1.8.4
  └── form-data@4.0.4 overridden
```

### Testing
Quick test filtering for bulk apis with most recent api spec yml.
```
~/fdev/repos/opensearch-protobufs (CVE-2025-7783 ✔) npm run preprocessing -- --filtered_path "/_bulk","/{index}/_bulk"

> opensearch_api_tools@1.0.0 preprocessing
> ts-node tools/proto-convert/src/PreProcessing.ts --filtered_path /_bulk,/{index}/_bulk

[INFO] PreProcessing /_bulk, /{index}/_bulk into /Users/carrofin/fdev/repos/opensearch-protobufs/build/processed-opensearch-openapi.yaml ...
[INFO] Done.
~/fdev/repos/opensearch-protobufs (CVE-2025-7783 ✔) head build/processed-opensearch-openapi.yaml
openapi: 3.1.0
info:
  title: OpenSearch API Specification
  version: 0.2.0
  x-api-version: 2.16.0
paths:
  /{index}/_bulk:
    post:
      operationId: bulk
      x-operation-group: bulk
~/fdev/repos/opensearch-protobufs (CVE-2025-7783 ✔)
```

### Issues Resolved
CVE issue - https://github.com/opensearch-project/opensearch-protobufs/issues/122

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
