### PR TITLE
Fix wheel artifact path in release drafter

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -63,5 +63,5 @@ jobs:
           generate_release_notes: true
           files: |
             opensearch-protobufs-java.tar.gz
-            opensearch_protobufs-*-py3-none-any.whl
+            dist/opensearch_protobufs-*-py3-none-any.whl
             opensearch-protobufs-*.zip


### PR DESCRIPTION
### Description
Fix opensearch_protobufs-*-py3-none-any.whl artifact path - Moved to `dist/` in previous step.

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
