### PR TITLE
Add filter to not convert additionalProperties when only one key allowed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add Cardinality and Missing aggregations. ([#245](https://github.com/opensearch-project/opensearch-protobufs/pull/245))
 - Add terms aggregation protos  ([#268](https://github.com/opensearch-project/opensearch-protobufs/pull/268))
 - Preprocessing: Handle unnamed additionalProperties.([#272](https://github.com/opensearch-project/opensearch-protobufs/pull/272))
+- Preprocessing - Preprocessing - Add filter to not convert additionalProperties when only one key allowed ([#288](https://github.com/opensearch-project/opensearch-protobufs/pull/288))
 
 ### Changed
 - Update preprocessing for x-protobuf-excluded ([#266](https://github.com/opensearch-project/opensearch-protobufs/pull/266))

--- a/tools/proto-convert/src/SchemaModifier.ts
+++ b/tools/proto-convert/src/SchemaModifier.ts
@@ -19,7 +19,6 @@ export class SchemaModifier {
         traverse(this.root, {
             onSchemaProperty: (schema) => {
                 this.deduplicateEnumValue(schema)
-                this.convertAdditionalPropertiesToProperty(schema, true)
                 this.handleAdditionalPropertiesUndefined(schema)
                 this.convertNullTypeToNullValue(schema)
                 this.collapseOrMergeOneOfArray(schema)
@@ -27,7 +26,7 @@ export class SchemaModifier {
             onSchema: (schema, schemaName) => {
                 if (!schema || isReferenceObject(schema)) return;
                 this.deduplicateEnumValue(schema)
-                this.convertAdditionalPropertiesToProperty(schema, false)
+                this.convertAdditionalPropertiesToProperty(schema)
                 this.handleAdditionalPropertiesUndefined(schema)
                 this.convertNullTypeToNullValue(schema)
                 this.handleOneOfConst(schema, schemaName)
@@ -351,7 +350,6 @@ export class SchemaModifier {
      * Converts additionalProperties with a title into a named property.
      *
      * @param schema - The schema to process
-     * @param isNestedProperty - If true, skip conversion (nested properties already have context)
      *
      * Example:
      *   Input:
@@ -381,14 +379,14 @@ export class SchemaModifier {
      *     minProperties: 2
      *   }
      **/
-    convertAdditionalPropertiesToProperty(schema: OpenAPIV3.SchemaObject, isNestedProperty: boolean = false): void {
+    convertAdditionalPropertiesToProperty(schema: OpenAPIV3.SchemaObject): void {
         if (!schema.additionalProperties || typeof schema.additionalProperties !== 'object') {
             return;
         }
 
         const additionalProps = schema.additionalProperties as any;
 
-        if (isNestedProperty) {
+        if (schema.minProperties === 1 && schema.maxProperties === 1) {
             return;
         }
 


### PR DESCRIPTION
### Description
Preprocessing - Add filter to not convert additionalProperties with min/max = 1

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
