### PR TITLE
Replace `underscore_` prefix with `x_`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 
 ### Changed
-update `score` type. ([#176](https://github.com/opensearch-project/opensearch-protobufs/pull/176))
-
+- update `score` type. ([#176](https://github.com/opensearch-project/opensearch-protobufs/pull/176))
+- Replace `underscore_` prefix with `x_` ([#177](https://github.com/opensearch-project/opensearch-protobufs/pull/177))
 ### Removed
 
 ### Fixed

--- a/protos/schemas/common.proto
+++ b/protos/schemas/common.proto
@@ -464,7 +464,7 @@ message TermsQuery {
   optional float boost = 1;
 
   // [optional] Query name for query tagging.
-  optional string underscore_name = 2;
+  optional string x_name = 2;
 
   // [optional] Specifies the types of values used for filtering. Valid values are `default` and `bitmap`. Default is `default`.
   optional TermsQueryValueType value_type = 3;
@@ -479,7 +479,7 @@ message NestedQuery {
   optional float boost = 1;
 
   // [optional] Query name for query tagging.
-  optional string underscore_name = 2;
+  optional string x_name = 2;
 
   // Set to `true` to ignore an unmapped field and not match any documents for this query. Set to `false` to throw an exception if the field is not mapped.
   bool ignore_unmapped = 3;
@@ -542,7 +542,7 @@ message InnerHits {
   repeated SortOptions sort = 12;
 
   // [optional] Select what fields of the source are returned
-  optional SourceConfig underscore_source = 13;
+  optional SourceConfig x_source = 13;
 
   // [optional] A list of stored fields to return as part of a hit. If no fields are specified, no stored fields are included in the response. If this option is specified, the _source parameter defaults to false. You can pass _source: true to return both source fields and stored fields in the search response.
   repeated string stored_fields = 14;
@@ -857,13 +857,13 @@ enum FieldType {
 
 message SortOptionsOneOf {
   // [optional]
-  optional ScoreSort underscore_score = 1;
+  optional ScoreSort x_score = 1;
   // [optional]
-  optional ScoreSort underscore_doc = 2;
+  optional ScoreSort x_doc = 2;
   // [optional]
-  optional GeoDistanceSort underscore_geo_distance = 3;
+  optional GeoDistanceSort x_geo_distance = 3;
   // [optional]
-  optional ScriptSort underscore_script = 4;
+  optional ScriptSort x_script = 4;
 }
 
 message ScoreSort {
@@ -1008,7 +1008,7 @@ message ScriptScoreQuery {
   optional float boost = 1;
 
   // [optional] Query name for query tagging.
-  optional string underscore_name = 2;
+  optional string x_name = 2;
 
   // Documents with a score lower than this floating point number are excluded from the search results.
   float min_score = 3;
@@ -1027,7 +1027,7 @@ message ExistsQuery {
   optional float boost = 2;
 
   // [optional] Query name for query tagging.
-  optional string underscore_name = 3;
+  optional string x_name = 3;
 }
 
 enum Operator {
@@ -1042,7 +1042,7 @@ message SimpleQueryStringQuery {
   optional float boost = 1;
 
   // [optional] Query name for query tagging.
-  optional string underscore_name = 2;
+  optional string x_name = 2;
 
   // Analyzer used to convert text in the query string into tokens.
   string analyzer = 3;
@@ -1088,7 +1088,7 @@ message WildcardQuery {
   optional float boost = 2;
 
   // [optional] The name of the query for query tagging.
-  optional string underscore_name = 3;
+  optional string x_name = 3;
 
   // [optional] Allows case insensitive matching of the pattern with the indexed field values when set to `true`. Default is `false` which means the case sensitivity of matching depends on the underlying field's mapping.
   optional bool case_insensitive = 4;
@@ -1166,7 +1166,7 @@ message KnnQuery {
   optional float boost = 7;
 
   // [optional] Query name for query tagging.
-  optional string underscore_name = 8;
+  optional string x_name = 8;
 
   // [optional]
   // Method parameters are dependent on the combination of engine and method used to create the index.
@@ -1211,7 +1211,7 @@ message MatchQuery {
   optional float boost = 1;
 
   // [optional] Query name for query tagging.
-  optional string underscore_name = 2;
+  optional string x_name = 2;
 
   // [optional]
   // The analyzer used to tokenize the query string text.
@@ -1327,7 +1327,7 @@ message BoolQuery {
   optional float boost = 1;
 
   // [optional] The name of the query for query tagging.
-  optional string underscore_name = 2;
+  optional string x_name = 2;
 
   // [optional] The clause (query) must appear in matching documents. However, unlike `must`, the score of the query will be ignored.
   repeated QueryContainer filter = 3;
@@ -1363,7 +1363,7 @@ message BoostingQuery {
   optional float boost = 1;
 
   // [optional] Query name for query tagging.
-  optional string underscore_name = 2;
+  optional string x_name = 2;
 
   // Floating point number between 0 and 1.0 used to decrease the relevance scores of documents matching the `negative` query.
   float negative_boost = 3;
@@ -1380,7 +1380,7 @@ message ConstantScoreQuery {
   optional float boost = 1;
 
   // [optional] Query name for query tagging.
-  optional string underscore_name = 2;
+  optional string x_name = 2;
 
   QueryContainer filter = 3;
 
@@ -1392,7 +1392,7 @@ message DisMaxQuery {
   optional float boost = 1;
 
   // [optional] Query name for query tagging.
-  optional string underscore_name = 2;
+  optional string x_name = 2;
 
   // One or more query clauses. Returned documents must match one or more of these queries. If a document matches multiple queries, OpenSearch uses the highest relevance score.
   repeated QueryContainer queries = 3;
@@ -1408,7 +1408,7 @@ message FunctionScoreQuery {
   optional float boost = 1;
 
   // [optional] Query name for query tagging.
-  optional string underscore_name = 2;
+  optional string x_name = 2;
 
   FunctionBoostMode boost_mode = 3;
 
@@ -1500,7 +1500,7 @@ message IntervalsQuery {
   optional float boost = 2;
 
   // [optional] Query name for query tagging.
-  optional string underscore_name = 3;
+  optional string x_name = 3;
 
   oneof intervals_query {
     IntervalsAllOf all_of = 4;
@@ -1597,7 +1597,7 @@ message PrefixQuery {
   optional float boost = 2;
 
   // [optional] Query name for query tagging.
-  optional string underscore_name = 3;
+  optional string x_name = 3;
 
   // [optional]
   // Determines how OpenSearch rewrites the query.
@@ -1713,7 +1713,7 @@ message TermsSetQuery {
   optional float boost = 2;
 
   // [optional] Query name for query tagging.
-  optional string underscore_name = 3;
+  optional string x_name = 3;
 
   // [optional]
   // The name of the numeric field that specifies the number of matching terms required in order to return a document in the results.
@@ -1737,7 +1737,7 @@ message TermQuery {
   optional float boost = 2;
 
   // [optional] Query name for query tagging.
-  optional string underscore_name = 3;
+  optional string x_name = 3;
 
   // [required]
   // Term you wish to find in the provided <field>. To return a document, the term must exactly match the field value, including whitespace and capitalization.
@@ -1755,7 +1755,7 @@ message QueryStringQuery {
   optional float boost = 1;
 
   // [optional] Query name for query tagging.
-  optional string underscore_name = 2;
+  optional string x_name = 2;
 
   bool allow_leading_wildcard = 3;
 
@@ -1878,7 +1878,7 @@ message RegexpQuery {
   optional float boost = 3;
 
   // [optional] Query name for query tagging
-  optional string underscore_name = 4;
+  optional string x_name = 4;
 
   // [optional] If true, allows case-insensitive matching of the regular expression value with the indexed field values. Default is false (case sensitivity is determined by the field’s mapping).
   optional bool case_insensitive = 5;
@@ -1908,7 +1908,7 @@ message DateRangeQuery {
   optional float boost = 1;
 
   // [optional] Query name for query tagging.
-  optional string underscore_name = 2;
+  optional string x_name = 2;
 
   RangeRelation relation = 3;
   enum RangeRelation {
@@ -1955,7 +1955,7 @@ message NumberRangeQuery {
   optional float boost = 1;
 
   // [optional] Query name for query tagging.
-  optional string underscore_name = 2;
+  optional string x_name = 2;
 
   RangeRelation relation = 3;
   enum RangeRelation {
@@ -2005,7 +2005,7 @@ message FuzzyQuery {
   optional float boost = 2;
 
   // [optional] Query name for query tagging.
-  optional string underscore_name = 3;
+  optional string x_name = 3;
 
   // [optional]
   // The maximum number of terms to which the query can expand. Fuzzy queries "expand to" a number of matching terms that are within the distance specified in fuzziness. Then OpenSearch tries to match those terms. Default is 50.
@@ -2086,7 +2086,7 @@ message IdsQuery {
   optional float boost = 1;
 
   // [optional] Query name for query tagging.
-  optional string underscore_name = 2;
+  optional string x_name = 2;
 
   repeated string values = 3;
 
@@ -2144,7 +2144,7 @@ message MatchAllQuery {
   optional float boost = 1;
 
   // [optional] Query name for query tagging.
-  optional string underscore_name = 2;
+  optional string x_name = 2;
 }
 
 message MatchBoolPrefixQuery {
@@ -2155,7 +2155,7 @@ message MatchBoolPrefixQuery {
   optional float boost = 2;
 
   // [optional] Query name for query tagging.
-  optional string underscore_name = 3;
+  optional string x_name = 3;
 
   // [optional]
   // The analyzer used to tokenize the query string text.
@@ -2231,7 +2231,7 @@ message MatchNoneQuery {
   optional float boost = 1;
 
   // [optional] Query name for query tagging.
-  optional string underscore_name = 2;
+  optional string x_name = 2;
 }
 
 
@@ -2248,7 +2248,7 @@ message MatchPhrasePrefixQuery {
   optional float boost = 1;
 
   // [optional] Query name for query tagging.
-  optional string underscore_name = 2;
+  optional string x_name = 2;
 
   // [optional]
   // The analyzer used to tokenize the query string text.
@@ -2284,7 +2284,7 @@ message MatchPhraseQuery {
   optional float boost = 2;
 
   // [optional] The name of the query for query tagging.
-  optional string underscore_name = 3;
+  optional string x_name = 3;
 
   // [optional]
   // The analyzer used to tokenize the query string text.
@@ -2314,7 +2314,7 @@ message MultiMatchQuery {
   optional float boost = 2;
 
   // [optional] The name of the query for query tagging.
-  optional string underscore_name = 3;
+  optional string x_name = 3;
 
   // [optional] The analyzer used to tokenize the query string text. Default is the index-time analyzer specified for the default_field. If no analyzer is specified for the default_field, the analyzer is the default analyzer for the index. For more information about index.query.default_field, see Dynamic index-level index settings.
   optional string analyzer = 4;
@@ -2739,11 +2739,11 @@ message InlineGet {
 
   bool found = 2;
 
-  int64 underscore_seq_no = 3;
+  int64 x_seq_no = 3;
 
-  int64 underscore_primary_term = 4;
+  int64 x_primary_term = 4;
 
-  repeated string underscore_routing = 5;
+  repeated string x_routing = 5;
 
   oneof inline_get_source {
 
@@ -2751,7 +2751,7 @@ message InlineGet {
     .google.protobuf.Struct struct_source = 6;
 
     // Use bytes for better latency/performance, as it reduces payload size over the wire
-    bytes underscore_source = 7;
+    bytes x_source = 7;
 
   }
 }

--- a/protos/schemas/document.proto
+++ b/protos/schemas/document.proto
@@ -17,11 +17,11 @@ message BulkRequest {
   // [optional] If not provided here, index will be required in the BulkRequestBody instead
   optional string index = 1;
   // [optional] Set `true` or `false` to return the `_source` field or not, or a list of fields to return.
-  optional SourceConfigParam underscore_source = 2;
+  optional SourceConfigParam x_source = 2;
   // [optional] A list of source fields to exclude from the response.
-  repeated string underscore_source_excludes = 3;
+  repeated string x_source_excludes = 3;
   // [optional] A list of source fields to include in the response.
-  repeated string underscore_source_includes = 4;
+  repeated string x_source_includes = 4;
   // [optional] ID of the pipeline to use to preprocess incoming documents. If the index has a default ingest pipeline specified, then setting the value to `_none` disables the default ingest pipeline for this request. If a final pipeline is configured it will always run, regardless of the value of this parameter.
   optional string pipeline = 5;
   // [optional] The enum of whether to refresh the affected shards after performing the indexing operations. Default is false
@@ -89,7 +89,7 @@ message UpdateAction {
   // [optional] If the document does not already exist, the contents of `upsert` are inserted as a new document. If the document exists, the `script` is executed.
   optional bytes upsert = 6;
   // [optional]
-  optional SourceConfig underscore_source = 7;
+  optional SourceConfig x_source = 7;
 }
 
 enum OpType {
@@ -107,9 +107,9 @@ enum VersionType {
 
 message IndexOperation {
   // [optional] The document ID. If no ID is specified, a document ID is automatically generated.
-  optional string underscore_id = 1;
+  optional string x_id = 1;
   // [optional] Name of the the data stream, index, or index alias to perform the action on. This parameter is required if index not specified in bulk request.
-  optional string underscore_index = 2;
+  optional string x_index = 2;
 
   // [optional] Custom value used to route operations to a specific shard.
   optional string routing = 3;
@@ -140,9 +140,9 @@ message WriteOperation {
   optional string routing = 1;
 
   // [optional] The unique identifier for a resource.
-  optional string underscore_id = 2;
+  optional string x_id = 2;
   // [optional]
-  optional string underscore_index = 3;
+  optional string x_index = 3;
 
   // [optional] The pipeline ID for preprocessing documents. When the index has a default ingest pipeline specified, then setting the value to `_none` disables the default ingest pipeline for this request. When a final pipeline is configured, that pipeline will always run, regardless of the value of this parameter.
   optional string pipeline = 4;
@@ -153,9 +153,9 @@ message WriteOperation {
 
 message UpdateOperation {
   // [required] The document ID.
-  optional string underscore_id = 1;
+  optional string x_id = 1;
   // [optional] Name of the the data stream, index, or index alias to perform the action on. This parameter is required if index not specified in bulk request.
-  optional string underscore_index = 2;
+  optional string x_index = 2;
   // [optional] Custom value used to route operations to a specific shard.
   optional string routing = 3;
 
@@ -172,9 +172,9 @@ message UpdateOperation {
 
 message DeleteOperation {
   // [required] The document ID.
-  optional string underscore_id = 1;
+  optional string x_id = 1;
   // [optional] Name of the the data stream, index, or index alias to perform the action on. This parameter is required if index not specified in bulk request.
-  optional string underscore_index = 2;
+  optional string x_index = 2;
   // [optional] Custom value used to route operations to a specific shard.
   optional string routing = 3;
 
@@ -237,30 +237,30 @@ enum ResponseOpType {
 
 message ResponseItem {
   // [required] Name of the index associated with the operation. If the operation targeted a data stream, this is the backing index into which the document was written.
-  string underscore_index = 1;
+  string x_index = 1;
   // [required] HTTP status code returned for the operation.
   // TODO: use grpc status code instead
   int32 status = 2;
   // [optional] The document type.
-  optional string underscore_type = 3;
+  optional string x_type = 3;
 
   // [optional] The document ID associated with the operation.
-  optional Id underscore_id = 4;
+  optional Id x_id = 4;
 
   // [optional] Contains additional information about the failed operation.
   optional ErrorCause error = 5;
 
   // [optional] The primary term assigned to the document for the operation.
-  optional int64 underscore_primary_term = 6;
+  optional int64 x_primary_term = 6;
 
   // [optional] Result of the operation. Successful values are `created`, `deleted`, and `updated`.
   optional string result = 7;
   // [optional] The sequence number assigned to the document for the operation. Sequence numbers are used to ensure an older version of a document doesn't overwrite a newer version
-  optional int64 underscore_seq_no = 8;
+  optional int64 x_seq_no = 8;
   // [optional] Contains shard information for the operation. This parameter is only returned for successful operations.
-  optional ShardInfo underscore_shards = 9;
+  optional ShardInfo x_shards = 9;
   // [optional] The document version associated with the operation. The document version is incremented each time the document is updated. This parameter is only returned for successful actions.
-  optional int64 underscore_version = 10;
+  optional int64 x_version = 10;
   // [optional] if `true`, it requires immediate visibility of the document
   optional bool forced_refresh = 11;
   // [optional]
@@ -278,11 +278,11 @@ message InlineGetDictUserDefined {
   // [optional] The sequence number assigned to the document for the operation. Sequence numbers are used to ensure an older version of a document doesn't overwrite a newer version
   optional int64 seq_no = 4;
   // [optional] The primary term assigned to the document for the operation.
-  optional int64 underscore_primary_term = 5;
+  optional int64 x_primary_term = 5;
   // [optional] Custom value used to route operations to a specific shard.
-  string underscore_routing = 6;
+  string x_routing = 6;
   // [optional] Contains the document's data
-  optional bytes underscore_source = 7;
+  optional bytes x_source = 7;
 }
 
 enum Refresh {
@@ -369,22 +369,22 @@ enum Result {
 
 message IndexDocumentResponseBody {
   // [optional] The document type.
-  optional string underscore_type = 1;
+  optional string x_type = 1;
   // [optional] The document's ID.
-  optional string underscore_id = 2;
+  optional string x_id = 2;
   // [optional] The name of the index.
-  optional string underscore_index = 3;
+  optional string x_index = 3;
   // [optional] The primary term assigned when the document was indexed.
-  optional int64 underscore_primary_term = 4;
+  optional int64 x_primary_term = 4;
 
   // [optional] The result of the index operation.
   optional Result result = 5;
   // [optional] The sequence number assigned when the document was indexed.
-  optional int64 underscore_seq_no = 6;
+  optional int64 x_seq_no = 6;
   // [optional] Detailed information about the cluster's shards.
-  ShardStatistics underscore_shards = 7;
+  ShardStatistics x_shards = 7;
   // [optional] The document's version.
-  optional int64 underscore_version = 8;
+  optional int64 x_version = 8;
   // [optional] if `true`, it requires immediate visibility of the document
   optional bool forced_refresh = 9;
 }
@@ -418,21 +418,21 @@ message DeleteDocumentRequest {
 
 message DeleteDocumentResponseBody {
   // [optional] The document type.
-  optional string underscore_type = 1;
+  optional string x_type = 1;
   // [optional] The document's ID.
-  optional string underscore_id = 2;
+  optional string x_id = 2;
   // [optional] The name of the index.
-  optional string underscore_index = 3;
+  optional string x_index = 3;
   // [optional] The primary term assigned when the document was indexed.
-  optional int64 underscore_primary_term = 4;
+  optional int64 x_primary_term = 4;
   // [optional] The result of the index operation.
   optional Result result = 5;
   // [optional] The sequence number assigned when the document was indexed.
-  optional int64 underscore_seq_no = 6;
+  optional int64 x_seq_no = 6;
   // [optional] Detailed information about the cluster's shards.
-  ShardStatistics underscore_shards = 7;
+  ShardStatistics x_shards = 7;
   // [optional] The document's version.
-  optional int64 underscore_version = 8;
+  optional int64 x_version = 8;
   // [optional] if `true`, it requires immediate visibility of the document
   optional bool forced_refresh = 9;
 
@@ -460,11 +460,11 @@ message UpdateDocumentRequest {
   // [optional] Name of the data stream or index to target. If the target doesn't exist and matches the name or wildcard (`*`) pattern of an index template with a `data_stream` definition, this request creates the data stream. If the target doesn't exist and doesn't match a data stream template, this request creates the index.
   optional string index = 2;
   // [optional] Set to false to disable source retrieval. You can also specify a comma-separated list of the fields you want to retrieve.
-  optional SourceConfigParam underscore_source = 3;
+  optional SourceConfigParam x_source = 3;
   // [optional] A comma-separated list of source fields to exclude from the response.
-  repeated string underscore_source_excludes = 4;
+  repeated string x_source_excludes = 4;
   // [optional] A comma-separated list of source fields to include in the response.
-  repeated string underscore_source_includes = 5;
+  repeated string x_source_includes = 5;
   // [optional] Only perform the operation if the document has this primary term.
   optional int64 if_primary_term = 6;
   // [optional] Only perform the operation if the document has this sequence number.
@@ -516,7 +516,7 @@ message UpdateDocumentRequestBody {
   //[optional] Set to true to execute the script whether or not the document exists.
   optional bool scripted_upsert = 5;
   // [optional] Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered.
-  optional SourceConfig underscore_source = 6;
+  optional SourceConfig x_source = 6;
 
   // [optional] If the document does not already exist, the contents of 'upsert' are inserted as a new document. If the document exists, the 'script' is executed.
   // Provide document either as ObjectMap or bytes
@@ -545,21 +545,21 @@ message UpdateDocumentErrorResponse {
 
 message UpdateDocumentResponseBody {
   // [optional] The document type.
-  optional string underscore_type = 1;
+  optional string x_type = 1;
   // [optional] The document's ID.
-  optional string underscore_id = 2;
+  optional string x_id = 2;
   // [optional] The name of the index.
-  optional string underscore_index = 3;
+  optional string x_index = 3;
   // [optional] The primary term assigned when the document was indexed.
-  optional int64 underscore_primary_term = 4;
+  optional int64 x_primary_term = 4;
   // [optional] The result of the index operation.
   optional Result result = 5;
   // [optional] The sequence number assigned when the document was indexed.
-  optional int64 underscore_seq_no = 6;
+  optional int64 x_seq_no = 6;
   // [optional] Detailed information about the cluster's shards.
-  ShardStatistics underscore_shards = 7;
+  ShardStatistics x_shards = 7;
   // [optional] The document's version.
-  optional int64 underscore_version = 8;
+  optional int64 x_version = 8;
   // [optional] if `true`, it requires immediate visibility of the document
   optional bool forced_refresh = 9;
   // [optional]
@@ -573,11 +573,11 @@ message GetDocumentRequest {
   // [required] Name of the data stream or index to target. If the target doesn't exist and matches the name or wildcard (`*`) pattern of an index template with a `data_stream` definition, this request creates the data stream. If the target doesn't exist and doesn't match a data stream template, this request creates the index.
   string index = 2;
   // [optional] Set to false to disable source retrieval. You can also specify a comma-separated list of the fields you want to retrieve. Default is true.
-  optional SourceConfigParam underscore_source = 3;
+  optional SourceConfigParam x_source = 3;
   // [optional] A comma-separated list of source fields to exclude from the response.
-  repeated string underscore_source_excludes = 4;
+  repeated string x_source_excludes = 4;
   // [optional] A comma-separated list of source fields to include in the response.
-  repeated string underscore_source_includes = 5;
+  repeated string x_source_includes = 5;
   // [optional] Specifies a preference of which shard to retrieve results from. Available options are _local, which tells the operation to retrieve results from a locally allocated shard replica, and a custom string value assigned to a specific shard replica. By default, OpenSearch executes get document operations on random shards.
   optional string preference = 6;
   // [optional] Specifies whether the operation should run in realtime. If false, the operation waits for the index to refresh to analyze the source to retrieve data, which makes the operation near-realtime. Default is true.
@@ -602,21 +602,21 @@ message GetDocumentRequest {
 
 message GetDocumentResponseBody {
   // [optional] The document type.
-  optional string underscore_type = 1;
+  optional string x_type = 1;
   // [optional] The name of the index.
-  optional string underscore_index = 2;
+  optional string x_index = 2;
   // [optional] Contains the document's data that's stored in the index. Only returned if both stored_fields and found are true.
   ObjectMap fields = 3;
   // [optional] Whether the document exists.
   optional bool found = 4;
   // [optional] The document's ID.
-  optional string underscore_id = 5;
+  optional string x_id = 5;
   // [optional] The primary term assigned when the document is indexed.
-  optional int64 underscore_primary_term = 6;
+  optional int64 x_primary_term = 6;
   // [optional] The shard that the document is routed to. If the document is not routed to a particular shard, this field is omitted.
-  optional string underscore_routing = 7;
+  optional string x_routing = 7;
   // [optional] The sequence number assigned when the document was indexed.
-  optional int64 underscore_seq_no = 8;
+  optional int64 x_seq_no = 8;
   // [optional] Contains the document's data if found is true. If _source is set to false or stored_fields is set to true in the URL parameters, this field is omitted.
   // Source to be returned as either an Struct or bytes
   oneof get_document_response_body_source {
@@ -624,11 +624,11 @@ message GetDocumentResponseBody {
     // struct_source field to be returned upon explicit request by user
     .google.protobuf.Struct struct_source = 9;
     // Use bytes for better latency/performance, as it reduces payload size over the wire
-    bytes underscore_source = 11;
+    bytes x_source = 11;
 
   }
   // [optional] The document's version number. Updated whenever the document changes.
-  optional int64 underscore_version = 10;
+  optional int64 x_version = 10;
 }
 
 // The response from get document request with document ID specified request

--- a/protos/schemas/search.proto
+++ b/protos/schemas/search.proto
@@ -19,11 +19,11 @@ message SearchRequest {
   // [optional] A list of indices to search for documents. If not provided, the default value will be to search through all indexes.
   repeated string index = 1;
   // [optional] Whether to include the _source field in the response.
-  optional SourceConfigParam underscore_source = 2;
+  optional SourceConfigParam x_source = 2;
   // [optional] A list of source fields to exclude from the response. You can also use this parameter to exclude fields from the subset specified in `source_includes` query parameter. If the `source` parameter is `false`, this parameter is ignored.
-  repeated string underscore_source_excludes = 3;
+  repeated string x_source_excludes = 3;
   // [optional] A list of source fields to include in the response. If this parameter is specified, only these source fields are returned. You can exclude fields from this subset using the `source_excludes` query parameter. If the `source` parameter is `false`, this parameter is ignored.
-  repeated string underscore_source_includes = 4;
+  repeated string x_source_includes = 4;
   // [optional] Whether to ignore wildcards that don't match any indexes. Default is true.
   optional bool allow_no_indices = 5;
   // [optional] Whether to return partial results if the request runs into an error or times out. Default is true.
@@ -221,7 +221,7 @@ message SearchRequestBody {
   repeated SortOptions sort = 22;
 
   // [optional] Whether to include the _source field in the response.
-  optional SourceConfig underscore_source = 23;
+  optional SourceConfig x_source = 23;
 
   // [optional] The fields to search for in the request. Specify a format to return results in a certain format, such as date and time.
   repeated FieldAndFormat fields = 24;
@@ -335,7 +335,7 @@ message ResponseBody {
   bool timed_out = 2;
 
   // [required] Contains a count of shards used for the request.
-  ShardStatistics underscore_shards = 3;
+  ShardStatistics x_shards = 3;
 
   // [optional] Phase-level took time values in the response.
   optional PhaseTook phase_took = 4;
@@ -347,7 +347,7 @@ message ResponseBody {
   repeated ProcessorExecutionDetail processor_results = 6;
 
   // [optional] When you search one or more remote clusters, a `_clusters` section is included to provide information about the search on each cluster.
-  optional ClusterStatistics underscore_clusters = 7;
+  optional ClusterStatistics x_clusters = 7;
 
   // [optional] Retrieved specific fields in the search response
   optional ObjectMap fields = 8;
@@ -362,7 +362,7 @@ message ResponseBody {
   optional string pit_id = 11;
 
   // [optional] Identifier for the search and its search context.
-  optional string underscore_scroll_id = 12;
+  optional string x_scroll_id = 12;
 
   // [optional] If the query was terminated early, the terminated_early flag will be set to true in the response
   optional bool terminated_early = 13;
@@ -461,12 +461,12 @@ message HitUnderscoreScore {
 
 message HitsMetadataHitsInner {
 
-  optional string underscore_type = 1;
+  optional string x_type = 1;
 
   // [required] Name of the index containing the returned document.
-  string underscore_index = 2;
+  string x_index = 2;
   // [required] Unique identifier for the returned document. This ID is only unique within the returned index.
-  string underscore_id = 3;
+  string x_id = 3;
 
   // [optional] Relevance of the returned document.
   optional HitUnderscoreScore score = 4;
@@ -487,33 +487,33 @@ message HitsMetadataHitsInner {
   repeated string matched_queries = 9;
 
   // [optional] Defines from what inner nested object this inner hit came from
-  optional NestedIdentity underscore_nested = 10;
+  optional NestedIdentity x_nested = 10;
 
   // [optional] List of fields ignored.
-  repeated string underscore_ignored = 11;
+  repeated string x_ignored = 11;
 
   // [optional] These values are retrieved from the document’s original JSON source and are raw so will not be formatted or treated in any way, unlike the successfully indexed fields which are returned in the fields section.
   map<string, StringArray> ignored_field_values = 12;
 
   // [optional] Shard from which this document was retrieved.
-  optional string underscore_shard = 13;
+  optional string x_shard = 13;
 
   // [optional] Node from which this document was retrieved.
-  optional string underscore_node = 14;
+  optional string x_node = 14;
 
-  optional string underscore_routing = 15;
+  optional string x_routing = 15;
 
   // [optional] Source document.
-  optional bytes underscore_source = 16;
+  optional bytes x_source = 16;
 
   // [optional] Counts the number of operations that happened on the index
-  optional int64 underscore_seq_no = 17;
+  optional int64 x_seq_no = 17;
 
   // [optional] Counts the number of shard has changed.
-  optional int64 underscore_primary_term = 18;
+  optional int64 x_primary_term = 18;
 
   // [optional] Version number of the document.
-  optional int64 underscore_version = 19;
+  optional int64 x_version = 19;
 
   // [optional] Sorted values
   repeated FieldValue sort = 20;
@@ -961,6 +961,6 @@ message NestedIdentity {
   int32 offset = 2;
 
   // [optional] Inner nested object.
-  optional NestedIdentity underscore_nested = 3;
+  optional NestedIdentity x_nested = 3;
 
 }


### PR DESCRIPTION
### Description
Use `x_` instead of `underscore_` for fields with leading underscores in the HTTP/JSON API (e.g. `_source`, `_id`). 

The previous `underscore_` prefix was a literal translation, which was both confusing and longwinded as well, so replacing it with a shorter alternative. 

### Issues Resolved
#30 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
