### PR TITLE
Update jenkins to 10.2.2 to resolve trailing space issues

### DIFF
--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -1,4 +1,4 @@
-lib = library(identifier: 'jenkins@10.2.1', retriever: modernSCM([
+lib = library(identifier: 'jenkins@10.2.2', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))


### PR DESCRIPTION
### Description
Context: https://opensearch.slack.com/archives/C07ALF6A746/p1753926922150319

The protobufs 0.6.0 release is stuck in draft mode: https://github.com/opensearch-project/opensearch-protobufs/releases, because the Jenkins job https://build.ci.opensearch.org/job/opensearch-protobufs-release/9/consoleFull failed due to:
```
Failed to close and release staging repository 78d7607cc6e881--f77f15b0-3ab0-4db5-9f36-1331ed6c3630. Response code: Failed to process request: trailing characters at line 5 column 8400
Please release the staging repository manually via Sonatype portal https://central.sonatype.com/publishing .
```
The new lib version resolves the trailing space issues

### Issues Resolved
Chore

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
