### PR TITLE
Updates the backward compatibility report workflow to compare against the latest proto files

### DIFF
--- a/.github/workflows/backward-compatible-report.yml
+++ b/.github/workflows/backward-compatible-report.yml
@@ -117,6 +117,17 @@ jobs:
         run: |
           java -jar cloned-repo/modules/openapi-generator-cli/target/openapi-generator-cli.jar generate -c tools/proto-convert/src/config/protobuf-generator-config.yaml
 
+      - name: Check for auto-pr-branch and use its protos if exists
+        run: |
+          # Check if auto-pr-branch exists
+          if git ls-remote --exit-code --heads origin auto-pr-branch > /dev/null 2>&1; then
+            echo "Found auto-pr-branch, using its proto files for comparison"
+            git fetch origin auto-pr-branch
+            git checkout origin/auto-pr-branch -- protos/schemas/
+          else
+            echo "auto-pr-branch not found, using main branch proto files"
+          fi
+
       - name: Post Process Protobuf (dry-run for report)
         id: merge_report
         run: |

--- a/.github/workflows/convert-proto.yml
+++ b/.github/workflows/convert-proto.yml
@@ -32,11 +32,11 @@ jobs:
       - name: Download Release Assets
         uses: robinraju/release-downloader@v1
         with:
-         repository: 'opensearch-project/opensearch-api-specification'
-         latest: true
-         fileName: 'opensearch-openapi.yaml'
-         tag: 'main-latest'
-         preRelease: true
+          repository: 'opensearch-project/opensearch-api-specification'
+          latest: true
+          fileName: 'opensearch-openapi.yaml'
+          tag: 'main-latest'
+          preRelease: true
 
       - name: Get Latest Commit ID
         id: get_commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Changed
 - Fix enum value annotations not being preserved ([#353](https://github.com/opensearch-project/opensearch-protobufs/pull/353))
+- Updates the backward compatibility report workflow to compare against the latest proto files ([#356](https://github.com/opensearch-project/opensearch-protobufs/pull/356))
 ### Removed
 
 ### Fixed


### PR DESCRIPTION
### Description
Updates the backward compatibility report workflow to compare against the latest proto files, including those in pending PRs that haven't been merged yet.

Previously, the compatibility report compared new generated protobufs against the main branch. This caused the report to include all changes since the last merge instead of changes introduced by the current PR.

### Test
https://github.com/lucy66hw/opensearch-api-specification/pull/18
<img width="877" height="505" alt="image" src="https://github.com/user-attachments/assets/7295ca53-b93a-4185-8807-de38a44a9355" />


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
