### PR TITLE
Preprocessing - Collapses single-item composite schemas (oneOf, allOf,, anyOf) by replacing the composite with its single child schema.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Preprocessing - Support x-protobuf-required to enforce required protobuf field and convert oneOf properties pattern to min/max Properties = 1 ([#318](https://github.com/opensearch-project/opensearch-protobufs/pull/318))
 - Preprocessing - Add schema exclusion list to filter out schemas and their dependencies ([#328](https://github.com/opensearch-project/opensearch-protobufs/pull/328))
 - Postprocessing- Add postprocessing support ([#333](https://github.com/opensearch-project/opensearch-protobufs/pull/333))
+- Preprocessing - Collapses single-item composite schemas (oneOf, allOf, anyOf) by replacing the composite with its single child schema. ([#334](https://github.com/opensearch-project/opensearch-protobufs/pull/334))
 
 ### Changed
 - Backward incompatible change for unimplemented query types `ScriptScoreQuery`, `SimpleQueryStringQuery`, `DisMaxQuery`, `IntervalsQuery`, `QueryStringQuery` and `TermsAggregation` ([#324](https://github.com/opensearch-project/opensearch-protobufs/pull/324))

--- a/tools/proto-convert/test/SchemaModifier.test.ts
+++ b/tools/proto-convert/test/SchemaModifier.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Tests for SchemaModifier.
+ */
+
+import type { OpenAPIV3 } from 'openapi-types';
+import { SchemaModifier } from '../src/SchemaModifier';
+
+describe('SchemaModifier', () => {
+    // Helper to create a minimal OpenAPI document
+    const createDocument = (): OpenAPIV3.Document => ({
+        openapi: '3.0.0',
+        info: { title: 'Test', version: '1.0.0' },
+        paths: {},
+        components: { schemas: {} }
+    });
+
+    describe('deduplicateOneOfWithArrayType', () => {
+        it('should remove single item when array of same primitive type exists', () => {
+            const doc = createDocument();
+            const modifier = new SchemaModifier(doc);
+
+            const schema: OpenAPIV3.SchemaObject = {
+                oneOf: [
+                    { type: 'string' },
+                    { type: 'array', items: { type: 'string' } }
+                ]
+            };
+
+            modifier.deduplicateOneOfWithArrayType(schema);
+
+            expect(schema.oneOf).toHaveLength(1);
+            expect(schema.oneOf![0]).toEqual({ type: 'array', items: { type: 'string' } });
+        });
+
+        it('should remove single item when array of same $ref type exists', () => {
+            const doc = createDocument();
+            const modifier = new SchemaModifier(doc);
+
+            const schema: OpenAPIV3.SchemaObject = {
+                oneOf: [
+                    { $ref: '#/components/schemas/MyType' },
+                    { type: 'array', items: { $ref: '#/components/schemas/MyType' } }
+                ]
+            };
+
+            modifier.deduplicateOneOfWithArrayType(schema);
+
+            expect(schema.oneOf).toHaveLength(1);
+            expect(schema.oneOf![0]).toEqual({
+                type: 'array',
+                items: { $ref: '#/components/schemas/MyType' }
+            });
+        });
+
+        it('should not modify when no duplicate exists', () => {
+            const doc = createDocument();
+            const modifier = new SchemaModifier(doc);
+
+            const schema: OpenAPIV3.SchemaObject = {
+                oneOf: [
+                    { type: 'string' },
+                    { type: 'array', items: { type: 'integer' } }
+                ]
+            };
+
+            modifier.deduplicateOneOfWithArrayType(schema);
+
+            expect(schema.oneOf).toHaveLength(2);
+            expect(schema.oneOf![0]).toEqual({ type: 'string' });
+            expect(schema.oneOf![1]).toEqual({ type: 'array', items: { type: 'integer' } });
+        });
+
+        it('should handle additionalProperties in type comparison', () => {
+            const doc = createDocument();
+            const modifier = new SchemaModifier(doc);
+
+            const schema: OpenAPIV3.SchemaObject = {
+                oneOf: [
+                    { type: 'object', additionalProperties: { type: 'string' } },
+                    { type: 'array', items: { type: 'object', additionalProperties: { type: 'string' } } }
+                ]
+            };
+
+            modifier.deduplicateOneOfWithArrayType(schema);
+
+            expect(schema.oneOf).toHaveLength(1);
+            expect(schema.oneOf![0]).toEqual({
+                type: 'array',
+                items: { type: 'object', additionalProperties: { type: 'string' } }
+            });
+        });
+
+        it('should not remove when additionalProperties differ', () => {
+            const doc = createDocument();
+            const modifier = new SchemaModifier(doc);
+
+            const schema: OpenAPIV3.SchemaObject = {
+                oneOf: [
+                    { type: 'object', additionalProperties: { type: 'string' } },
+                    { type: 'array', items: { type: 'object', additionalProperties: { type: 'integer' } } }
+                ]
+            };
+
+            modifier.deduplicateOneOfWithArrayType(schema);
+
+            expect(schema.oneOf).toHaveLength(2);
+        });
+
+        it('should not modify schema without oneOf', () => {
+            const doc = createDocument();
+            const modifier = new SchemaModifier(doc);
+
+            const schema: OpenAPIV3.SchemaObject = {
+                type: 'object',
+                properties: {
+                    name: { type: 'string' }
+                }
+            };
+
+            modifier.deduplicateOneOfWithArrayType(schema);
+
+            expect(schema.oneOf).toBeUndefined();
+            expect(schema.type).toBe('object');
+        });
+
+        it('should remove first matching single item when multiple array types exist', () => {
+            const doc = createDocument();
+            const modifier = new SchemaModifier(doc);
+
+            const schema: OpenAPIV3.SchemaObject = {
+                oneOf: [
+                    { type: 'string' },
+                    { type: 'integer' },
+                    { type: 'array', items: { type: 'string' } },
+                    { type: 'array', items: { type: 'integer' } }
+                ]
+            };
+
+            modifier.deduplicateOneOfWithArrayType(schema);
+
+            expect(schema.oneOf).toHaveLength(3);
+            expect(schema.oneOf).toContainEqual({ type: 'integer' });
+            expect(schema.oneOf).toContainEqual({ type: 'array', items: { type: 'string' } });
+            expect(schema.oneOf).toContainEqual({ type: 'array', items: { type: 'integer' } });
+        });
+
+        it('should preserve items not matching any array type', () => {
+            const doc = createDocument();
+            const modifier = new SchemaModifier(doc);
+
+            const schema: OpenAPIV3.SchemaObject = {
+                oneOf: [
+                    { type: 'string' },
+                    { type: 'boolean' },
+                    { type: 'array', items: { type: 'string' } }
+                ]
+            };
+
+            modifier.deduplicateOneOfWithArrayType(schema);
+
+            expect(schema.oneOf).toHaveLength(2);
+            expect(schema.oneOf).toContainEqual({ type: 'boolean' });
+            expect(schema.oneOf).toContainEqual({ type: 'array', items: { type: 'string' } });
+        });
+    });
+
+    describe('collapseSingleItemComposite', () => {
+        it('should collapse single-item oneOf', () => {
+            const doc = createDocument();
+            const modifier = new SchemaModifier(doc);
+
+            const schema: OpenAPIV3.SchemaObject = {
+                oneOf: [{ type: 'string' }]
+            };
+
+            modifier.collapseSingleItemComposite(schema);
+
+            expect(schema.oneOf).toBeUndefined();
+            expect(schema.type).toBe('string');
+        });
+
+        it('should collapse single-item allOf', () => {
+            const doc = createDocument();
+            const modifier = new SchemaModifier(doc);
+
+            const schema: OpenAPIV3.SchemaObject = {
+                allOf: [{ type: 'integer' }]
+            };
+
+            modifier.collapseSingleItemComposite(schema);
+
+            expect(schema.allOf).toBeUndefined();
+            expect(schema.type).toBe('integer');
+        });
+
+        it('should collapse single-item anyOf', () => {
+            const doc = createDocument();
+            const modifier = new SchemaModifier(doc);
+
+            const schema: OpenAPIV3.SchemaObject = {
+                anyOf: [{ $ref: '#/components/schemas/MyType' }]
+            };
+
+            modifier.collapseSingleItemComposite(schema);
+
+            expect(schema.anyOf).toBeUndefined();
+            expect((schema as any).$ref).toBe('#/components/schemas/MyType');
+        });
+
+        it('should not collapse multi-item oneOf', () => {
+            const doc = createDocument();
+            const modifier = new SchemaModifier(doc);
+
+            const schema: OpenAPIV3.SchemaObject = {
+                oneOf: [
+                    { type: 'string' },
+                    { type: 'integer' }
+                ]
+            };
+
+            modifier.collapseSingleItemComposite(schema);
+
+            expect(schema.oneOf).toHaveLength(2);
+        });
+
+        it('should not modify empty array', () => {
+            const doc = createDocument();
+            const modifier = new SchemaModifier(doc);
+
+            const schema: OpenAPIV3.SchemaObject = {
+                oneOf: []
+            };
+
+            modifier.collapseSingleItemComposite(schema);
+
+            expect(schema.oneOf).toHaveLength(0);
+        });
+    });
+});


### PR DESCRIPTION
### Description
Preprocessing - Collapses single-item composite schemas (oneOf, allOf,, anyOf) by replacing the composite with its single child schema.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
