### PR TITLE
Specify use public npm registry

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -110,6 +110,12 @@ To generate Protobuf definitions from the latest OpenSearch API specification, f
 - **Node.js** >= v22
 - **Java** >= 17
 
+**Note:** If you're using an internal npm registry that blocks recent packages, configure npm to use the public registry:
+
+```bash
+npm config set registry https://registry.npmjs.org/
+```
+
 1. **Download the latest OpenSearch API Specification**
 
 


### PR DESCRIPTION
### Description
Was using an iternal registry and got these errors when running the local protobuf convert guide: 
```

npm error code E403
npm error 403 403 Forbidden - GET https://unpm.uberinternal.com/lodash/-/lodash-4.17.23.tgz
npm error 403 In most cases, you or one of your dependencies are requesting
npm error 403 a package version that is forbidden by your security policy, or
npm error 403 on a server you do not have access to.
npm error A complete log of this run can be found in: /home/user/.npm/_logs/2026-01-26T05_47_13_721Z-debug-0.log
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
