### PR TITLE
Upgrade lib version to accommodate maven publication changes

### DIFF
--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -1,4 +1,4 @@
-lib = library(identifier: 'jenkins@10.0.1', retriever: modernSCM([
+lib = library(identifier: 'jenkins@10.2.1', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))


### PR DESCRIPTION
### Description
The new version has a refactored script that upgrades maven plugin version as suggested by support team at maven central as well as replaced plugin action with API call since migration broke the compatibility. 

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/5552

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
