### PR TITLE
Add source content type in search response

### DIFF
--- a/protos/schemas/search.proto
+++ b/protos/schemas/search.proto
@@ -365,6 +365,15 @@ message HitXScore {
   }
 }
 
+// Content type of the source document
+enum SourceContentType {
+  SOURCE_CONTENT_TYPE_UNSPECIFIED = 0;
+  SOURCE_CONTENT_TYPE_JSON = 1;
+  SOURCE_CONTENT_TYPE_SMILE = 2;
+  SOURCE_CONTENT_TYPE_CBOR = 3;
+  SOURCE_CONTENT_TYPE_YAML = 4;
+}
+
 message HitsMetadataHitsInner {
 
   optional string x_type = 1;
@@ -427,6 +436,9 @@ message HitsMetadataHitsInner {
   // [optional] Contains metadata values for the documents.
   // TODO: No field named "meta_fields" in the spec. Needs adaptor_unnest.
   optional ObjectMap meta_fields = 21;
+
+  // [optional] Content type of the x_source document
+  optional SourceContentType x_source_content_type = 22;
 }
 
 message ClusterStatistics {


### PR DESCRIPTION
### Description
Since documents can be ingested in various XContent formats (JSON, CBOR, SMILE, or YAML), search responses should specify to the user which format it is in, to avoid confusion.

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/19311

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
