### PR TITLE
Bump up version to 0.9.0

### DIFF
--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=0.8.0
+version=0.9.0


### PR DESCRIPTION
### Description
In https://github.com/opensearch-project/opensearch-protobufs/pull/162/files, version.properties was missed to be bumped to 0.9.0

### Issues Resolved
Chore 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
