### PR TITLE
Separate GlobalParams into a separate message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Changed
 - Modify `searchResponse` and `bulkResponse` according to the updated spec and remove the error response. ([#194](https://github.com/opensearch-project/opensearch-protobufs/pull/194))
-- Remove `x_` prefix, remove global `source` param, use separate `GlobalParams` message ([#181](https://github.com/opensearch-project/opensearch-protobufs/pull/181))
+- Use separate `GlobalParams` message ([#181](https://github.com/opensearch-project/opensearch-protobufs/pull/181))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Changed
 - Modify `searchResponse` and `bulkResponse` according to the updated spec and remove the error response. ([#194](https://github.com/opensearch-project/opensearch-protobufs/pull/194))
+- Remove `x_` prefix, remove global `source` param, use separate `GlobalParams` message ([#181](https://github.com/opensearch-project/opensearch-protobufs/pull/181))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Changed
 - Modify `searchResponse` and `bulkResponse` according to the updated spec and remove the error response. ([#194](https://github.com/opensearch-project/opensearch-protobufs/pull/194))
-- Use separate `GlobalParams` message ([#181](https://github.com/opensearch-project/opensearch-protobufs/pull/181))
+- Use separate `GlobalParams` message ([#207](https://github.com/opensearch-project/opensearch-protobufs/pull/207))
 
 ### Removed
 

--- a/protos/schemas/common.proto
+++ b/protos/schemas/common.proto
@@ -10,6 +10,16 @@ option go_package = "github.com/opensearch-project/opensearch-protobufs/go/opens
 
 import "google/protobuf/struct.proto";
 
+// TODO: not supported yet in server
+message GlobalParams {
+  // [optional] Whether to return human-readable values for statistics.
+  optional bool human = 1;
+  // [optional] Whether to include the stack trace of returned errors.
+  optional bool error_trace = 2;
+  // [optional] A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+  repeated string filter_path = 3;
+}
+
 message WaitForActiveShards {
 
   oneof wait_for_active_shards {

--- a/protos/schemas/document.proto
+++ b/protos/schemas/document.proto
@@ -40,15 +40,8 @@ message BulkRequest {
   optional WaitForActiveShards wait_for_active_shards = 11;
   // [required] The request body contains create, delete, index, and update actions and their associated source data
   repeated BulkRequestBody request_body = 12;
-  // [optional] Whether to return human-readable values for statistics.
-  optional bool human = 13;
-  // [optional] Whether to include the stack trace of returned errors.
-  // TODO not supported yet
-  optional bool error_trace = 14;
-  // [optional] The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-  optional string source = 15;
-  // [optional] A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-  repeated string filter_path = 16;
+  // [optional] Global parameters
+  optional GlobalParams global_params = 13;
 }
 
 message BulkRequestBody {

--- a/protos/schemas/search.proto
+++ b/protos/schemas/search.proto
@@ -136,7 +136,7 @@ message SearchRequest {
   // [optional] Search Request body
   SearchRequestBody request_body = 49;
   // [optional] Global parameters
-  optional GlobalParams global_params = 13;
+  optional GlobalParams global_params = 50;
 }
 
 message FloatMap {

--- a/protos/schemas/search.proto
+++ b/protos/schemas/search.proto
@@ -135,15 +135,8 @@ message SearchRequest {
   optional bool version = 48;
   // [optional] Search Request body
   SearchRequestBody request_body = 49;
-  // [optional] Whether to return human-readable values for statistics.
-  optional bool human = 50;
-  // [optional] Whether to include the stack trace of returned errors.
-  // todo: not supported yet.
-  optional bool error_trace = 52;
-  // [optional] The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-  optional string source = 53;
-  // [optional] A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-  repeated string filter_path = 54;
+  // [optional] Global parameters
+  optional GlobalParams global_params = 13;
 }
 
 message FloatMap {


### PR DESCRIPTION
### Description
Separate GlobalParams into a separate message to make it easier to distinguish and implement functionality for it on the server side.

### Issues Resolved
#30 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
