### PR TITLE
Add protobuf zip generation for releases

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -2,8 +2,9 @@ name: Release drafter
 
 # Push events to every tag not containing "/"
 #
-# Publish the commons JAR to Maven Local, and create 'artifacts.tar.gz'
-# using build dir and adding the contents of repository
+# Publish the Java JAR to Maven Local, and create versioned release artifacts:
+# - opensearch-protobufs-java-{version}.tar.gz (Java/Maven artifacts)
+# - opensearch-protobufs-{version}.zip (Raw proto files)
 #
 on:
   push:
@@ -39,7 +40,9 @@ jobs:
       - name: Build with Gradle
         run: |
           ./tools/java/package_proto_jar.sh -c true -s false
-          ./gradlew --no-daemon -Dbuild.snapshot=false publishCreatePublicationToLocalRepoRepository && tar -C build -cvf artifacts.tar.gz repository
+          ./gradlew --no-daemon -Dbuild.snapshot=false publishCreatePublicationToLocalRepoRepository
+          VERSION=$(cat version.properties | cut -d'=' -f2)
+          tar -C build -cvf "opensearch-protobufs-java-${VERSION}.tar.gz" repository
 
       - name: Create protobuf zip
         run: ./tools/package_proto_zip.sh
@@ -50,5 +53,5 @@ jobs:
           draft: true
           generate_release_notes: true
           files: |
-            artifacts.tar.gz
+            opensearch-protobufs-java-*.tar.gz
             opensearch-protobufs-*.zip

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -40,6 +40,10 @@ jobs:
         run: |
           ./tools/java/package_proto_jar.sh -c true -s false
           ./gradlew --no-daemon -Dbuild.snapshot=false publishCreatePublicationToLocalRepoRepository && tar -C build -cvf artifacts.tar.gz repository
+
+      - name: Create protobuf zip
+        run: ./tools/package_proto_zip.sh
+
       - name: Draft a release
         uses: softprops/action-gh-release@v1
         with:
@@ -47,3 +51,4 @@ jobs:
           generate_release_notes: true
           files: |
             artifacts.tar.gz
+            opensearch-protobufs-*.zip

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -2,8 +2,8 @@ name: Release drafter
 
 # Push events to every tag not containing "/"
 #
-# Publish the Java JAR to Maven Local, and create versioned release artifacts:
-# - opensearch-protobufs-java-{version}.tar.gz (Java/Maven artifacts)
+# Publish the Java JAR to Maven Local, and create release artifacts:
+# - opensearch-protobufs-java.tar.gz (Java/Maven artifacts)
 # - opensearch-protobufs-{version}.zip (Raw proto files)
 #
 on:
@@ -41,8 +41,7 @@ jobs:
         run: |
           ./tools/java/package_proto_jar.sh -c true -s false
           ./gradlew --no-daemon -Dbuild.snapshot=false publishCreatePublicationToLocalRepoRepository
-          VERSION=$(cat version.properties | cut -d'=' -f2)
-          tar -C build -cvf "opensearch-protobufs-java-${VERSION}.tar.gz" repository
+          tar -C build -cvf "opensearch-protobufs-java.tar.gz" repository
 
       - name: Create protobuf zip
         run: ./tools/package_proto_zip.sh
@@ -53,5 +52,5 @@ jobs:
           draft: true
           generate_release_notes: true
           files: |
