### PR TITLE
Remove uint32 from GeneralNumber template

### DIFF
--- a/tools/proto-convert/src/config/protobuf-schema-template/custom_message.mustache
+++ b/tools/proto-convert/src/config/protobuf-schema-template/custom_message.mustache
@@ -29,8 +29,7 @@ message GeneralNumber {
     int64 int64_value = 2;
     float float_value = 3;
     double double_value = 4;
-    uint32 uint32_value = 5;
-    uint64 uint64_value = 6;
+    uint64 uint64_value = 5;
   }
 }
 


### PR DESCRIPTION
### Description
Remove uint32 from GeneralNumber template

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
