### PR TITLE
Preprocessing change underscore_ to x_ and require map key. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### Added
+- Preprocessing: change prefix from underscore_ to x_ and require map key ([#216](https://github.com/opensearch-project/opensearch-protobufs/pull/216))
 
 ### Changed
 - Update `FunctionScoreQuery`, `RangeQuery`, `ScriptQuery` protobufs ([#212](https://github.com/opensearch-project/opensearch-protobufs/pull/212))

--- a/tools/proto-convert/src/Sanitizer.ts
+++ b/tools/proto-convert/src/Sanitizer.ts
@@ -73,7 +73,7 @@ export class Sanitizer {
       onResponseSchema: (schema) => this.sanitize_schema(schema),
       onParameter: (param, _paramName) => {
         if (!('$ref' in param) && param.name && param.name.startsWith('_')) {
-          param.name = `underscore${param.name}`;
+          param.name = `x${param.name}`;
         }
       }
     });
@@ -93,7 +93,7 @@ export class Sanitizer {
   public rename_properties_name(properties: Record<string, OpenAPIV3.SchemaObject>) {
     for (var propName in properties) {
       if(propName.startsWith("_")) {
-        const newPropName = "underscore" + propName;
+        const newPropName = "x" + propName;
         properties[newPropName] = properties[propName];
         delete properties[propName];
       }
@@ -104,7 +104,7 @@ export class Sanitizer {
     for (var index in requireList) {
       var propName = requireList[index];
       if(propName.startsWith("_")) {
-        requireList[index] = "underscore" + propName;
+        requireList[index] = "x" + propName;
       }
     }
   }

--- a/tools/proto-convert/src/SchemaModifier.ts
+++ b/tools/proto-convert/src/SchemaModifier.ts
@@ -224,7 +224,8 @@ export class SchemaModifier {
                 [DEFAULT_MAP_KEY]: {
                     type: "string"
                 }
-            }
+            },
+            required: [DEFAULT_MAP_KEY]
         };
     }
 


### PR DESCRIPTION
### Description
Preprocessing change underscore_ to x_ and require map key. 
### Issues Resolved
Before
```
message MatchPhraseQuery {
  // Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
  optional float boost = 1;

  **optional string underscore_name** = 2;

  // Analyzer used to convert the text in the query value into tokens.
  optional string analyzer = 3;

  // Query terms that are analyzed and turned into a phrase query.
  string query = 4;

  // Maximum number of positions allowed between matching tokens.
  optional int32 slop = 5;

  optional ZeroTermsQuery zero_terms_query = 6;

  **optional string field = 7;**

}
```
After
```
message MatchPhraseQuery {
  // Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
  optional float boost = 1;

  **optional string x_name = 2;**

  // Analyzer used to convert the text in the query value into tokens.
  optional string analyzer = 3;

  // Query terms that are analyzed and turned into a phrase query.
  string query = 4;

  // Maximum number of positions allowed between matching tokens.
  optional int32 slop = 5;

  optional ZeroTermsQuery zero_terms_query = 6;

  **string field = 7;**

}
```