-            opensearch-protobufs-java-*.tar.gz
+            opensearch-protobufs-java.tar.gz
             opensearch-protobufs-*.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 ### Added
 - Add Go protobuf generation support ([#131](https://github.com/opensearch-project/opensearch-protobufs/pull/131))
+- Add protobuf zip generation for releases ([#139](https://github.com/opensearch-project/opensearch-protobufs/pull/139))
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ docker build --target test-bazel-go .
 
 Each OpenSearch Protobufs release includes:
 
-- **Java JAR**: Maven-compatible JAR files for Java/Gradle projects
-- **Protobuf ZIP**: Raw `.proto` files for generating client libraries in any language
+- **Java Archive**: `opensearch-protobufs-java-{version}.tar.gz` - Maven-compatible JAR files for Java/Gradle projects
+- **Protobuf ZIP**: `opensearch-protobufs-{version}.zip` - Raw `.proto` files for generating client libraries in any language
 
 Download the latest release from the [GitHub Releases page](https://github.com/opensearch-project/opensearch-protobufs/releases).
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ docker build --target test-bazel-go .
 
 Each OpenSearch Protobufs release includes:
 
-- **Java Archive**: `opensearch-protobufs-java-{version}.tar.gz` - Maven-compatible JAR files for Java/Gradle projects
+- **Java Archive**: `opensearch-protobufs-java.tar.gz` - Maven-compatible JAR files for Java/Gradle projects
 - **Protobuf ZIP**: `opensearch-protobufs-{version}.zip` - Raw `.proto` files for generating client libraries in any language
 
 Download the latest release from the [GitHub Releases page](https://github.com/opensearch-project/opensearch-protobufs/releases).

--- a/README.md
+++ b/README.md
@@ -45,6 +45,28 @@ docker build --target package-bazel-go .
 docker build --target test-bazel-go .
 ```
 
+## Releases
+
+Each OpenSearch Protobufs release includes:
+
+- **Java JAR**: Maven-compatible JAR files for Java/Gradle projects
+- **Protobuf ZIP**: Raw `.proto` files for generating client libraries in any language
+
+Download the latest release from the [GitHub Releases page](https://github.com/opensearch-project/opensearch-protobufs/releases).
+
+### Using Raw Proto Files
+
+Download `opensearch-protobufs-{version}.zip` from releases to get just the `.proto` files:
+
+```bash
+# Extract the zip
+unzip opensearch-protobufs-{version}.zip
+
+# Use with protoc to generate client libraries
+protoc --python_out=. opensearch-protobufs-{version}/schemas/*.proto
+protoc --go_out=. opensearch-protobufs-{version}/services/*.proto
+```
+
 ## Generated Code Usage
 
 ### Go

--- a/README.md
+++ b/README.md
@@ -56,16 +56,14 @@ Download the latest release from the [GitHub Releases page](https://github.com/o
 
 ### Using Raw Proto Files
 
-Download `opensearch-protobufs-{version}.zip` from releases to get just the `.proto` files:
+1. Download `opensearch-protobufs-{version}.zip` from releases to get just the `.proto` files:
 
+2. Extract the zip:
 ```bash
-# Extract the zip
 unzip opensearch-protobufs-{version}.zip
-
-# Use with protoc to generate client libraries
-protoc --python_out=. opensearch-protobufs-{version}/schemas/*.proto
-protoc --go_out=. opensearch-protobufs-{version}/services/*.proto
+cd opensearch-protobufs-{version}
 ```
+3. Follow latest documentation on https://protobuf.dev/reference/ to generate client libraries for different languages.
 
 ## Generated Code Usage
 

--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -8,6 +8,7 @@ standardReleasePipelineWithGenericTrigger(
     tokenIdCredential: 'jenkins-opensearch-protobufs-generic-webhook-token',
     causeString: 'A tag was cut on opensearch-project/opensearch-protobufs repository causing this workflow to run',
     downloadReleaseAsset: true,
+    downloadReleaseAssetName: 'opensearch-protobufs-java-*.tar.gz',
     publishRelease: true) {
         publishToMaven(
             signingArtifactsPath: "$WORKSPACE/repository/",

--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -8,7 +8,7 @@ standardReleasePipelineWithGenericTrigger(
     tokenIdCredential: 'jenkins-opensearch-protobufs-generic-webhook-token',
     causeString: 'A tag was cut on opensearch-project/opensearch-protobufs repository causing this workflow to run',
     downloadReleaseAsset: true,
-    downloadReleaseAssetName: 'opensearch-protobufs-java-*.tar.gz',
+    downloadReleaseAssetName: 'opensearch-protobufs-java.tar.gz',
     publishRelease: true) {
         publishToMaven(
             signingArtifactsPath: "$WORKSPACE/repository/",

--- a/tools/package_proto_zip.sh
+++ b/tools/package_proto_zip.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Script to package proto files into a zip for release
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Get version from version.properties
+VERSION=$(grep 'version=' "${ROOT_DIR}/version.properties" | cut -d'=' -f2)
+ZIP_NAME="opensearch-protobufs-${VERSION}.zip"
+
+echo "Creating protobuf zip: ${ZIP_NAME}"
+
+# Create temporary directory for organization
+TEMP_DIR=$(mktemp -d)
+PROTO_DIR="${TEMP_DIR}/opensearch-protobufs-${VERSION}"
+
+# Copy proto files with structure
+mkdir -p "${PROTO_DIR}/schemas"
+mkdir -p "${PROTO_DIR}/services"
+
+cp "${ROOT_DIR}/protos/schemas"/*.proto "${PROTO_DIR}/schemas/"
+cp "${ROOT_DIR}/protos/services"/*.proto "${PROTO_DIR}/services/"
+
+# Add a README for the zip
+cat > "${PROTO_DIR}/README.txt" << EOF
+OpenSearch Protocol Buffers v${VERSION}
+
+This archive contains the Protocol Buffer (.proto) files for OpenSearch gRPC APIs.
+
+Structure:
+- schemas/     - Core data structure definitions
+- services/    - gRPC service definitions
+
+Usage:
+Use these .proto files with your preferred Protocol Buffer compiler (protoc)
+to generate client libraries for your programming language.
+
+For more information, visit:
+https://github.com/opensearch-project/opensearch-protobufs
+
+EOF
+
+# Create the zip
+cd "${TEMP_DIR}"
+zip -r "${ROOT_DIR}/${ZIP_NAME}" "opensearch-protobufs-${VERSION}/"
+
+# Cleanup
+rm -rf "${TEMP_DIR}"
+
+echo "Successfully created: ${ZIP_NAME}"
+echo "Contents:"
+unzip -l "${ROOT_DIR}/${ZIP_NAME}"


### PR DESCRIPTION
### Description
1. Creates a versioned zip file (`opensearch-protobufs-{version}.zip`) for opensearch-protobufs releases, which can be downloaded and manually generated into clients' language of choice . 
2. Also renames the existing java artifact from `artifacts.tar.gz` to `opensearch-protobufs-java-{version}.tar.gz`


When the next release is created, users will now find two download options:
* `opensearch-protobufs-{version}.zip` - Raw proto files for any language
* `opensearch-protobufs-java-{version}.tar.gz` - Java JAR files for Maven/Gradle projects


### Test Plan
Contents of the zip: 
* Directory structure: 
<img width="325" height="205" alt="Screenshot 2025-08-04 at 6 07 00 PM" src="https://github.com/user-attachments/assets/dbe902ce-2186-412d-9c3e-42a23e258a66" />

* README contents: 
<img width="688" height="290" alt="Screenshot 2025-08-04 at 6 07 04 PM" src="https://github.com/user-attachments/assets/84bedae2-23ed-4eb6-8be6-dd10e8c0e8f1" />

* Command output: 
```
~/opensearch-protobufs on [zipgen] % ./tools/package_proto_zip.sh
Creating protobuf zip: opensearch-protobufs-0.7.0.zip
  adding: opensearch-protobufs-0.7.0/ (stored 0%)
  adding: opensearch-protobufs-0.7.0/schemas/ (stored 0%)
  adding: opensearch-protobufs-0.7.0/schemas/document.proto (deflated 83%)
  adding: opensearch-protobufs-0.7.0/schemas/search.proto (deflated 74%)
  adding: opensearch-protobufs-0.7.0/schemas/common.proto (deflated 82%)
  adding: opensearch-protobufs-0.7.0/services/ (stored 0%)
  adding: opensearch-protobufs-0.7.0/services/search_service.proto (deflated 51%)
  adding: opensearch-protobufs-0.7.0/services/document_service.proto (deflated 62%)
  adding: opensearch-protobufs-0.7.0/README.txt (deflated 40%)
Successfully created: opensearch-protobufs-0.7.0.zip
Contents:
Archive:  /home/user/opensearch-protobufs/opensearch-protobufs-0.7.0.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
        0  2025-08-04 22:13   opensearch-protobufs-0.7.0/
        0  2025-08-04 22:13   opensearch-protobufs-0.7.0/schemas/
    35800  2025-08-04 22:13   opensearch-protobufs-0.7.0/schemas/document.proto
    43744  2025-08-04 22:13   opensearch-protobufs-0.7.0/schemas/search.proto
   109707  2025-08-04 22:13   opensearch-protobufs-0.7.0/schemas/common.proto
        0  2025-08-04 22:13   opensearch-protobufs-0.7.0/services/
      826  2025-08-04 22:13   opensearch-protobufs-0.7.0/services/search_service.proto
     1444  2025-08-04 22:13   opensearch-protobufs-0.7.0/services/document_service.proto
      457  2025-08-04 22:13   opensearch-protobufs-0.7.0/README.txt
---------                     -------
   191978                     9 files
```
### Issues Resolved
#78 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
