### PR TITLE
Bump version to 0.6.0 after 0.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,9 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### Added
-- Fix WildcardQuery protos ([#117](https://github.com/opensearch-project/opensearch-protobufs/pull/117)
-- Fix MultiMatchQuery protos ([#119](https://github.com/opensearch-project/opensearch-protobufs/pull/119)
-- Fix RegexpQuery and ExistsQuery protos ([#121](https://github.com/opensearch-project/opensearch-protobufs/pull/121)
 
 ### Removed
 
 ### Fixed
-- Fix `fuzzy_transpositions` in MultiMatchQuery ([#120](https://github.com/opensearch-project/opensearch-protobufs/pull/120)
-- Bump form-data to 4.0.4 for CVE-2025-7783 ([#123](https://github.com/opensearch-project/opensearch-protobufs/pull/123)
 
 ### Security

--- a/release-notes/opensearch-protobufs.release-notes-0.5.0.md
+++ b/release-notes/opensearch-protobufs.release-notes-0.5.0.md
@@ -1,0 +1,14 @@
+## Version 0.5.0 (2025-07-23) Release Notes
+
+### Added
+- Fix WildcardQuery protos ([#117](https://github.com/opensearch-project/opensearch-protobufs/pull/117)
+- Fix MultiMatchQuery protos ([#119](https://github.com/opensearch-project/opensearch-protobufs/pull/119)
+- Fix RegexpQuery and ExistsQuery protos ([#121](https://github.com/opensearch-project/opensearch-protobufs/pull/121)
+
+### Removed
+
+### Fixed
+- Fix `fuzzy_transpositions` in MultiMatchQuery ([#120](https://github.com/opensearch-project/opensearch-protobufs/pull/120)
+- Bump form-data to 4.0.4 for CVE-2025-7783 ([#123](https://github.com/opensearch-project/opensearch-protobufs/pull/123)
+
+### Security

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=0.5.0
+version=0.6.0


### PR DESCRIPTION
### Description
Follow RELEASING.md to clean up after most recent release

### Issues Resolved
Chore

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
