### PR TITLE
Add Go protobuf generation support

### DIFF
--- a/.github/workflows/build-protobufs-go.yml
+++ b/.github/workflows/build-protobufs-go.yml
@@ -1,0 +1,18 @@
+name: Build OpenSearch Protobufs GO Artifacts
+
+on:
+  pull_request:
+
+jobs:
+  build-protobufs-go:
+    runs-on: ubuntu-latest
+    if: github.repository == 'opensearch-project/opensearch-protobufs'
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin # Temurin is a distribution of adoptium
+          java-version: 21
+      - name: build protobufs go
+        run: bazel build //:go_protos_all

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
 package(default_visibility = ["//visibility:public"])
 
 java_library(
@@ -21,5 +23,17 @@ py_library(
         "//protos/schemas:search_python_proto",
         "//protos/services:document_service_python_proto",
         "//protos/services:search_service_python_proto",
+    ],
+)
+
+go_library(
+    name = "go_protos_all",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//protos/schemas:common_go_proto",
+        "//protos/schemas:document_go_proto",
+        "//protos/schemas:search_go_proto",
+        "//protos/services:document_service_go_proto",
+        "//protos/services:search_service_go_proto",
     ],
 )

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add support for generating python schema and gRPC libraries. ([#114](https://github.com/opensearch-project/opensearch-protobufs/pull/114))
 - Fix IdsQuery protos ([#128](https://github.com/opensearch-project/opensearch-protobufs/pull/128))
 - Fix `boost` and `underscore_name` fields for query types protos ([#129](https://github.com/opensearch-project/opensearch-protobufs/pull/129))
+- Add Go protobuf generation support ([#131](https://github.com/opensearch-project/opensearch-protobufs/pull/131))
 
 ### Removed
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -18,6 +18,11 @@ bazel build //:java_protos_all
 bazel build //:python_protos_all
 ```
 
+## Go
+```
+bazel build //:go_protos_all
+```
+
 # Proto generated code
 ## Java
 ### Generate Java Code and packaging as a Maven/Gradle dependency

--- a/README.md
+++ b/README.md
@@ -2,12 +2,125 @@
 
 This repository stores the Protobufs and generated code used for client <> server GRPC APIs.
 
-The [opensearch-api-specification repo](https://github.com/opensearch-project/opensearch-api-specification)  will continue to be the source of truth, and these protobufs will mostly be a downstream consumer of the spec.
+The [opensearch-api-specification repo](https://github.com/opensearch-project/opensearch-api-specification) will continue to be the source of truth, and these protobufs will mostly be a downstream consumer of the spec.
 
 This repository will also include a variety of tooling and CI, linters and validators, and generated code, which is described in more detail below.
 
+## Quick Start
+
+### Build Protobuf Libraries
+
+Generate protobuf libraries for your preferred language:
+
+```bash
+# Java
+bazel build //:java_protos_all
+
+# Python
+bazel build //:python_protos_all
+
+# Go
+bazel build //:go_protos_all
+
+# All languages
+bazel build //:java_protos_all //:python_protos_all //:go_protos_all
+```
+
+### Docker Build Options
+
+Use Docker to build and test protobuf libraries:
+
+```bash
+# Java
+docker build --target build-bazel-java .
+docker build --target package-bazel-java .
+docker build --target test-bazel-java .
+
+# Python
+docker build --target build-bazel-python .
+
+# Go
+docker build --target build-bazel-go .
+docker build --target package-bazel-go .
+docker build --target test-bazel-go .
+```
+
+## Generated Code Usage
+
+### Go
+
+```go
+import (
+    "github.com/opensearch-project/opensearch-protobufs/go/opensearchpb"
+    "github.com/opensearch-project/opensearch-protobufs/go/services"
+)
+
+// Use generated message types
+request := &opensearchpb.SearchRequest{
+    Query: "elasticsearch",
+    Size:  10,
+}
+
+// Use generated gRPC clients
+client := services.NewSearchServiceClient(conn)
+response, err := client.Search(ctx, request)
+```
+
+### Java
+
+```java
+import org.opensearch.protobufs.SearchRequest;
+import org.opensearch.protobufs.services.SearchServiceGrpc;
+
+// Use generated message types
+SearchRequest request = SearchRequest.newBuilder()
+    .setQuery("elasticsearch")
+    .setSize(10)
+    .build();
+
+// Use generated gRPC clients
+SearchServiceGrpc.SearchServiceBlockingStub client =
+    SearchServiceGrpc.newBlockingStub(channel);
+SearchResponse response = client.search(request);
+```
+
+### Python
+
+```python
+from opensearch_pb2 import SearchRequest
+from search_service_pb2_grpc import SearchServiceStub
+
+# Use generated message types
+request = SearchRequest()
+request.query = "elasticsearch"
+request.size = 10
+
+# Use generated gRPC clients
+client = SearchServiceStub(channel)
+response = client.Search(request)
+```
+
+## Generated Code Locations
+
+After building, find generated code in:
+
+```bash
+# Go
+bazel-bin/protos/schemas/*_go_proto_pb/protos/schemas/*.pb.go
+bazel-bin/protos/services/*_go_proto_pb/protos/services/*.pb.go
+
+# Java
+bazel-bin/libjava_protos_all.jar
+
+# Python
+bazel-bin/protos/schemas/*_python_proto_pb/protos/schemas/*_pb2.py
+bazel-bin/protos/services/*_python_proto_pb/protos/services/*_pb2.py
+```
+
 ## Intended usage of the repo
+
 The repo will consist of:
+
 1. **Protobufs**
     - Raw `*.proto` files based on the API spec
     - Build files/tooling to compile the protobufs
@@ -21,3 +134,18 @@ The repo will consist of:
 
 4. **Linters/Validators (TBD)**
     - Tooling to validate and lint the generated `*.proto` files, to ensure they conform to Google's protobuf best practices, as well as conventions established within the OpenSearch org (more important for any portions that are hand-rolled)
+
+## Development
+
+For development documentation, see [DEVELOPER_GUIDE.md](./DEVELOPER_GUIDE.md).
+
+## CI/CD
+
+GitHub Actions workflows automatically validate protobuf builds:
+- `build-protobufs-java.yml` - Validates Java protobuf generation
+- `build-protobufs-python.yml` - Validates Python protobuf generation
+- `build-protobufs-go.yml` - Validates Go protobuf generation
+
+## Contributing
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for contribution guidelines.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -102,8 +102,15 @@ rules_proto_grpc_python_repos()
 load("@rules_proto_grpc//java:repositories.bzl", rules_proto_grpc_java_repos = "java_repos")
 rules_proto_grpc_java_repos()
 
+load("@rules_proto_grpc//go:repositories.bzl", rules_proto_grpc_go_repos = "go_repos")
+rules_proto_grpc_go_repos()
+
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+go_rules_dependencies()
+go_register_toolchains()
+
 """
-Dependencies for java gRPC rules are sourced from maven. 
+Dependencies for java gRPC rules are sourced from maven.
 """
 
 load("@rules_jvm_external//:defs.bzl", "maven_install")

--- a/protos/schemas/BUILD.bazel
+++ b/protos/schemas/BUILD.bazel
@@ -2,6 +2,7 @@
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@rules_proto_grpc//java:defs.bzl", "java_proto_library")
 load("@rules_proto_grpc//python:defs.bzl", "python_proto_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -59,4 +60,21 @@ python_proto_library(
 python_proto_library(
     name = "search_python_proto",
     protos = [":search_proto"],
+)
+
+go_proto_library(
+    name = "common_go_proto",
+    protos = [":common_proto"],
+)
+
+go_proto_library(
+    name = "document_go_proto",
+    protos = [":document_proto"],
+    deps = [":common_go_proto"],
+)
+
+go_proto_library(
+    name = "search_go_proto",
+    protos = [":search_proto"],
+    deps = [":common_go_proto"],
 )

--- a/protos/schemas/common.proto
+++ b/protos/schemas/common.proto
@@ -6,7 +6,7 @@ syntax = "proto3";
 option java_multiple_files = true;
 option java_package = "org.opensearch.protobufs";
 option java_outer_classname = "CommonProto";
-option go_package = "opensearchpb";
+option go_package = "github.com/opensearch-project/opensearch-protobufs/go/opensearchpb";
 
 import "google/protobuf/struct.proto";
 
@@ -89,7 +89,7 @@ message ObjectMap {
       ListValue list_value = 9;
     }
   }
-  
+
   // `ListValue` is a wrapper around a repeated field of values.
   // The JSON representation for `ListValue` is JSON array.
   message ListValue {
@@ -259,10 +259,10 @@ message ErrorCause {
 
   optional string index_uuid = 9;
 
-  // [optional] The spec actually does not have a field named 'metadata'. This should have adaptor_unnest. 
+  // [optional] The spec actually does not have a field named 'metadata'. This should have adaptor_unnest.
   map<string, ObjectMap.Value> metadata = 10;
 
-  // [optional] 
+  // [optional]
   map<string, StringOrStringArray> header = 11;
 }
 message ShardStatistics {
@@ -430,7 +430,7 @@ message NestedQuery {
 
   // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
   optional float boost = 1;
-  
+
   // [optional] Query name for query tagging.
   optional string underscore_name = 2 [json_name = "_name"];
 
@@ -923,7 +923,7 @@ message ScriptScoreQuery {
 
   // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
   optional float boost = 1;
-  
+
   // [optional] Query name for query tagging.
   optional string underscore_name = 2 [json_name = "_name"];
 
@@ -942,7 +942,7 @@ message ExistsQuery {
 
   // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
   optional float boost = 2;
-  
+
   // [optional] Query name for query tagging.
   optional string underscore_name = 3 [json_name = "_name"];
 }
@@ -957,7 +957,7 @@ message SimpleQueryStringQuery {
 
   // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
   optional float boost = 1;
-  
+
   // [optional] Query name for query tagging.
   optional string underscore_name = 2 [json_name = "_name"];
 
@@ -1057,8 +1057,8 @@ message PipeSeparatedFlagsSimpleQueryStringFlag {
 
 message KnnQuery {
   // [required] Specifies the vector field against which to run a search query
-  string field = 1; 
-  
+  string field = 1;
+
   // [optional]
   // Query vector. Must have the same number of dimensions as the vector field you are searching against.
   repeated float vector = 2;
@@ -1094,7 +1094,7 @@ message KnnQuery {
   // Available in version later than 2.17
   // To explicitly apply rescoring, provide the rescore parameter in a query on a quantized index and specify the oversample_factor "https://opensearch.org/docs/latest/search-plugins/knn/approximate-knn/#rescoring-quantized-results-using-full-precision"
   optional KnnQueryRescore rescore = 10;
-  
+
   // [optional] When true, retrieves scores for all nested field documents within each parent document. Used with nested queries. For more information, see Vector search with nested fields.
   optional bool expand_nested_docs = 11;
 
@@ -1126,7 +1126,7 @@ message MatchQuery {
 
   // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
   optional float boost = 1;
-  
+
   // [optional] Query name for query tagging.
   optional string underscore_name = 2 [json_name = "_name"];
 
@@ -1260,7 +1260,7 @@ message BoolQuery {
 
   // [optional] The clause (query) should appear in the matching document.
   repeated QueryContainer should = 7;
-  
+
   // [optional] Ensures correct behavior when a query contains only `must_not` clauses. By default set to true, OpenSearch adds a match-all clause to ensure results are returned from Lucene, with the `must_not` conditions applied as filters. If set to false, the query may return no results, as Lucene typically requires at least one positive condition.
   optional bool adjust_pure_negative = 8;
 }
@@ -1278,7 +1278,7 @@ message BoostingQuery {
 
   // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
   optional float boost = 1;
-  
+
   // [optional] Query name for query tagging.
   optional string underscore_name = 2 [json_name = "_name"];
 
@@ -1295,7 +1295,7 @@ message ConstantScoreQuery {
 
   // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
   optional float boost = 1;
-  
+
   // [optional] Query name for query tagging.
   optional string underscore_name = 2 [json_name = "_name"];
 
@@ -1307,7 +1307,7 @@ message DisMaxQuery {
 
   // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
   optional float boost = 1;
-  
+
   // [optional] Query name for query tagging.
   optional string underscore_name = 2 [json_name = "_name"];
 
@@ -1323,7 +1323,7 @@ message FunctionScoreQuery {
 
   // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
   optional float boost = 1;
-  
+
   // [optional] Query name for query tagging.
   optional string underscore_name = 2 [json_name = "_name"];
 
@@ -1415,7 +1415,7 @@ message IntervalsQuery {
 
   // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
   optional float boost = 2;
-  
+
   // [optional] Query name for query tagging.
   optional string underscore_name = 3 [json_name = "_name"];
 
@@ -1512,7 +1512,7 @@ message PrefixQuery {
 
   // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
   optional float boost = 2;
-  
+
   // [optional] Query name for query tagging.
   optional string underscore_name = 3 [json_name = "_name"];
 
@@ -1569,13 +1569,13 @@ enum ValueType {
 message TermsQueryField {
   // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
   optional float boost = 1;
-  
+
   // [optional] Query name for query tagging.
   optional string underscore_name = 2 [json_name = "_name"];
-  
+
   // [optional] Specifies the types of values used for filtering. Valid values are default and bitmap. If omitted, the value defaults to default.
-  optional ValueType value_type = 3; 
-  
+  optional ValueType value_type = 3;
+
   // [required]
   map<string, TermsLookupFieldStringArrayMap> terms_lookup_field_string_array_map = 4;
 }
@@ -1597,19 +1597,19 @@ message TermsLookupField {
   // [optional]
   // Custom routing value of the document from which to fetch term values. If a custom routing value was provided when the document was indexed, this parameter is required.
   optional string routing = 4;
-  
-  // [optional] 
+
+  // [optional]
   optional bool store = 5;
-  
+
 }
 
 message TermsSetQuery {
   // [required] Specifies the field against which to run a search query
   string field = 1;
-  
+
   // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
   optional float boost = 2;
-  
+
   // [optional] Query name for query tagging.
   optional string underscore_name = 3 [json_name = "_name"];
 
@@ -1633,7 +1633,7 @@ message TermQuery {
 
   // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
   optional float boost = 2;
-  
+
   // [optional] Query name for query tagging.
   optional string underscore_name = 3 [json_name = "_name"];
 
@@ -1651,7 +1651,7 @@ message TermQuery {
 message QueryStringQuery {
   // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
   optional float boost = 1;
-  
+
   // [optional] Query name for query tagging.
   optional string underscore_name = 2 [json_name = "_name"];
 
@@ -1758,7 +1758,7 @@ message RandomScoreFunction {
 message RangeQuery {
   // [required] Specifies the field against which to run a search query
   string field = 1;
-  
+
   oneof range_query{
     DateRangeQuery date_range_query = 2;
     NumberRangeQuery number_range_query = 3;
@@ -1768,7 +1768,7 @@ message RangeQuery {
 message RegexpQuery {
   // [required] Specifies the field against which to run a search query
   string field = 1;
-  
+
   // [required] Regular expression for terms you wish to find in the provided field.
   string value = 2;
 
@@ -1804,7 +1804,7 @@ message DateRangeQuery {
 
   // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
   optional float boost = 1;
-  
+
   // [optional] Query name for query tagging.
   optional string underscore_name = 2 [json_name = "_name"];
 
@@ -1851,7 +1851,7 @@ message NumberRangeQuery {
 
   // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
   optional float boost = 1;
-  
+
   // [optional] Query name for query tagging.
   optional string underscore_name = 2 [json_name = "_name"];
 
@@ -1901,7 +1901,7 @@ message FuzzyQuery {
 
   // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
   optional float boost = 2;
-  
+
   // [optional] Query name for query tagging.
   optional string underscore_name = 3 [json_name = "_name"];
 
@@ -1981,7 +1981,7 @@ message IdsQuery {
 
   // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
   optional float boost = 1;
-  
+
   // [optional] Query name for query tagging.
   optional string underscore_name = 2 [json_name = "_name"];
 
@@ -2039,7 +2039,7 @@ message IntervalsWildcard {
 message MatchAllQuery {
   // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
   optional float boost = 1;
-  
+
   // [optional] Query name for query tagging.
   optional string underscore_name = 2 [json_name = "_name"];
 }
@@ -2047,7 +2047,7 @@ message MatchAllQuery {
 message MatchBoolPrefixQuery {
   // [required] Specifies the field against which to run a search query
   string field = 1;
-  
+
   // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
   optional float boost = 2;
 
@@ -2110,7 +2110,7 @@ message MatchBoolPrefixQuery {
   // If the query string contains multiple search terms, whether all terms need to match (and) or only one term needs to match (or) for a document to be considered a match.
   // Default is or.
   Operator operator = 10;
-  
+
   // [optional]
   // The number of leading characters that are not considered in fuzziness.
   // Default is 0.
@@ -2126,7 +2126,7 @@ message MatchNoneQuery {
 
   // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
   optional float boost = 1;
-  
+
   // [optional] Query name for query tagging.
   optional string underscore_name = 2 [json_name = "_name"];
 }
@@ -2143,7 +2143,7 @@ enum ZeroTermsQuery {
 message MatchPhrasePrefixQuery {
   // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
   optional float boost = 1;
-  
+
   // [optional] Query name for query tagging.
   optional string underscore_name = 2 [json_name = "_name"];
 
@@ -2240,7 +2240,7 @@ message MultiMatchQuery {
 
   // [optional] If the query string contains multiple search terms, whether all terms need to match (AND) or only one term needs to match (OR) for a document to be considered a match. Valid values are: 1) OR: The string to be is interpreted as to OR be. 2) AND: The string to be is interpreted as to AND be. Default is OR.
   optional Operator operator = 12;
-  
+
   // [optional] The number of leading characters that are not considered in fuzziness. Default is 0.
   optional int32 prefix_length = 13;
 

--- a/protos/schemas/document.proto
+++ b/protos/schemas/document.proto
@@ -6,7 +6,7 @@ syntax = "proto3";
 option java_multiple_files = true;
 option java_package = "org.opensearch.protobufs";
 option java_outer_classname = "DocumentProto";
-option go_package = "opensearchpb";
+option go_package = "github.com/opensearch-project/opensearch-protobufs/go/opensearchpb";
 
 import "google/protobuf/struct.proto";
 import "protos/schemas/common.proto";

--- a/protos/schemas/search.proto
+++ b/protos/schemas/search.proto
@@ -7,7 +7,7 @@ syntax = "proto3";
 option java_multiple_files = true;
 option java_package = "org.opensearch.protobufs";
 option java_outer_classname = "SearchProto";
-option go_package = "opensearchpb";
+option go_package = "github.com/opensearch-project/opensearch-protobufs/go/opensearchpb";
 
 import "google/protobuf/struct.proto";
 import "protos/schemas/common.proto";
@@ -213,15 +213,15 @@ message SearchRequestBody {
 
   // [optional] Profile provides timing information about the execution of individual components of a search request. Using the Profile API, you can debug slow requests and understand how to improve their performance.
   optional bool profile = 13;
-  
+
   // [optional] Customizable sequence of processing stages applied to search queries.
   // TODO add to spec
   optional string search_pipeline = 14;
-  
+
   // [optional] Enables or disables verbose mode for the search pipeline.
   // TODO add to spec
   optional bool verbose_pipeline = 15;
-  
+
   // [optional] The DSL query to use in the request.
   optional QueryContainer query = 16;
 
@@ -264,7 +264,7 @@ message SearchRequestBody {
   // [optional] Whether to return scores with named queries. Default is false.
   // TODO add to spec
   optional bool include_named_queries_score = 29;
-  
+
   // [optional] Whether to include the document version in the response.
   optional bool version = 30;
 
@@ -283,8 +283,8 @@ message SearchRequestBody {
   // [optional] Defines the aggregations that are run as part of the search request.
   // TODO not supported yet
   // map<string, AggregationContainer> aggs = 32;
-    
-  // [optional] 
+
+  // [optional]
   // TODO add to spec (since 2.14)
   map<string, DerivedField> derived = 35;
 }
@@ -523,7 +523,7 @@ message Hit {
 
   // [optional] Sorted values
   repeated FieldValue sort = 20;
-  
+
   // [optional] Contains metadata values for the documents.
   // TODO: No field named "meta_fields" in the spec. Needs adaptor_unnest.
   optional ObjectMap meta_fields = 21;
@@ -743,7 +743,7 @@ message SearchProfile {
   int64 rewrite_time = 3;
 
 }
- 
+
 message NumberMap {
   map<string, float> number_map = 1;
 }

--- a/protos/services/BUILD.bazel
+++ b/protos/services/BUILD.bazel
@@ -2,6 +2,7 @@
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@rules_proto_grpc//java:defs.bzl", "java_grpc_library")
 load("@rules_proto_grpc//python:defs.bzl", "python_grpc_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_grpc_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -37,4 +38,16 @@ python_grpc_library(
 python_grpc_library(
     name = "search_service_python_proto",
     protos = [":search_service_proto"],
+)
+
+go_grpc_library(
+    name = "document_service_go_proto",
+    protos = [":document_service_proto"],
+    deps = ["//protos/schemas:document_go_proto"],
+)
+
+go_grpc_library(
+    name = "search_service_go_proto",
+    protos = [":search_service_proto"],
+    deps = ["//protos/schemas:search_go_proto"],
 )

--- a/protos/services/document_service.proto
+++ b/protos/services/document_service.proto
@@ -15,16 +15,17 @@ package org.opensearch.protobufs.services;
 option java_multiple_files = true;
 option java_package = "org.opensearch.protobufs.services";
 option java_outer_classname = "DocumentServiceProto";
+option go_package = "github.com/opensearch-project/opensearch-protobufs/go/services";
 
 import "protos/schemas/document.proto";
 
 service DocumentService {
   // Bulk add, update, or delete multiple documents in a single request.
   rpc Bulk(BulkRequest) returns (BulkResponse) {}
-  
+
   // Stream bulk requests to add, update, or delete multiple documents, and receive responses in a stream.
   rpc StreamBulk(stream BulkRequest) returns (stream BulkResponse) {}
-  
+
   // Ingest a single document to an index
   rpc IndexDocument(IndexDocumentRequest) returns (IndexDocumentResponse) {}
 

--- a/protos/services/search_service.proto
+++ b/protos/services/search_service.proto
@@ -15,6 +15,7 @@ package org.opensearch.protobufs.services;
 option java_multiple_files = true;
 option java_package = "org.opensearch.protobufs.services";
 option java_outer_classname = "SearchServiceProto";
+option go_package = "github.com/opensearch-project/opensearch-protobufs/go/services";
 
 import "protos/schemas/search.proto";
 


### PR DESCRIPTION
### Description
Add Go protobuf generation support with build pipeline including: Bazel targets, GHA CI, Docker packaging stages, and documentation updates.

- Add Go rules and dependencies to WORKSPACE
- Configure go_package options in all proto files with proper import paths
- Create go_protos_all target in BUILD.bazel combining schemas and services
- Add GitHub Actions workflow for Go protobuf builds
- Install golang-go in base Docker image
- Create packaged artifacts for distribution
- Update DEVELOPER_GUIDE.md and README with changes

### Issues Resolved
#8 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
