### PR TITLE
Clean up after 0.24.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,32 +4,11 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### Added
-- Preprocessing: Change prefix from underscore_ to x_ and require map key ([#216](https://github.com/opensearch-project/opensearch-protobufs/pull/216))
-- Add Cardinality and Missing aggregations. ([#245](https://github.com/opensearch-project/opensearch-protobufs/pull/245))
-- Add terms aggregation protos  ([#268](https://github.com/opensearch-project/opensearch-protobufs/pull/268))
-- Preprocessing: Handle unnamed additionalProperties.([#272](https://github.com/opensearch-project/opensearch-protobufs/pull/272))
-- Support importing without proto file name knowledge in Python generated protobuf code ([#275](https://github.com/opensearch-project/opensearch-protobufs/pull/275))
-- Preprocessing - Add filter to not convert additionalProperties when only one key allowed ([#292](https://github.com/opensearch-project/opensearch-protobufs/pull/292))
-- Add HybridQuery protos ([#294](https://github.com/opensearch-project/opensearch-protobufs/pull/294))
-- Preprocessing - Consolidate global parameters into GlobalParams schema ([#295](https://github.com/opensearch-project/opensearch-protobufs/pull/295))
-- Preprocessing - x-protobuf-type override origin type ([#297](https://github.com/opensearch-project/opensearch-protobufs/pull/297))
-- Preprocessing - Support x-protobuf-type overrides in composed schemas with proper OpenAPI type+format mapping ([#300](https://github.com/opensearch-project/opensearch-protobufs/pull/300))
+
 ### Changed
-- Update preprocessing for x-protobuf-excluded ([#266](https://github.com/opensearch-project/opensearch-protobufs/pull/266))
-- Fix aggregations protos ([#270](https://github.com/opensearch-project/opensearch-protobufs/pull/270))
-- Bump gradle to 9.2.0 and JDK to 25 in GHAs ([#276](https://github.com/opensearch-project/opensearch-protobufs/pull/276))
-- Align protobuf 0.24.0 with latest spec ([#302](https://github.com/opensearch-project/opensearch-protobufs/pull/302))
 
 ### Removed
-- Remove error responses for single doc ingestion APIS (Index, Update, Get, Delete Doc) ([#258](https://github.com/opensearch-project/opensearch-protobufs/pull/258))
 
 ### Fixed
 
 ### Security
-- Updated gRPC from 1.68.2 to 1.70.0 to address multiple Netty vulnerabilities (CVE-2024-47535 and others)
-- Updated Protobuf from 3.25.5 to 3.25.8 to address CVE-2024-7254 (stack overflow vulnerability)
-- Updated JavaScript dependencies to address low-severity vulnerabilities:
-  - eslint-config-standard-with-typescript: 43.0.1 -> 43.0.2
-  - json-schema-to-typescript: 14.0.4 -> 15.0.2
-  - @eslint/eslintrc: 3.0.2 -> 3.1.0
-- Added JUnit override >=4.13.2 to address test framework vulnerabilities

--- a/release-notes/opensearch-protobufs.release-notes-0.24.0.md
+++ b/release-notes/opensearch-protobufs.release-notes-0.24.0.md
@@ -1,0 +1,32 @@
+## Version 0.24.0 (2025-11-19) Release Notes
+
+### Added
+- Preprocessing: Change prefix from underscore_ to x_ and require map key ([#216](https://github.com/opensearch-project/opensearch-protobufs/pull/216))
+- Add Cardinality and Missing aggregations. ([#245](https://github.com/opensearch-project/opensearch-protobufs/pull/245))
+- Add terms aggregation protos  ([#268](https://github.com/opensearch-project/opensearch-protobufs/pull/268))
+- Preprocessing: Handle unnamed additionalProperties.([#272](https://github.com/opensearch-project/opensearch-protobufs/pull/272))
+- Support importing without proto file name knowledge in Python generated protobuf code ([#275](https://github.com/opensearch-project/opensearch-protobufs/pull/275))
+- Preprocessing - Add filter to not convert additionalProperties when only one key allowed ([#292](https://github.com/opensearch-project/opensearch-protobufs/pull/292))
+- Add HybridQuery protos ([#294](https://github.com/opensearch-project/opensearch-protobufs/pull/294))
+- Preprocessing - Consolidate global parameters into GlobalParams schema ([#295](https://github.com/opensearch-project/opensearch-protobufs/pull/295))
+- Preprocessing - x-protobuf-type override origin type ([#297](https://github.com/opensearch-project/opensearch-protobufs/pull/297))
+- Preprocessing - Support x-protobuf-type overrides in composed schemas with proper OpenAPI type+format mapping ([#300](https://github.com/opensearch-project/opensearch-protobufs/pull/300))
+### Changed
+- Update preprocessing for x-protobuf-excluded ([#266](https://github.com/opensearch-project/opensearch-protobufs/pull/266))
+- Fix aggregations protos ([#270](https://github.com/opensearch-project/opensearch-protobufs/pull/270))
+- Bump gradle to 9.2.0 and JDK to 25 in GHAs ([#276](https://github.com/opensearch-project/opensearch-protobufs/pull/276))
+- Align protobuf 0.24.0 with latest spec ([#302](https://github.com/opensearch-project/opensearch-protobufs/pull/302))
+
+### Removed
+- Remove error responses for single doc ingestion APIS (Index, Update, Get, Delete Doc) ([#258](https://github.com/opensearch-project/opensearch-protobufs/pull/258))
+
+### Fixed
+
+### Security
+- Updated gRPC from 1.68.2 to 1.70.0 to address multiple Netty vulnerabilities (CVE-2024-47535 and others)
+- Updated Protobuf from 3.25.5 to 3.25.8 to address CVE-2024-7254 (stack overflow vulnerability)
+- Updated JavaScript dependencies to address low-severity vulnerabilities:
+  - eslint-config-standard-with-typescript: 43.0.1 -> 43.0.2
+  - json-schema-to-typescript: 14.0.4 -> 15.0.2
+  - @eslint/eslintrc: 3.0.2 -> 3.1.0
+- Added JUnit override >=4.13.2 to address test framework vulnerabilities

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=0.24.0
+version=0.25.0


### PR DESCRIPTION
### Description
Clean up changelog and bump up version.properties after 0.24.0 release 

### Issues Resolved
Chore

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
