### PR TITLE
Changed fields type and remove include_unmapped from FieldAndFormat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 - Refactor protobuf by moving the nested enum outside the message and renaming the field following naming convention  ([#228](https://github.com/opensearch-project/opensearch-protobufs/pull/228))
 - Revert bulk response back to without error response. ([#232](https://github.com/opensearch-project/opensearch-protobufs/pull/232))
-
+- Changed fields type and remove include_unmapped from FieldAndFormat ([#235](https://github.com/opensearch-project/opensearch-protobufs/pull/235))
 ### Removed
 
 ### Fixed

--- a/protos/schemas/common.proto
+++ b/protos/schemas/common.proto
@@ -675,7 +675,7 @@ message InnerHits {
   optional bool seq_no_primary_term = 10;
 
   // [optional] Retrieve selected fields from a search
-  repeated string fields = 11;
+  repeated FieldAndFormat fields = 11;
 
   // [optional] How the inner hits should be sorted per inner_hits. By default the hits are sorted by the score.
   repeated SortCombinations sort = 12;
@@ -1108,9 +1108,6 @@ message FieldAndFormat {
 
   // [optional] Format in which the values are returned.
   optional string format = 2;
-
-  // [optional] Retrieve unmapped fields in an object from _source
-  optional bool include_unmapped = 3;
 
 }
 


### PR DESCRIPTION
### Description
Changed fields type and remove include_unmapped from FieldAndFormat
1. Changed fields type to use FieldAndFormat.
https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/index/query/InnerHitBuilder.java#L101
2. FieldAndFormat doesn't have field include_unmapped.
https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/search/fetch/subphase/FieldAndFormat.java#L58
