### PR TITLE
Fix wheel license classifier

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -146,7 +146,7 @@ py_wheel(
     license = "Apache-2.0",
     classifiers = [
         "Intended Audience :: Developers",
-        "License :: Apache-2.0 Software License",
+        "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3",
     ],
     homepage = "https://opensearch.org/",


### PR DESCRIPTION
### Description

"License :: Apache-2.0 Software License" -> "License :: OSI Approved :: Apache Software License"

Classifier needs to match PyPI classifier exactly.
https://pypi.org/classifiers/

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
