### PR TITLE
Remove `REFRESH_BOOLEAN` from  `Refresh` enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 
 ### Changed
-- Mark `OperationContainer` as required in `BulkRequestBody` ([#165](https://github.com/opensearch-project/opensearch-protobufs/pull/165/files)
+- Mark `OperationContainer` as required in `BulkRequestBody` ([#165](https://github.com/opensearch-project/opensearch-protobufs/pull/165)
 
 ### Removed
+- Remove `REFRESH_BOOLEAN` from `Refresh` enum ([#166](https://github.com/opensearch-project/opensearch-protobufs/pull/166)
 
 ### Fixed
 

--- a/protos/schemas/document.proto
+++ b/protos/schemas/document.proto
@@ -288,10 +288,9 @@ message InlineGetDictUserDefined {
 
 enum Refresh {
   REFRESH_UNSPECIFIED = 0;
-  REFRESH_BOOLEAN = 1;
-  REFRESH_FALSE = 2;
-  REFRESH_TRUE = 3;
-  REFRESH_WAIT_FOR = 4;
+  REFRESH_FALSE = 1;
+  REFRESH_TRUE = 2;
+  REFRESH_WAIT_FOR = 3;
 }
 
 // index document.


### PR DESCRIPTION
### Description
In the spec / JSON API, it allows refresh to be provided as as a boolean `true` or a string `'true'` (and vice versa for  `false`) : https://github.com/opensearch-project/opensearch-api-specification/blob/c5ca97a26dbeb089aebc4c946a3e0e22449a75c6/spec/schemas/_common.yaml#L862. 

In protos, we don't need to duplicate translate both the boolean value and the string values
This will be fixed in a future iteration of the tooling

### Issues Resolved
#30 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
