### PR TITLE
Upgrade python wheel version after 0.11.0 release

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -137,7 +137,7 @@ py_wheel(
     name = "opensearch_protos_wheel",
     distribution = "opensearch-protobufs",
     python_tag = "py3",
-    version = "0.11.0",
+    version = "0.12.0",
     requires = [
         "protobuf>=3.20.3",
         "grpcio>=1.68.1",


### PR DESCRIPTION
### Description
Upgrade python wheel version to match `version.properties` file 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
