### PR TITLE
Include LICENSE.txt in Python wheel distribution

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -163,6 +163,9 @@ py_wheel(
     },
     platform = "any",
     python_requires = ">=3.10",
+    extra_distinfo_files = {
+        "//:LICENSE.txt": "LICENSE.txt",
+    },
     deps = [
         ":python_protos_all",
     ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Remove error responses for single doc ingestion APIS (Index, Update, Get, Delete Doc) ([#258](https://github.com/opensearch-project/opensearch-protobufs/pull/258))
 
 ### Fixed
+- Include LICENSE.txt in Python wheel distribution ([#321](https://github.com/opensearch-project/opensearch-protobufs/pull/321))
 
 ### Security
 - Updated gRPC from 1.68.2 to 1.70.0 to address multiple Netty vulnerabilities (CVE-2024-47535 and others)


### PR DESCRIPTION
### Description

Add LICENSE.txt to the wheel's extra_distinfo_files to ensure the license is properly distributed with the package.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
