### PR TITLE
Preprocessing: Handle unnamed additionalProperties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### Added
-- Preprocessing: change prefix from underscore_ to x_ and require map key ([#216](https://github.com/opensearch-project/opensearch-protobufs/pull/216))
+- Preprocessing: Change prefix from underscore_ to x_ and require map key ([#216](https://github.com/opensearch-project/opensearch-protobufs/pull/216))
 - Add Cardinality and Missing aggregations. ([#245](https://github.com/opensearch-project/opensearch-protobufs/pull/245))
 - Add terms aggregation protos  ([#268](https://github.com/opensearch-project/opensearch-protobufs/pull/268))
+- Preprocessing: Handle unnamed additionalProperties.([#272](https://github.com/opensearch-project/opensearch-protobufs/pull/272))
 
 ### Changed
 - Update preprocessing for x-protobuf-excluded ([#266](https://github.com/opensearch-project/opensearch-protobufs/pull/266))


### PR DESCRIPTION
### Description
Preprocessing: Handle unnamed additionalProperties.
in rest APIs, a map type could be used to represent arbitrary key-value pairs.
However, in Protobuf, each field must be explicitly defined within the message.
This change converts schemas with unnamed additionalProperties into explicit message fields to ensure compatibility with Protobuf.

### Test
Tested in fork repository: https://github.com/lucy66hw/opensearch-protobufs/pull/35
