### PR TITLE
Add protobuf definitions for TermsAggregation, MinAggregation and MaxAggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### Added
+- Add compatibility matrix ([#373](https://github.com/opensearch-project/opensearch-protobufs/pull/373))
+- Enhance spec-filter to support x-operation-group filtering and merge parameters across operations in same x-operation-group instead of selecting by max parameters ([#374](https://github.com/opensearch-project/opensearch-protobufs/pull/374))
+- Add BoostingQuery and SimpleQueryString protos ([#376](https://github.com/opensearch-project/opensearch-protobufs/pull/376))
+- Add protobuf generation documentation and remove unused BUILD dependency ([#379](https://github.com/opensearch-project/opensearch-protobufs/pull/379))
+- Test Coverage Improvements ([#380](https://github.com/opensearch-project/opensearch-protobufs/pull/380))
+- Add TermsAggregation, MaxAggregation, MinAggregation support in AggregationContainer and add MaxAggregate, MinAggregate, TermsAggregate variants (DoubleTermsAggregate, LongTermsAggregate, StringTermsAggregate, UnmappedTermsAggregate, UnsignedLongTermsAggregate) in Aggregate ([#391](https://github.com/opensearch-project/opensearch-protobufs/pull/391))
 
 ### Changed
  - Fix simplifySingleMapSchema to generate named wrapper schemas. ([#406](https://github.com/opensearch-project/opensearch-protobufs/pull/406))

--- a/tools/proto-convert/src/config/spec-filter.yaml
+++ b/tools/proto-convert/src/config/spec-filter.yaml
@@ -6,8 +6,6 @@ x-operation-groups:
 # Schemas to exclude from proto generation
 # These schemas and their nested dependencies will not be included
 excluded_schemas:
-  - AggregationContainer
-  - Aggregate
   - Suggester
   - Suggest
   - DisMaxQuery
@@ -39,3 +37,123 @@ excluded_schemas:
   - TypeQuery
   - WrapperQuery
   - XyShapeQuery
+
+  # AggregationContainer - exclude all except TermsAggregation
+  - AdjacencyMatrixAggregation
+  - AutoDateHistogramAggregation
+  - AverageAggregation
+  - AverageBucketAggregation
+  - BoxplotAggregation
+  - BucketScriptAggregation
+  - BucketSelectorAggregation
+  - BucketSortAggregation
+  - CardinalityAggregation
+  - ChildrenAggregation
+  - CompositeAggregation
+  - CumulativeCardinalityAggregation
+  - CumulativeSumAggregation
+  - DateHistogramAggregation
+  - DateRangeAggregation
+  - DerivativeAggregation
+  - DiversifiedSamplerAggregation
+  - ExtendedStatsAggregation
+  - ExtendedStatsBucketAggregation
+  - FiltersAggregation
+  - GeoBoundsAggregation
+  - GeoCentroidAggregation
+  - GeoDistanceAggregation
+  - GeoHashGridAggregation
+  - GeoTileGridAggregation
+  - GlobalAggregation
+  - HistogramAggregation
+  - IpRangeAggregation
+  - MatrixStatsAggregation
+  - MaxBucketAggregation
+  - MedianAbsoluteDeviationAggregation
+  - MinBucketAggregation
+  - MissingAggregation
+  - MovingAverageAggregation
+  - MovingFunctionAggregation
+  - MovingPercentilesAggregation
+  - MultiTermsAggregation
+  - NestedAggregation
+  - NormalizeAggregation
+  - ParentAggregation
+  - PercentileRanksAggregation
+  - PercentilesAggregation
+  - PercentilesBucketAggregation
+  - RangeAggregation
+  - RareTermsAggregation
+  - RateAggregation
+  - ReverseNestedAggregation
+  - SamplerAggregation
+  - ScriptedMetricAggregation
+  - SerialDifferencingAggregation
+  - SignificantTermsAggregation
+  - SignificantTextAggregation
+  - StatsAggregation
+  - StatsBucketAggregation
+  - SumAggregation
+  - SumBucketAggregation
+  - TopHitsAggregation
+  - TTestAggregation
+  - ValueCountAggregation
+  - VariableWidthHistogramAggregation
+  - WeightedAverageAggregation
+
+  # Aggregate - exclude all except TermsAggregate variants (DoubleTerms, LongTerms, StringTerms, UnmappedTerms)
+  - AdjacencyMatrixAggregate
+  - AutoDateHistogramAggregate
+  - AvgAggregate
+  - BoxPlotAggregate
+  - BucketMetricValueAggregate
+  - CardinalityAggregate
+  - ChildrenAggregate
+  - CompositeAggregate
+  - CumulativeCardinalityAggregate
+  - DateHistogramAggregate
+  - DateRangeAggregate
+  - DerivativeAggregate
+  - ExtendedStatsAggregate
+  - ExtendedStatsBucketAggregate
+  - FilterAggregate
+  - FiltersAggregate
+  - GeoBoundsAggregate
+  - GeoCentroidAggregate
+  - GeoDistanceAggregate
+  - GeoHashGridAggregate
+  - GeoTileGridAggregate
+  - GlobalAggregate
+  - HdrPercentileRanksAggregate
+  - HdrPercentilesAggregate
+  - HistogramAggregate
+  - IpRangeAggregate
+  - LongRareTermsAggregate
+  - MatrixStatsAggregate
+  - MedianAbsoluteDeviationAggregate
+  - MissingAggregate
+  - MultiTermsAggregate
+  - NestedAggregate
+  - ParentAggregate
+  - PercentilesBucketAggregate
+  - RangeAggregate
+  - RateAggregate
+  - ReverseNestedAggregate
+  - SamplerAggregate
+  - ScriptedMetricAggregate
+  - SignificantLongTermsAggregate
+  - SignificantStringTermsAggregate
+  - SimpleValueAggregate
+  - StatsAggregate
+  - StatsBucketAggregate
+  - StringRareTermsAggregate
+  - SumAggregate
+  - TDigestPercentileRanksAggregate
+  - TDigestPercentilesAggregate
+  - TopHitsAggregate
+  - TTestAggregate
+  - UnmappedRareTermsAggregate
+  - UnmappedSignificantTermsAggregate
+  - ValueCountAggregate
+  - VariableWidthHistogramAggregate
+  - WeightedAvgAggregate


### PR DESCRIPTION
# Description
This PR adds support for TermsAggregation, MinAggregation and MaxAggregation in the OpenSearch protobuf definitions while filtering out unsupported aggregation types to reduce complexity and maintain a focused protobuf schema.

  ## Changes

  ### Updated configuration
  - **`tools/proto-convert/src/config/spec-filter.yaml`** (+128 lines)
    - Excluded unsupported AggregationContainer types (e.g., Histogram, Cardinality, Stats, Range, Percentiles, Geo*, etc.)
    - Excluded unsupported Aggregate types (e.g., Stats, Sum, Filters, RareTerms, SignificantTerms, etc.)
    - Kept only TermsAggregation, MinAggregation and MaxAggregation and its corresponding aggregate variants

  ### Modified `common.proto`
```
/**
    This is generated from the spec. DO NOT manually modify.
*/
syntax = "proto3";
package org.opensearch.protobufs;

option go_package = "github.com/opensearch-project/opensearch-protobufs/go/opensearchpb";
option java_multiple_files = true;
option java_outer_classname = "CommonProto";
option java_package = "org.opensearch.protobufs";

// The Search API operation to perform a search across all indices in the cluster or index search
message SearchRequest {

  // [optional] A list of indices to search for documents. If not provided, the default value will be to search through all indexes.
  repeated string index = 1;

  // [optional] Whether to include the _source field in the response.
  optional SourceConfigParam x_source = 2;

  // [optional] A list of source fields to exclude from the response. You can also use this parameter to exclude fields from the subset specified in `source_includes` query parameter. If the `source` parameter is `false`, this parameter is ignored.
  repeated string x_source_excludes = 3;

  // [optional] A list of source fields to include in the response. If this parameter is specified, only these source fields are returned. You can exclude fields from this subset using the `source_excludes` query parameter. If the `source` parameter is `false`, this parameter is ignored.
  repeated string x_source_includes = 4;

  // [optional] Whether to ignore wildcards that don't match any indexes. Default is true.
  optional bool allow_no_indices = 5;

  // [optional] Whether to return partial results if the request runs into an error or times out. Default is true.
  optional bool allow_partial_search_results = 6;

  // [optional] Whether the update operation should include wildcard and prefix queries in the analysis. Default is false.
  optional bool analyze_wildcard = 7;

  // [optional] How many shard results to reduce on a node. Default is 512.
  optional int32 batched_reduce_size = 8;

  // [optional] The time after which the search request will be canceled. Request-level parameter takes precedence over cancel_after_time_interval cluster setting. Default is -1.
  optional string cancel_after_time_interval = 9;

  // [optional] Whether to minimize round-trips between a node and remote clusters. Default is true.
  optional bool ccs_minimize_roundtrips = 10;

  // [optional] Indicates whether the default operator for a string query should be AND or OR. Default is OR.
  optional Operator default_operator = 11;

  // [optional] The default field in case a field prefix is not provided in the query string.
  optional string df = 12;

  // [optional] The fields that OpenSearch should return using their docvalue forms.
  repeated string docvalue_fields = 13;

  // [optional] Specifies the type of index that wildcard expressions can match. Supports list of values. Default is open.
  repeated ExpandWildcard expand_wildcards = 14;

  // [optional] Whether to ignore concrete, expanded, or indexes with aliases if indexes are frozen. Default is true.
  optional bool ignore_throttled = 15;

  // [optional] Specifies whether to include missing or closed indexes in the response and ignores unavailable shards during the search request. Default is false.
  optional bool ignore_unavailable = 16;

  // [optional] Numbers of concurrent shard requests this request should execute on each node. Default is 5.
  optional int32 max_concurrent_shard_requests = 17;

  // [optional] Whether to return phase-level took time values in the response. Default is false.
  optional bool phase_took = 18;

  // [optional] A prefilter size threshold that triggers a prefilter operation if the request exceeds the threshold. Default is 128 shards.
  optional int32 pre_filter_shard_size = 19;

  // [optional] Specifies the shards or nodes on which OpenSearch should perform the search. For valid values see "https://opensearch.org/docs/latest/api-reference/search/#the-preference-query-parameter"
  optional string preference = 20;

  // [optional] Query in the Lucene query string syntax using query parameter search.
  optional string q = 21;

  // [optional] Specifies whether OpenSearch should use the request cache. Default is whether it's enabled in the index's settings.
  optional bool request_cache = 22;

  // [optional] Indicates whether to return hits.total as an integer. Returns an object otherwise. Default is false.
  optional bool total_hits_as_int = 23;

  // [optional] Value used to route the update by query operation to a specific shard.
  repeated string routing = 24;

  // [optional] Period to keep the search context open.
  optional string scroll = 25;

  // [optional] Whether OpenSearch should use global term and document frequencies when calculating relevance scores. Default is SEARCH_TYPE_QUERY_THEN_FETCH.
  optional SearchType search_type = 26;

  // [optional] Fields OpenSearch can use to look for similar terms.
  optional string suggest_field = 27;

  // [optional] The mode to use when searching. This parameter can only be used when the `suggest_field` and `suggest_text` query string parameters are specified.
  optional SuggestMode suggest_mode = 28;

  // [optional] Number of suggestions to return.
  optional int32 suggest_size = 29;

  // [optional] The source that suggestions should be based off of.
  optional string suggest_text = 30;

  // [optional] Whether returned aggregations and suggested terms should include their types in the response. Default is true.
  optional bool typed_keys = 31;

  // [optional] Search Request body
  optional SearchRequestBody search_request_body = 32;

  // [optional] Global parameters
  // TODO not supported in server
  optional GlobalParams global_params = 33;
}

message SearchRequestBody {

  // [optional] The collapse parameter groups search results by a particular field value. This returns only the top document within each group, which helps reduce redundancy by eliminating duplicates.
  optional FieldCollapse collapse = 2;

  // [optional] Whether to return details about how OpenSearch computed the document's score. Default is false.
  optional bool explain = 3;

  // [optional] ext object is to contain plugin-specific response fields. For example, in conversational search, the result of Retrieval Augmented Generation (RAG) is a single “hit” (answer). Plugin authors can include this answer in the search response as part of the ext object so that it is separate from the search hits.
  optional ObjectMap ext = 4;

  // [optional] The starting index to search from. Default is 0.
  optional int32 from = 5;

  // [optional] Highlighting emphasizes the search term(s) in the results so you can emphasize the query matches.
  optional Highlight highlight = 6;

  // [optional] Whether to return how many documents matched the query.
  optional TrackHits track_total_hits = 7;

  // [optional] Values used to boost the score of specified indexes. Specify in the format of <index> : <boost-multiplier>
  map<string, float> indices_boost = 8 [deprecated = true];

  // [optional] The fields that OpenSearch should return using their docvalue forms. Specify a format to return results in a certain format, such as date and time.
  repeated FieldAndFormat docvalue_fields = 9;

  // [optional] Specify a score threshold to return only documents above the threshold.
  optional float min_score = 11;

  // [optional] Use post_filter to refine search hits based on user selections while preserving all aggregation options.
  optional QueryContainer post_filter = 12;

  // [optional] Profile provides timing information about the execution of individual components of a search request. Using the Profile API, you can debug slow requests and understand how to improve their performance.
  optional bool profile = 13;

  // [optional] Customizable sequence of processing stages applied to search queries.
  optional string search_pipeline = 14;

  // [optional] Enables or disables verbose mode for the search pipeline.
  optional bool verbose_pipeline = 15;

  // [optional] The DSL query to use in the request.
  optional QueryContainer query = 16;

  // [optional] Can be used to improve precision by reordering just the top (for example 100 - 500) documents returned by the `query` and `post_filter` phases.
  repeated Rescore rescore = 17;

  // [optional] The script_fields parameter allows you to include custom fields whose values are computed using scripts in your search results. This can be useful for calculating values dynamically based on the document data. You can also retrieve derived fields by using a similar approach.
  map<string, ScriptField> script_fields = 18;

  // [optional] The search_after parameter provides a live cursor that uses the previous page's results to obtain the next page's results. It is similar to the scroll operation in that it is meant to scroll many queries in parallel. You can use search_after only when sorting is applied.
  repeated FieldValue search_after = 19;

  // [optional] The number of results to return. Default is 10.
  optional int32 size = 20;

  // [optional] You can use the scroll operation to retrieve a large number of results. For example, for machine learning jobs, you can request an unlimited number of results in batches.
  optional SlicedScroll slice = 21;

  // [optional] Sorting allows your users to sort results in a way that's most meaningful to them. By default, full-text queries sort results by the relevance score. You can choose to sort the results by any field value in either ascending or descending order by setting the order parameter to asc or desc.
  repeated SortCombinations sort = 22;

  // [optional] Whether to include the _source field in the response.
  optional SourceConfig x_source = 23;

  // [optional] The fields to search for in the request. Specify a format to return results in a certain format, such as date and time.
  repeated FieldAndFormat fields = 24;

  // [optional] The maximum number of documents OpenSearch should process before terminating the request. If a query reaches this limit, OpenSearch terminates the query early. OpenSearch collects documents before sorting. Use with caution. OpenSearch applies this parameter to each shard handling the request. When possible, let OpenSearch perform early termination automatically. Avoid specifying this parameter for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early. Default is 0.
  optional int32 terminate_after = 26;

  // [optional] The period of time to wait for a response. Default is no timeout. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.
  optional string timeout = 27;

  // [optional] Whether to return document scores. Default is false.
  optional bool track_scores = 28;

  // [optional] Whether to return scores with named queries. Default is false.
  optional bool include_named_queries_score = 29;

  // [optional] Whether to include the document version in the response.
  optional bool version = 30;

  // [optional] Whether to return sequence number and primary term of the last operation of each document hit.
  optional bool seq_no_primary_term = 31;

  // [optional] A list of stored fields to return as part of a hit. If no fields are specified, no stored fields are included in the response. If this option is specified, the _source parameter defaults to false. You can pass _source: true to return both source fields and stored fields in the search response.
  repeated string stored_fields = 32;

  // [optional] Point in Time (PIT) lets you run different queries against a dataset that is fixed in time.
  optional PointInTimeReference pit = 33;

  // [optional] Value to associate with the request for additional logging.
  repeated string stats = 34;

  // [optional]
  map<string, DerivedField> derived = 35;

  // Defines the aggregations that are run as part of the search request.
  map<string, AggregationContainer> aggregations = 36;

  // [optional] Values used to boost the score of specified indexes. Specify in the format of <index> : <boost-multiplier>
  repeated FloatMap indices_boost_2 = 37;
}

message DerivedField {

  // [required]
  string name = 1;

  // [required]
  string type = 2;

  // [required]
  Script script = 3;

  // [optional]
  optional string prefilter_field = 4;

  // [optional]
  optional ObjectMap properties = 5;

  // [optional]
  optional bool ignore_malformed = 6;

  // [optional]
  optional string format = 7;
}

message TrackHits {
  oneof track_hits {
    bool enabled = 1;

    int32 count = 2;

  }
}

// The response from search request.
message SearchResponse {

  // [required] Milliseconds it took Elasticsearch to execute the request.
  int64 took = 1;

  // [required]  If true, the request timed out before completion; returned results may be partial or empty.
  bool timed_out = 2;

  // [required] Contains a count of shards used for the request.
  ShardStatistics x_shards = 3;

  // [optional] Phase-level took time values in the response.
  optional PhaseTook phase_took = 4;

  // [required] Contains returned documents and metadata.
  HitsMetadata hits = 5;

  // [optional]
  repeated ProcessorExecutionDetail processor_results = 6;

  // [optional] When you search one or more remote clusters, a `_clusters` section is included to provide information about the search on each cluster.
  optional ClusterStatistics x_clusters = 7;

  // [optional] Retrieved specific fields in the search response
  optional ObjectMap fields = 8 [deprecated = true];

  // [optional] The number of times that the coordinating node aggregates results from batches of shard responses
  optional int32 num_reduce_phases = 9;

  // [optional] Contains profiling information.
  optional Profile profile = 10;

  // [optional] The PIT ID.
  optional string pit_id = 11;

  // [optional] Identifier for the search and its search context.
  optional string x_scroll_id = 12;

  // [optional] If the query was terminated early, the terminated_early flag will be set to true in the response
  optional bool terminated_early = 13;

  map<string, Aggregate> aggregations = 14;
}

message ProcessorExecutionDetail {

  // [optional]
  optional string processor_name = 1;

  // [optional]
  optional int64 duration_millis = 2;

  // [optional]
  optional ObjectMap input_data = 3;

  // [optional]
  optional ObjectMap output_data = 4;

  // [optional]
  optional string status = 5;

  // [optional]
  optional string tag = 6;

  // [optional]
  optional string error = 7;
}

message PhaseTook {

  // [required] Time taken in dfs_pre_query phase.
  int64 dfs_pre_query = 1;

  // [required] Time taken in query phase.
  int64 query = 2;

  // [required] Time taken in fetch phase.
  int64 fetch = 3;

  // [required] Time taken in dfs_query phase.
  int64 dfs_query = 4;

  // [required] Time taken in expand phase.
  int64 expand = 5;

  // [required] Time taken in can_match phase.
  int64 can_match = 6;
}

message HitsMetadataTotal {
  oneof hits_metadata_total {
    TotalHits total_hits = 1;

    int64 int64 = 2;

  }
}

message HitsMetadataMaxScore {
  oneof hits_metadata_max_score {
    float float = 1;

    NullValue null_value = 2;

  }
}

message HitsMetadata {

  // [optional] Metadata about the number of matching documents.
  optional HitsMetadataTotal total = 1;

  // [required] Array of returned document objects.
  repeated HitsMetadataHitsInner hits = 2;

  // [optional] Highest returned document _score.
  optional HitsMetadataMaxScore max_score = 3;
}

message TotalHits {

  // [required] Indicates whether the number of matching documents in the value parameter is accurate or a lower bound.
  TotalHitsRelation relation = 1;

  // [required] Total number of matching documents.
  int64 value = 2;
}

message InnerHitsResult {

  // [required] An additional nested hits value.
  HitsMetadata hits = 1;
}

message HitXScore {
  oneof hit_x_score {
    NullValue null_value = 1;

    double double = 2;

  }
}

message HitsMetadataHitsInner {

  optional string x_type = 1;

  // [optional] Name of the index containing the returned document.
  optional string x_index = 2;

  // [optional] Unique identifier for the returned document. This ID is only unique within the returned index.
  optional string x_id = 3;

  // [optional] Relevance of the returned document.
  optional HitXScore x_score = 4;

  // [optional] Explanation of how the relevance score (_score) is calculated for every result.
  optional Explanation x_explanation = 5;

  // [optional] Contains field values for the documents.
  optional ObjectMap fields = 6;

  // [optional] An additional highlight element for each search hit that includes the highlighted fields and the highlighted fragments.
  map<string, StringArray> highlight = 7;

  // [optional] An additional nested hits that caused a search hit to match in a different scope.
  map<string, InnerHitsResult> inner_hits = 8;

  // [optional] List of matched query names used in the search request.
  repeated string matched_queries = 9 [deprecated = true];

  // [optional] Defines from what inner nested object this inner hit came from
  optional NestedIdentity x_nested = 10;

  // [optional] List of fields ignored.
  repeated string x_ignored = 11;

  // [optional] These values are retrieved from the document’s original JSON source and are raw so will not be formatted or treated in any way, unlike the successfully indexed fields which are returned in the fields section.
  map<string, StringArray> ignored_field_values = 12;

  // [optional] Shard from which this document was retrieved.
  optional string x_shard = 13;

  // [optional] Node from which this document was retrieved.
  optional string x_node = 14;

  optional string x_routing = 15;

  // [optional] Source document.
  optional bytes x_source = 16;

  // [optional] Counts the number of operations that happened on the index
  optional int64 x_seq_no = 17;

  // [optional] Counts the number of shard has changed.
  optional int64 x_primary_term = 18;

  // [optional] Version number of the document.
  optional int64 x_version = 19;

  // [optional] Sorted values
  repeated FieldValue sort = 20;

  // [optional] Contains metadata values for the documents.
  optional ObjectMap meta_fields = 21;

  // [optional] List of matched query names used in the search request.
  optional HitMatchedQueries matched_queries_2 = 22;
}

message ClusterStatistics {

  // [required] Number of shards that skipped the request because a lightweight check helped realize that no documents could possibly match on this shard. This typically happens when a search request includes a range filter and the shard only has values that fall outside of that range.
  int32 skipped = 1;

  // [required] Number of shards that executed the request successfully.
  int32 successful = 2;

  // [required] Total number of shards that require querying, including unallocated shards.
  int32 total = 3;
}

message Profile {

  // [required] A search request can be executed against one or more shards in the index, and a search may involve one or more indexes. Thus, the profile.shards array contains profiling information for each shard that was involved in the search.
  repeated ShardProfile shards = 1;
}

message RescoreQuery {

  // [required] A second query only on the Top-K results returned by the query and post_filter phases.
  QueryContainer rescore_query = 1;

  // [optional] The relative importance of the original query as compared to the rescore query.
  optional float query_weight = 2;

  // [optional] The relative importance of the rescore query as compared to the original query.
  optional float rescore_query_weight = 3;

  // [optional] Control the way the scores are combined.
  optional ScoreMode score_mode = 4;
}

message Rescore {

  // [required] Contains the rescore_query, which is the secondary query used to adjust the scores of the initial results
  RescoreQuery query = 1;

  // [optional] The number of docs which will be examined on each shard can be controlled.
  optional int32 window_size = 2;
}

message SlicedScroll {

  // [optional] Specific document field by which slicing is performed.
  optional string field = 1;

  // [required] The id of the slice
  int32 id = 2;

  // [required] The maximum number of slices
  int32 max = 3;
}

message ShardProfile {

  // [required] Profiling information about the aggregation execution.
  repeated AggregationProfile aggregations = 1;

  // [required] The shard ID of the shard in the [node-ID][index-name][shard-ID] format.
  string id = 2;

  // [required] Search represents a query executed against the underlying Lucene index. Most search requests execute a single search against a Lucene index, but some search requests can execute more than one search. For example, including a global aggregation results in a secondary match_all query for the global context. The profile.shards array contains profiling information about each search execution.
  repeated SearchProfile searches = 3;

  // [optional] Fetch timing and debug information.
  optional FetchProfile fetch = 4;
}

message AggregationProfile {

  // [required]
  AggregationBreakdown breakdown = 1;

  // [required]
  string description = 2;

  // [required] Time unit for nanoseconds
  int64 time_in_nanos = 3;

  // [required]
  string type = 4;

  // [optional]
  optional AggregationProfileDebug debug = 5;

  // [optional]
  repeated AggregationProfile children = 6;
}

message AggregationBreakdown {

  // [required] Contains the time spent running the aggregation’s buildAggregations() method, which builds the results of this aggregation. For concurrent segment search, the build_aggregation method contains the total elapsed time across all slices (the difference between the last completed slice execution end time and the first slice execution start time).
  int64 build_aggregation = 1;

  // [required] Contains the number of invocations of a build_aggregation.
  int64 build_aggregation_count = 2;

  // [required] Contains the time spent running the aggregation’s getLeafCollector() method, which creates a new collector to collect the given context. For concurrent segment search, the build_leaf_collector method contains the total elapsed time across all slices (the difference between the last completed slice execution end time and the first slice execution start time).
  int64 build_leaf_collector = 3;

  // [required] Contains the number of invocations of a build_leaf_collector.
  int64 build_leaf_collector_count = 4;

  // [required] Contains the time spent collecting the documents into buckets. For concurrent segment search, the collect method contains the total elapsed time across all slices (the difference between the last completed slice execution end time and the first slice execution start time).
  int64 collect = 5;

  // [required] Contains the number of invocations of a collect.
  int64 collect_count = 6;

  // [required] Contains the amount of time taken to execute the preCollection() callback method during AggregationCollectorManager creation. For concurrent segment search, the initialize method contains the total elapsed time across all slices (the difference between the last completed slice execution end time and the first slice execution start time).
  int64 initialize = 7;

  // [required] Contains the number of invocations of a initialize.
  int64 initialize_count = 8;

  // [optional] Contains the time spent running the aggregation’s postCollection() callback method. For concurrent segment search, the post_collection method contains the total elapsed time across all slices (the difference between the last completed slice execution end time and the first slice execution start time).
  optional int64 post_collection = 9;

  // [optional] Contains the number of invocations of a post_collection.
  optional int64 post_collection_count = 10;

  // [required] Contains the time spent in the reduce phase. For concurrent segment search, the reduce method contains the total elapsed time across all slices (the difference between the last completed slice execution end time and the first slice execution start time).
  int64 reduce = 11;

  // [required] Contains the number of invocations of a reduce.
  int64 reduce_count = 12;
}

message SearchProfile {

  // [required] Profiling information about the Lucene collectors that ran the search.
  repeated Collector collector = 1;

  // [required] Profiling information about the query execution.
  repeated QueryProfile query = 2;

  // [required] All Lucene queries are rewritten. A query and its children may be rewritten more than once, until the query stops changing. The rewriting process involves performing optimizations, such as removing redundant clauses or replacing a query path with a more efficient one. After the rewriting process, the original query may change significantly. The rewrite_time field contains the cumulative total rewrite time for the query and all its children, in nanoseconds.
  int64 rewrite_time = 3;
}

message PointInTimeReference {

  // [required] ID for the PIT to search. If you provide a pit object, this parameter is required.
  string id = 1;

  // [optional] Period of time used to extend the life of the PIT. Units can be `nanos`, `micros`, `ms` (milliseconds), `s` (seconds), `m` (minutes), `h` (hours) and `d` (days). Also accepts \"0\" without a unit and \"-1\" to indicate an unspecified value.
  optional string keep_alive = 2;
}

message Collector {

  // [required] The collector name.
  string name = 1;

  // [required] Contains a description of the collector.
  string reason = 2;

  // [required] The total elapsed time for this collector, in nanoseconds. For concurrent segment search, time_in_nanos is the total amount of time across all slices (the difference between the last completed slice execution end time and the first slice execution start time).
  int64 time_in_nanos = 3;

  // [optional] If a collector has subcollectors (children), this field contains information about the subcollectors.
  repeated Collector children = 4;
}

message QueryProfile {

  // [required] Contains timing statistics about low-level Lucene execution.
  QueryBreakdown breakdown = 1;

  // [required] Contains a Lucene explanation of the query. Helps differentiate queries with the same type.
  string description = 2;

  // [required] The total elapsed time for this query, in nanoseconds. For concurrent segment search, time_in_nanos is the total time spent across all the slices (the difference between the last completed slice execution end time and the first slice execution start time).
  int64 time_in_nanos = 3;

  // [required] The Lucene query type into which the search query was rewritten. Corresponds to the Lucene class name (which often has the same name in OpenSearch).
  string type = 4;

  // [optional] If a query has subqueries (children), this field contains information about the subqueries.
  repeated QueryProfile children = 5;
}

message QueryBreakdown {

  // [required] The advance method is a lower-level version of the next_doc method in Lucene. It also finds the next matching document but necessitates that the calling query perform additional tasks, such as identifying skips. Some queries, such as conjunctions (must clauses in Boolean queries), cannot use next_doc. For those queries, advance is timed.
  int64 advance = 1;

  // [required] Contains the number of invocations of the advance method. Different invocations of the same method occur because the method is called on different documents. You can determine the selectivity of a query by comparing counts in different query components.
  int64 advance_count = 2;

  // [required] A Scorer iterates over matching documents and generates a score for each document. The build_scorer field contains the amount of time spent generating the Scorer object. This does not include the time spent scoring the documents. The Scorer initialization time depends on the optimization and complexity of a particular query. The build_scorer parameter also includes the amount of time associated with caching, if caching is applicable and enabled for the query.
  int64 build_scorer = 3;

  // [required] Build_scorer_count contains the number of invocations of the build_scorer method. Different invocations of the same method occur because the method is called on different documents. You can determine the selectivity of a query by comparing counts in different query components.
  int64 build_scorer_count = 4;

  // [required] A Query object in Lucene is immutable. Yet, Lucene should be able to reuse Query objects in multiple IndexSearcher objects. Thus, Query objects need to keep temporary state and statistics associated with the index in which the query is executed. To achieve reuse, every Query object generates a Weight object, which keeps the temporary context (state) associated with the <IndexSearcher, Query> tuple. The create_weight field contains the amount of time spent creating the Weight object.
  int64 create_weight = 5;

  // [required] Create_weight_count contains the number of invocations of the create_weight method. Different invocations of the same method occur because the method is called on different documents. You can determine the selectivity of a query by comparing counts in different query components.
  int64 create_weight_count = 6;

  // [required] For some queries, document matching is performed in two steps. First, the document is matched approximately. Second, those documents that are approximately matched are examined through a more comprehensive process. For example, a phrase query first checks whether a document contains all terms in the phrase. Next, it verifies that the terms are in order (which is a more expensive process). The match field is non-zero only for those queries that use the two-step verification process.
  int64 match = 7;

  // [required] Match_count contains the number of invocations of the match method. Different invocations of the same method occur because the method is called on different documents. You can determine the selectivity of a query by comparing counts in different query components.
  int64 match_count = 8;

  // [required] Contains the amount of time required to execute the advanceShallow Lucene method.
  int64 shallow_advance = 9;

  // [required] Shallow_advance_count contains the number of invocations of the shallow_advance method. Different invocations of the same method occur because the method is called on different documents. You can determine the selectivity of a query by comparing counts in different query components.
  int64 shallow_advance_count = 10;

  // [required] The next_doc Lucene method returns the document ID of the next document that matches the query. This method is a special type of the advance method and is equivalent to advance(docId() + 1). The next_doc method is more convenient for many Lucene queries. The next_doc field contains the amount of time required to determine the next matching document, which varies depending on the query type.
  int64 next_doc = 11;

  // [required] Next_doc_count contains the number of invocations of the next_doc method. Different invocations of the same method occur because the method is called on different documents. You can determine the selectivity of a query by comparing counts in different query components.
  int64 next_doc_count = 12;

  // [required] Contains the time taken for a Scorer to score a particular document.
  int64 score = 13;

  // [required] Score_count contains the number of invocations of the score method. Different invocations of the same method occur because the method is called on different documents. You can determine the selectivity of a query by comparing counts in different query components.
  int64 score_count = 14;

  // [required] Contains the amount of time required to execute the getMaxScore Lucene method.
  int64 compute_max_score = 15;

  // [required] Compute_max_score_count contains the number of invocations of the compute_max_score method. Different invocations of the same method occur because the method is called on different documents. You can determine the selectivity of a query by comparing counts in different query components.
  int64 compute_max_score_count = 16;

  // [required] Contains the amount of time required to execute the setMinCompetitiveScore Lucene method.
  int64 set_min_competitive_score = 17;

  // [required] Set_min_competitive_score_count contains the number of invocations of the set_min_competitive_score method. Different invocations of the same method occur because the method is called on different documents. You can determine the selectivity of a query by comparing counts in different query components.
  int64 set_min_competitive_score_count = 18;
}

message FetchProfileDebug {

  repeated string stored_fields = 1;

  optional int32 fast_path = 2;
}

message FetchProfile {

  string type = 1;

  string description = 2;

  // Time unit for nanoseconds
  int64 time_in_nanos = 3;

  FetchProfileBreakdown breakdown = 4;

  optional FetchProfileDebug debug = 5;

  repeated FetchProfile children = 6;
}

message FetchProfileBreakdown {

  optional int32 load_source = 1;

  optional int32 load_source_count = 2;

  optional int32 load_stored_fields = 3;

  optional int32 load_stored_fields_count = 4;

  optional int32 next_reader = 5;

  optional int32 next_reader_count = 6;

  optional int32 process_count = 7;

  optional int32 process = 8;
}

message AggregationProfileDebug {

  optional int32 segments_with_multi_valued_ords = 1;

  optional string collection_strategy = 2;

  optional int32 segments_with_single_valued_ords = 3;

  optional int32 total_buckets = 4;

  optional int32 built_buckets = 5;

  optional string result_strategy = 6;

  optional bool has_filter = 7;

  optional string delegate = 8;

  optional AggregationProfileDelegateDebug delegate_debug = 9;

  optional int32 chars_fetched = 10;

  optional int32 extract_count = 11;

  optional int32 extract_ns = 12;

  optional int32 values_fetched = 13;

  optional int32 collect_analyzed_ns = 14;

  optional int32 collect_analyzed_count = 15;

  optional int32 surviving_buckets = 16;

  optional int32 ordinals_collectors_used = 17;

  optional int32 ordinals_collectors_overhead_too_high = 18;

  optional int32 string_hashing_collectors_used = 19;

  optional int32 numeric_collectors_used = 20;

  optional int32 empty_collectors_used = 21;

  repeated string deferred_aggregators = 22;

  optional string map_reducer = 28;
}

message AggregationProfileDelegateDebug {

  optional int32 segments_with_doc_count_field = 1;

  optional int32 segments_with_deleted_docs = 2;

  repeated AggregationProfileDelegateDebugFilter filters = 3;

  optional int32 segments_counted = 4;

  optional int32 segments_collected = 5;
}

message AggregationProfileDelegateDebugFilter {

  optional int32 results_from_metadata = 1;

  optional string query = 2;

  optional string specialized_for = 3;

  optional int32 segments_counted_in_constant_time = 4;
}

message Explanation {

  // [required] Explains what type of calculation is performed
  string description = 1;

  // [optional] Shows any subcalculations performed.
  repeated Explanation details = 2;

  // [required] Shows the result of the calculation,
  float value = 3;
}

message NestedIdentity {

  // [required] The name of the nested field.
  string field = 1;

  // [required] Indicates the position or index of the nested document.
  int32 offset = 2;

  // [optional] Inner nested object.
  optional NestedIdentity x_nested = 3;
}

// The bulk operation lets you add, update, or delete multiple documents in a single request, index name needs to be specified in `BulkRequestBody`
message BulkRequest {

  // [optional] If not provided here, index will be required in the BulkRequestBody instead
  optional string index = 1;

  // [optional] Set `true` or `false` to return the `_source` field or not, or a list of fields to return.
  optional SourceConfigParam x_source = 2;

  // [optional] A list of source fields to exclude from the response.
  repeated string x_source_excludes = 3;

  // [optional] A list of source fields to include in the response.
  repeated string x_source_includes = 4;

  // [optional] ID of the pipeline to use to preprocess incoming documents. If the index has a default ingest pipeline specified, then setting the value to `_none` disables the default ingest pipeline for this request. If a final pipeline is configured it will always run, regardless of the value of this parameter.
  optional string pipeline = 5;

  // [optional] The enum of whether to refresh the affected shards after performing the indexing operations. Default is false
  optional Refresh refresh = 6;

  // [optional] If `true`, the request's actions must target an index alias. Defaults to false.
  optional bool require_alias = 7;

  // [optional] Custom value used to route operations to a specific shard.
  optional string routing = 8;

  // [optional] Period each action waits for the following operations: automatic index creation, dynamic mapping updates, waiting for active shards. pattern: ^([0-9\.]+)(?:d|h|m|s|ms|micros|nanos)$. Defaults to 1m (one minute). This guarantees OpenSearch waits for at least the timeout before failing. The actual wait time could be longer, particularly when multiple waits occur.
  optional string timeout = 9;

  // [deprecated] The default document type for documents that don't specify a type. Default is _doc. We highly recommend ignoring this parameter and using a type of _doc for all indexes.
  optional string type = 10;

  // [optional] The number of active shards that must be available before OpenSearch processes the request. Default is 1 (only the primary shard). Set to all or a positive integer. Values greater than 1 require replicas. For example, if you specify a value of 3, the index must have two replicas distributed across two additional nodes for the operation to succeed.
  optional WaitForActiveShards wait_for_active_shards = 11;

  // [required] The request body contains create, delete, index, and update actions and their associated source data
  repeated BulkRequestBody bulk_request_body = 12;

  // [optional] Global parameters
  // TODO not supported in server
  optional GlobalParams global_params = 13;
}

message BulkRequestBody {

  // [required]
  OperationContainer operation_container = 1;

  // [optional]
  optional UpdateAction update_action = 2;

  // [optional]
  optional bytes object = 3;
}

message OperationContainer {
  // [required] operation to perform (index, create, update, or delete)
  oneof operation_container {
    // Indexes the specified document. If the document exists, replaces the document and increments the version. It must followed with source data to be indexed in `doc` field.
    IndexOperation index = 1;

    // Indexes the specified document if it does not already exist. It must followed with the source data to be indexed in `object` field.
    WriteOperation create = 2;

    // Performs a partial document update. It must followed with the partial document and update options in in `doc` field.
    UpdateOperation update = 3;

    // Removes the specified document from the index.
    DeleteOperation delete = 4;

  }
}

message UpdateAction {

  // [optional] When `false` disables the setting `result` in the response to `noop` if no change to the document occurred.
  optional bool detect_noop = 1;

  // [optional] A partial update to an existing document.
  optional bytes doc = 2;

  // [optional] When `true`, uses the contents of `doc` as the value of `upsert`.
  optional bool doc_as_upsert = 3;

  // [optional]
  optional Script script = 4;

  // [optional] When `true`, executes the script whether or not the document exists.
  optional bool scripted_upsert = 5;

  // [optional] If the document does not already exist, the contents of `upsert` are inserted as a new document. If the document exists, the `script` is executed.
  optional bytes upsert = 6;

  // [optional]
  optional SourceConfig x_source = 7;
}

message IndexOperation {

  // [optional] The document ID. If no ID is specified, a document ID is automatically generated.
  optional string x_id = 1;

  // [optional] Name of the the data stream, index, or index alias to perform the action on. This parameter is required if index not specified in bulk request.
  optional string x_index = 2;

  // [optional] Custom value used to route operations to a specific shard.
  optional string routing = 3;

  // [optional] Only perform the operation if the document has this primary term.
  optional int64 if_primary_term = 4;

  // [optional] Only perform the operation if the document has this sequence number
  optional int64 if_seq_no = 5;

  // [optional] Set to create to only index the document if it does not already exist (put if absent). If a document with the specified `_id` already exists, the indexing operation will fail. Same as using the `<index>/_create` endpoint. Valid values: `index`, `create`. If document id is specified, it defaults to `index`. Otherwise, it defaults to `create`.
  optional OpType op_type = 6;

  // [optional] Explicit version number for concurrency control. The specified version must match the current version of the document for the request to succeed.
  optional int64 version = 7;

  // [optional] Assigns a specific type to the document.
  optional VersionType version_type = 8;

  // [optional] ID of the pipeline to use to preprocess incoming documents. If the index has a default ingest pipeline specified, then setting the value to `_none` disables the default ingest pipeline for this request. If a final pipeline is configured it will always run, regardless of the value of this parameter.
  optional string pipeline = 9;

  // [optional] If `true`, the request's actions must target an index alias. Defaults to false.
  optional bool require_alias = 10;
}

message WriteOperation {

  // [optional] The routing value for the document.
  optional string routing = 1;

  // [optional] The unique identifier for a resource.
  optional string x_id = 2;

  // [optional]
  optional string x_index = 3;

  // [optional] The pipeline ID for preprocessing documents. When the index has a default ingest pipeline specified, then setting the value to `_none` disables the default ingest pipeline for this request. When a final pipeline is configured, that pipeline will always run, regardless of the value of this parameter.
  optional string pipeline = 4;

  // [optional] When `true`, require that all actions target an index alias rather than an index. Default is `false`.
  optional bool require_alias = 5;
}

message UpdateOperation {

  // [required] The document ID.
  optional string x_id = 1;

  // [optional] Name of the the data stream, index, or index alias to perform the action on. This parameter is required if index not specified in bulk request.
  optional string x_index = 2;

  // [optional] Custom value used to route operations to a specific shard.
  optional string routing = 3;

  // [optional] Only perform the operation if the document has this primary term
  optional int64 if_primary_term = 4;

  // [optional] Only perform the operation if the document has this sequence number
  optional int64 if_seq_no = 5;

  // [optional] If `true`, the request's actions must target an index alias. Defaults to false.
  optional bool require_alias = 6;

  // [optional] Specify how many times an update should be retried in the case of a version conflict.
  optional int32 retry_on_conflict = 7;
}

message DeleteOperation {

  // [required] The document ID.
  optional string x_id = 1;

  // [optional] Name of the the data stream, index, or index alias to perform the action on. This parameter is required if index not specified in bulk request.
  optional string x_index = 2;

  // [optional] Custom value used to route operations to a specific shard.
  optional string routing = 3;

  // [optional] Only perform the operation if the document has this primary term
  optional int64 if_primary_term = 4;

  // [optional] Only perform the operation if the document has this sequence number
  optional int64 if_seq_no = 5;

  // [optional] Explicit version number for concurrency control. The specified version must match the current version of the document for the request to succeed.
  optional int64 version = 6;

  // [optional] Assigns a specific type to the document.
  optional VersionType version_type = 7;
}

message BulkResponse {

  // [required] If true, one or more of the operations in the bulk request did not complete successfully.
  bool errors = 1;

  // [required] Contains the result of each operation in the bulk request, in the order they were submitted.
  repeated Item items = 2;

  // [required] How long, in milliseconds, it took to process the bulk request.
  int64 took = 3;

  // [optional] How long, in milliseconds, it took to process documents through an ingest pipeline
  optional int64 ingest_took = 4;
}

message Item {
  oneof item {
    ResponseItem create = 1;

    ResponseItem delete = 2;

    ResponseItem index = 3;

    ResponseItem update = 4;

  }
}

message ResponseItem {

  // [required] Name of the index associated with the operation. If the operation targeted a data stream, this is the backing index into which the document was written.
  string x_index = 1;

  // [required] HTTP status code returned for the operation.
  int32 status = 2;

  // [optional] The document type.
  optional string x_type = 3;

  // [optional] The document ID associated with the operation.
  optional string x_id = 4;

  // [optional] Contains additional information about the failed operation.
  optional ErrorCause error = 5;

  // [optional] The primary term assigned to the document for the operation.
  optional int64 x_primary_term = 6;

  // [optional] Result of the operation. Successful values are `created`, `deleted`, and `updated`.
  optional string result = 7;

  // [optional] The sequence number assigned to the document for the operation. Sequence numbers are used to ensure an older version of a document doesn't overwrite a newer version
  optional int64 x_seq_no = 8;

  // [optional] Contains shard information for the operation. This parameter is only returned for successful operations.
  optional ShardInfo x_shards = 9;

  // [optional] The document version associated with the operation. The document version is incremented each time the document is updated. This parameter is only returned for successful actions.
  optional int64 x_version = 10;

  // [optional] if `true`, it requires immediate visibility of the document
  optional bool forced_refresh = 11;

  // [optional]
  optional InlineGetDictUserDefined get = 12;
}

message InlineGetDictUserDefined {

  // [optional]
  optional ObjectMap metadata_fields = 1;

  // [optional]
  optional ObjectMap fields = 2;

  // [required] Whether the document exists.
  bool found = 3;

  // [optional] The sequence number assigned to the document for the operation. Sequence numbers are used to ensure an older version of a document doesn't overwrite a newer version
  optional int64 x_seq_no = 4;

  // [optional] The primary term assigned to the document for the operation.
  optional int64 x_primary_term = 5;

  // [optional] Custom value used to route operations to a specific shard.
  optional string x_routing = 6;

  // [optional] Contains the document's data
  optional bytes x_source = 7;
}

message GlobalParams {

  // [optional] Whether to return human-readable values for statistics.
  optional bool human = 1;

  // [optional] Whether to include the stack trace of returned errors.
  optional bool error_trace = 2;

  // [optional] A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
  repeated string filter_path = 3;
}

message WaitForActiveShards {
  oneof wait_for_active_shards {
    int32 count = 1;

    WaitForActiveShardOptions option = 2;

  }
}

message Script {
  oneof script {
    // Defines an inline script to execute as part of a query.
    InlineScript inline = 1;

    // References a stored script by its ID for use in a query.
    StoredScriptId stored = 2;

  }
}

message InlineScript {

  // [optional] The parameters that can be passed to the script.
  optional ObjectMap params = 1;

  // [optional] The script's language. Default is painless.
  optional ScriptLanguage lang = 2;

  map<string, string> options = 3;

  // [required] The script source.
  string source = 4;
}

message ScriptLanguage {
  oneof script_language {
    BuiltinScriptLanguage builtin = 1;

    string custom = 2;

  }
}

message StoredScriptId {

  // [optional] The parameters that can be passed to the script.
  optional ObjectMap params = 1;

  // [required] The ID of a stored script previously created using the Create Stored Script API.
  string id = 2;
}

message GeoLocation {
  oneof geo_location {
    // The location specified using latitude and longitude coordinates.
    LatLonGeoLocation latlon = 1;

    // The location specified using a geohash value.
    GeoHashLocation geohash = 2;

    DoubleArray coords = 3;

    // The location specified as a string in `lat,lon` or WKT format.
    string text = 4;

  }
}

message DoubleArray {

  // The location specified as an array of `[longitude, latitude]`.
  repeated double double_array = 1;
}

message LatLonGeoLocation {

  // [required] Latitude
  double lat = 1;

  // [required] Longitude
  double lon = 2;
}

message GeoHashLocation {

  // [required]
  string geohash = 1;
}

message SourceConfigParam {
  oneof source_config_param {
    // `true` or `false` to return the `_source` field or not
    bool fetch = 1;

    // list of fields to be retrieved from `_source`
    StringArray fields = 2;

  }
}

message StringArray {

  repeated string string_array = 1;
}

message SourceConfig {
  oneof source_config {
    // [optional] if the source_config is bool value. true: The entire document source is returned. false: The document source is not returned.
    bool fetch = 1;

    // [optional] source_filter type containing a list of source fields to include or exclude.
    SourceFilter filter = 2;

  }
}

message SourceFilter {

  // [optional] Wildcard (*) patterns are supported as array elements to specify source fields to exclude from the response.
  repeated string excludes = 1;

  // [optional] Wildcard (*) patterns are supported as array elements to specify source fields to return.
  repeated string includes = 2;
}

message ErrorCause {

  // [required] The type of error
  string type = 1;

  // A human-readable explanation of the error, in english
  optional string reason = 2;

  // The server stack trace. Present only if the `error_trace=true` parameter was sent with the request.
  optional string stack_trace = 3;

  optional ErrorCause caused_by = 4;

  repeated ErrorCause root_cause = 5;

  repeated ErrorCause suppressed = 6;

  // [optional] The spec actually does not have a field named 'metadata'. This should have adaptor_unnest.
  optional ObjectMap metadata = 7;

  // [optional]
  map<string, StringArray> header = 8;
}

message ShardStatistics {

  // [required] Number of shards that failed to execute the request. Note that shards that are not allocated will be considered neither successful nor failed. Having failed+successful less than total is thus an indication that some of the shards were not allocated.
  int32 failed = 1;

  // [required] Number of shards that executed the request successfully.
  int32 successful = 2;

  // [required] Total number of shards that require querying, including unallocated shards.
  int32 total = 3;

  // [optional] An array of any shard-specific failures that occurred during the search operation.
  repeated ShardFailure failures = 4 [deprecated = true];

  // [optional] Number of shards that skipped the request because a lightweight check helped realize that no documents could possibly match on this shard. This typically happens when a search request includes a range filter and the shard only has values that fall outside of that range.
  optional int32 skipped = 5;

  // [optional] An array of any shard-specific failures that occurred during the search operation.
  repeated ShardSearchFailure failures_2 = 6;
}

message ShardInfo {

  // [required] Number of shards that failed to execute the request. Note that shards that are not allocated will be considered neither successful nor failed. Having failed+successful less than total is thus an indication that some of the shards were not allocated.
  int32 failed = 1;

  // [required] Number of shards that executed the request successfully.
  int32 successful = 2;

  // [required] Total number of shards that require querying, including unallocated shards.
  int32 total = 3;

  // [optional] An array of any shard-specific failures that occurred during the search operation.
  repeated ShardFailure failures = 4;
}

message ShardFailure {

  // [optional] Name of the index in which the shard failure occurred.
  optional string index = 1;

  // [optional] ID of the node where the shard is located.
  optional string node = 2;

  // [required] Provides details about the error that caused the shard failure.
  ErrorCause reason = 3;

  // [required] The shard number where the failure occurred.
  int32 shard = 4;

  // [optional] Error status.
  optional string status = 5;

  // [required]
  bool primary = 6;
}

message QueryContainer {
  oneof query_container {
    // A Boolean (bool) query can combine several query clauses into one advanced query. The clauses are combined with Boolean logic to find matching documents returned in the results.
    BoolQuery bool = 1;

    // A constant_score query wraps a filter query and assigns all documents in the results a relevance score equal to the value of the boost parameter.
    ConstantScoreQuery constant_score = 3;

    // Use a function_score query if you need to alter the relevance scores of documents returned in the results. A function_score query defines a query and one or more functions that can be applied to all results or subsets of the results to recalculate their relevance scores.
    FunctionScoreQuery function_score = 5;

    // Use the exists query to search for documents that contain a specific field.
    ExistsQuery exists = 6;

    // Fuzzy query is to searches for documents containing terms that are similar to the search term within the maximum allowed Damerau–Levenshtein distance. The Damerau–Levenshtein distance measures the number of one-character changes needed to change one term to another term.
    FuzzyQuery fuzzy = 7;

    // Use the ids query to search for documents with one or more specific document ID values in the _id field. For example, the following query requests documents with the IDs 34229 and 91296.
    IdsQuery ids = 8;

    // Prefix query is to search for terms that begin with a specific prefix.
    PrefixQuery prefix = 9;

    // Returns documents that contain terms within a provided range.
    RangeQuery range = 10;

    // Returns documents that contain terms matching a regular expression.
    RegexpQuery regexp = 11;

    // Term query is to search for an exact term in a field. The term query does not analyze the search term. The term query only searches for the exact term you provide.
    TermQuery term = 12;

    // Terms query field is to search for documents containing one or more terms in a specific field. Use the terms query to search for multiple terms in the same field.
    TermsQuery terms = 13;

    // terms set query is to search for documents that match a minimum number of exact terms in a specified field. A terms_set query is similar to a terms query, except that you can specify the minimum number of matching terms that are required in order to return a document. You can specify this number either in a field in the index or with a script.
    TermsSetQuery terms_set = 14;

    // Returns documents that contain terms matching a wildcard pattern.
    WildcardQuery wildcard = 15;

    // Use the match query for full-text search on a specific document field. If you run a match query on a text field, the match query analyzes the provided search string and returns documents that match any of the string's terms. If you run a match query on an exact-value field, it returns documents that match the exact value. The preferred way to search exact-value fields is to use a filter because, unlike a query, a filter is cached.
    MatchQuery match = 16;

    // The match_bool_prefix query analyzes the provided search string and creates a Boolean query from the string's terms. It uses every term except the last term as a whole word for matching. The last term is used as a prefix. The match_bool_prefix query returns documents that contain either the whole-word terms or terms that start with the prefix term, in any order.
    MatchBoolPrefixQuery match_bool_prefix = 17;

    // Use the match_phrase query to match documents that contain an exact phrase in a specified order. You can add flexibility to phrase matching by providing the slop parameter.
    MatchPhraseQuery match_phrase = 18;

    // Use the match_phrase_prefix query to specify a phrase to match in order. The documents that contain the phrase you specify will be returned. The last partial term in the phrase is interpreted as a prefix, so any documents that contain phrases that begin with the phrase and prefix of the last term will be returned.
    MatchPhrasePrefixQuery match_phrase_prefix = 19;

    // A multi-match operation functions similarly to the match operation. You can use a multi_match query to search multiple fields.
    MultiMatchQuery multi_match = 20;

    // Knn query is to search for the k-nearest neighbors to a query point across an index of vectors. To determine the neighbors, you can specify the space (the distance function) you want to use to measure the distance between points.
    KnnQuery knn = 24;

    // The match all query returns all documents. This query can be useful in testing large document sets if you need to return the entire set.
    MatchAllQuery match_all = 25;

    // This is the inverse of the match_all query, which matches no documents.
    MatchNoneQuery match_none = 26;

    // The nested query acts as a wrapper for other queries to search nested fields. The nested field objects are searched as though they were indexed as separate documents. If an object matches the search, the nested query returns the parent document at the root level.
    NestedQuery nested = 28;

    // A geodistance query returns documents with geopoints that are within a specified distance from the provided geopoint. A document with multiple geopoints matches the query if at least one geopoint matches the query.
    GeoDistanceQuery geo_distance = 29;

    // To search for documents that contain geopoint fields, use a geo-bounding box query. The geo-bounding box query returns documents whose geopoints are within the bounding box specified in the query. A document with multiple geopoints matches the query if at least one geopoint is within the bounding box.
    GeoBoundingBoxQuery geo_bounding_box = 30;

    // To filter documents based on a custom condition written in the Painless scripting language.
    ScriptQuery script = 31;

    // To combine relevance scores from multiple queries into one score for a given document.
    HybridQuery hybrid = 32;

    BoostingQuery boosting = 33;

    SimpleQueryStringQuery simple_query_string = 34;

  }
}

message HybridQuery {

  // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
  optional float boost = 1;

  // [optional] The name of the filter.
  optional string x_name = 2;

  // [optional] An array of one or more query clauses that are used to match documents. A document must match at least one query clause in order to be returned in the results
  repeated QueryContainer queries = 3;

  // [optional]
  optional int32 pagination_depth = 4;

  // [optional] Only supported for 3.x. A filter to apply to all the subqueries of the hybrid query.
  optional QueryContainer filter = 5;
}

message ScriptQuery {

  // [required]
  Script script = 1;

  // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
  optional float boost = 2;

  // [optional] Query name for query tagging.
  optional string x_name = 3;
}

message GeoBoundingBoxQuery {

  // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
  optional float boost = 1;

  // [optional] The name of the filter.
  optional string x_name = 2;

  // [optional]
  optional GeoExecution type = 3;

  // [optional] The validation method. Valid values are IGNORE_MALFORMED (accept geopoints with invalid coordinates), COERCE (try to coerce coordinates to valid values), and STRICT (return an error when coordinates are invalid). Default is STRICT.
  optional GeoValidationMethod validation_method = 4;

  // [optional] Specifies whether to ignore an unmapped field. If set to true, the query does not return any documents that have an unmapped field. If set to false, an exception is thrown when the field is unmapped. Default is false.
  optional bool ignore_unmapped = 5;

  // [optional]
  map<string, GeoBounds> bounding_box = 6;
}

message GeoBounds {
  oneof geo_bounds {
    // The bounds specified using coordinate values.
    CoordsGeoBounds coords = 1;

    // The bounds specified using upper-left and lower-right points.
    TopLeftBottomRightGeoBounds tlbr = 2;

    // The bounds specified using upper-right and lower-left points.
    TopRightBottomLeftGeoBounds trbl = 3;

    // The bounds specified using WKT format.
    WktGeoBounds wkt = 4;

  }
}

message WktGeoBounds {

  // [required] The WKT string representation of the geographical bounds.
  string wkt = 1;
}

message CoordsGeoBounds {

  // [required] The top boundary latitude.
  double top = 1;

  // [required] The bottom boundary latitude.
  double bottom = 2;

  // [required] The left boundary longitude.
  double left = 3;

  // [required] The right boundary longitude.
  double right = 4;
}

message TopLeftBottomRightGeoBounds {

  // [required] The upper-left corner coordinates.
  GeoLocation top_left = 1;

  // [required] The lower-right corner coordinates.
  GeoLocation bottom_right = 2;
}

message TopRightBottomLeftGeoBounds {

  // [required] The upper-right corner coordinates.
  GeoLocation top_right = 1;

  // [required] The lower-left corner coordinates.
  GeoLocation bottom_left = 2;
}

message GeoDistanceQuery {

  // [required] The distance within which to match the points. This distance is the radius of a circle centered at the specified point. For supported distance units, see Distance units.
  string distance = 1;

  // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
  optional float boost = 2;

  // [optional] The name of the filter.
  optional string x_name = 3;

  // [optional] Specifies how to calculate the distance. Valid values are arc or plane (faster but inaccurate for long distances or points close to the poles).
  optional GeoDistanceType distance_type = 4;

  // [optional] The validation method. Valid values are IGNORE_MALFORMED (accept geopoints with invalid coordinates), COERCE (try to coerce coordinates to valid values), and STRICT (return an error when coordinates are invalid). Default is STRICT.
  optional GeoValidationMethod validation_method = 5;

  // [optional] Set to `true` to ignore an unmapped field and not match any documents for this query. Set to `false` to throw an exception if the field is not mapped.
  optional bool ignore_unmapped = 6;

  // [optional] The unit of distance measurement.
  optional DistanceUnit unit = 7;

  // [optional]
  map<string, GeoLocation> location = 8;
}

message TermsQuery {

  // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
  optional float boost = 1;

  // [optional] Query name for query tagging.
  optional string x_name = 2;

  // [optional] Specifies the types of values used for filtering. Valid values are `default` and `bitmap`. Default is `default`.
  optional TermsQueryValueType value_type = 3;

  // [optional]
  map<string, TermsQueryField> terms = 4;
}

message NestedQuery {

  // [required] The path to a field or an array of paths. Some APIs support wildcards in the path, which allows you to select multiple fields.
  string path = 1;

  // [required] The query to run on the nested objects within the specified path.
  QueryContainer query = 2;

  // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
  optional float boost = 3;

  // [optional] Query name for query tagging.
  optional string x_name = 4;

  // [optional] Set to `true` to ignore an unmapped field and not match any documents for this query. Set to `false` to throw an exception if the field is not mapped.
  optional bool ignore_unmapped = 5;

  // [optional] If provided, returns the underlying hits that matched the query.
  optional InnerHits inner_hits = 6;

  // [optional] Defines how scores of matching inner documents influence the parent document’s score
  optional ChildScoreMode score_mode = 7;
}

message InnerHits {

  // [optional] The name to be used for the particular inner hit definition in the response. Useful when multiple inner hits have been defined in a single search request.
  optional string name = 1;

  // [optional] The maximum number of hits to return per `inner_hits`.
  optional int32 size = 2;

  // [optional] Inner hit starting document offset.
  optional int32 from = 3;

  // [optional] The collapse parameter groups search results by a particular field value. This returns only the top document within each group, which helps reduce redundancy by eliminating duplicates.
  optional FieldCollapse collapse = 4;

  // [optional] The fields that OpenSearch should return using their docvalue forms. Specify a format to return results in a certain format, such as date and time.
  repeated FieldAndFormat docvalue_fields = 5;

  // [optional] Whether to return details about how OpenSearch computed the document's score. Default is false.
  optional bool explain = 6;

  // [optional] Highlighting emphasizes the search term(s) in the results so you can emphasize the query matches.
  optional Highlight highlight = 7;

  // [optional] Specifies how to treat an unmapped field. Set ignore_unmapped to true to ignore unmapped fields. Default is false
  optional bool ignore_unmapped = 8;

  // [optional] The script_fields parameter allows you to include custom fields whose values are computed using scripts in your search results. This can be useful for calculating values dynamically based on the document data. You can also retrieve derived fields by using a similar approach.
  map<string, ScriptField> script_fields = 9;

  // [optional] Whether to return sequence number and primary term of the last operation of each document hit.
  optional bool seq_no_primary_term = 10;

  // [optional] Retrieve selected fields from a search
  repeated FieldAndFormat fields = 11;

  // [optional] How the inner hits should be sorted per inner_hits. By default the hits are sorted by the score.
  repeated SortCombinations sort = 12;

  // [optional] Select what fields of the source are returned
  optional SourceConfig x_source = 13;

  // [optional] A list of stored fields to return as part of a hit. If no fields are specified, no stored fields are included in the response. If this option is specified, the _source parameter defaults to false. You can pass _source: true to return both source fields and stored fields in the search response.
  repeated string stored_fields = 14;

  // [optional] Whether to return document scores. Default is false.
  optional bool track_scores = 15;

  // [optional] Whether to include the document version as a match.
  optional bool version = 16;
}

message ScriptField {

  Script script = 1;

  optional bool ignore_failure = 2;
}

message HighlighterType {
  oneof highlighter_type {
    BuiltinHighlighterType builtin = 1;

    string custom = 2;

  }
}

message SortCombinations {
  oneof sort_combinations {
    // The path to a field or an array of paths. Some APIs support wildcards in the path, which allows you to select multiple fields.
    string field = 1;

    SortOrderMap field_with_direction = 2;

    FieldSortMap field_with_order = 3;

    SortOptions options = 4;

  }
}

message SortOrderMap {

  map<string, SortOrder> sort_order_map = 1;
}

message FieldSortMap {

  map<string, FieldSort> field_sort_map = 1;
}

message SortOptions {
  oneof sort_options {
    ScoreSort x_score = 1;

    GeoDistanceSort x_geo_distance = 2;

    ScriptSort x_script = 3;

  }
}

message Highlight {

  // [optional] Specifies the highlighter to use. Default is unified.
  optional HighlighterType type = 1;

  // [optional] All boundary characters combined in a string. Default is ".,!? \t\n".
  optional string boundary_chars = 2;

  // [optional] Controls how far to scan for boundary characters when the boundary_scanner parameter for the fvh highlighter is set to chars. Default is 20.
  optional int32 boundary_max_scan = 3;

  // [optional] Specifies whether to split the highlighted fragments into sentences, words, or characters.
  optional BoundaryScanner boundary_scanner = 4;

  // [optional] Provides a locale for the boundary_scanner. Valid values are language tags (for example, "en-US"). Default is Locale.ROOT.
  optional string boundary_scanner_locale = 5;

  // [optional] Forces the highlighting to highlight fields based on the source even if fields are stored separately.
  optional bool force_source = 6;

  // [optional] Specifies how to split text into highlighted fragments. Valid only for the plain highlighter. Default HIGHLIGHTER_FRAGMENTER_SPAN.
  optional HighlighterFragmenter fragmenter = 7;

  // [optional]
  optional int32 fragment_offset = 8;

  // [optional] The size of a highlighted fragment, specified as the number of characters. If number_of_fragments is set to 0, fragment_size is ignored. Default is 100.
  optional int32 fragment_size = 9;

  // [optional]
  optional bool highlight_filter = 10;

  // [optional] Specifies that matches for a query other than the search query should be highlighted. The highlight_query option is useful when you use a faster query to get document matches and a slower query (for example, rescore_query) to refine the results. We recommend to include the search query as part of the highlight_query.
  optional QueryContainer highlight_query = 11;

  // [optional]
  optional int32 max_fragment_length = 12;

  // [optional] If set to a non-negative value, highlighting stops at this defined maximum limit. The rest of the text is not processed, thus not highlighted and no error is returned The `max_analyzed_offset` query setting does not override the `index.highlight.max_analyzed_offset` setting, which prevails when it's set to lower value than the query setting.
  optional int32 max_analyzer_offset = 13;

  // [optional] Specifies the number of characters, starting from the beginning of the field, to return if there are no matching fragments to highlight. Default is 0.
  optional int32 no_match_size = 14;

  // [optional] The maximum number of returned fragments. If number_of_fragments is set to 0, OpenSearch returns the highlighted contents of the entire field. Default is 5.
  optional int32 number_of_fragments = 15;

  optional ObjectMap options = 16;

  // [optional] The sort order for the highlighted fragments. Each highlighter has a different algorithm for calculating relevance scores. Default is none.
  optional HighlighterOrder order = 17;

  // [optional] The number of matching phrases in a document that are considered. Limits the number of phrases to analyze by the fvh highlighter to avoid consuming a lot of memory. If matched_fields are used, phrase_limit specifies the number of phrases for each matched field. A higher phrase_limit leads to increased query time and more memory consumption. Valid only for the fvh highlighter. Default is 256.
  optional int32 phrase_limit = 18;

  // [optional] Specifies the HTML end tags for the highlighted text as an array of strings.
  repeated string post_tags = 19;

  // [optional] Specifies the HTML start tags for the highlighted text as an array of strings.
  repeated string pre_tags = 20;

  // [optional] Specifies whether to highlight only fields that contain a search query match. Default is true. To highlight all fields, set this option to false.
  optional bool require_field_match = 21;

  // [optional] If you set this option to styled, OpenSearch uses the built-in tag schema. In this schema, the pre_tags are <em class="hlt1">, <em class="hlt2">, <em class="hlt3">, <em class="hlt4">, <em class="hlt5">, <em class="hlt6">, <em class="hlt7">, <em class="hlt8">, <em class="hlt9">, and <em class="hlt10">, and the post_tags is </em>.
  optional HighlighterTagsSchema tags_schema = 22;

  // [optional] Specifies whether the highlighted fragment should be HTML encoded before it is returned.
  optional HighlighterEncoder encoder = 23;

  // [required] Specifies the fields to search for text to be highlighted. Supports wildcard expressions. If you use wildcards, only text and keyword fields are highlighted. For example, you can set fields to my_field* to include all text and keyword fields that start with the prefix my_field.
  map<string, HighlightField> fields = 24;
}

message HighlightField {

  // [optional] Specifies the highlighter to use. Default is unified.
  optional HighlighterType type = 1;

  // [optional] All boundary characters combined in a string. Default is ".,!? \t\n".
  optional string boundary_chars = 2;

  // [optional] Controls how far to scan for boundary characters when the boundary_scanner parameter for the fvh highlighter is set to chars. Default is 20.
  optional int32 boundary_max_scan = 3;

  // [optional] Specifies whether to split the highlighted fragments into sentences, words, or characters.
  optional BoundaryScanner boundary_scanner = 4;

  // [optional] Provides a locale for the boundary_scanner. Valid values are language tags (for example, "en-US"). Default is Locale.ROOT.
  optional string boundary_scanner_locale = 5;

  // [x-deprecated]
  optional bool force_source = 6;

  // [optional] Specifies how to split text into highlighted fragments. Valid only for the plain highlighter. Default HIGHLIGHTER_FRAGMENTER_SPAN.
  optional HighlighterFragmenter fragmenter = 7;

  // [optional] The size of a highlighted fragment, specified as the number of characters. If number_of_fragments is set to 0, fragment_size is ignored. Default is 100.
  optional int32 fragment_size = 8;

  optional bool highlight_filter = 9;

  // [optional] Specifies that matches for a query other than the search query should be highlighted. The highlight_query option is useful when you use a faster query to get document matches and a slower query (for example, rescore_query) to refine the results. We recommend to include the search query as part of the highlight_query.
  optional QueryContainer highlight_query = 10;

  optional int32 max_fragment_length = 11;

  // [optional] If set to a non-negative value, highlighting stops at this defined maximum limit. The rest of the text is not processed, thus not highlighted and no error is returned The `max_analyzed_offset` query setting does not override the `index.highlight.max_analyzed_offset` setting, which prevails when it's set to lower value than the query setting.
  optional int32 max_analyzer_offset = 12;

  // [optional] Specifies the number of characters, starting from the beginning of the field, to return if there are no matching fragments to highlight. Default is 0.
  optional int32 no_match_size = 13;

  // [optional] The maximum number of returned fragments. If number_of_fragments is set to 0, OpenSearch returns the highlighted contents of the entire field. Default is 5.
  optional int32 number_of_fragments = 14;

  // [optional]
  optional ObjectMap options = 15;

  // [optional] The sort order for the highlighted fragments. Each highlighter has a different algorithm for calculating relevance scores. Default is none.
  optional HighlighterOrder order = 16;

  // [optional] The number of matching phrases in a document that are considered. Limits the number of phrases to analyze by the fvh highlighter to avoid consuming a lot of memory. If matched_fields are used, phrase_limit specifies the number of phrases for each matched field. A higher phrase_limit leads to increased query time and more memory consumption. Valid only for the fvh highlighter. Default is 256.
  optional int32 phrase_limit = 17;

  // [optional] Specifies the HTML end tags for the highlighted text as an array of strings.
  repeated string post_tags = 18;

  // [optional] Specifies the HTML start tags for the highlighted text as an array of strings.
  repeated string pre_tags = 19;

  // [optional] Specifies whether to highlight only fields that contain a search query match. Default is true. To highlight all fields, set this option to false.
  optional bool require_field_match = 20;

  // [optional]
  optional HighlighterTagsSchema tags_schema = 21;

  // [optional] If you set this option to styled, OpenSearch uses the built-in tag schema. In this schema, the pre_tags are <em class="hlt1">, <em class="hlt2">, <em class="hlt3">, <em class="hlt4">, <em class="hlt5">, <em class="hlt6">, <em class="hlt7">, <em class="hlt8">, <em class="hlt9">, and <em class="hlt10">, and the post_tags is </em>.
  optional int32 fragment_offset = 22;

  // [optional] Combines matches from different fields to highlight one field. The most common use case for this functionality is highlighting text that is analyzed in different ways and kept in multi-fields. All fields in the matched_fields list must have the term_vector field set to with_positions_offsets. The field in which the matches are combined is the only loaded field, so it is beneficial to set its store option to yes. Valid only for the fvh highlighter.
  repeated string matched_fields = 23;
}

message FieldSort {

  // The value to use when the field is missing.
  optional FieldValue missing = 1;

  // The mode for sorting on array fields.
  optional SortMode mode = 2;

  // The nested path sort options.
  optional NestedSortValue nested = 3;

  // The sort order direction.
  optional SortOrder order = 4;

  // The type to use for unmapped fields.
  optional FieldType unmapped_type = 5;

  // The numeric type to use for sorting.
  optional FieldSortNumericType numeric_type = 6;
}

message GeoDistanceSort {

  // [optional] Specifies how to handle a field with several geopoints.
  optional SortMode mode = 1;

  // [optional] Specifies the method of computing the distance.
  optional GeoDistanceType distance_type = 2;

  // [optional] Specifies how to treat an unmapped field. Set ignore_unmapped to true to ignore unmapped fields. Default is false
  optional bool ignore_unmapped = 3;

  // [optional]
  optional NestedSortValue nested = 4;

  // [optional] Specifies the sort order (asc or dsc) for the score.
  optional SortOrder order = 5;

  // [optional] Specifies the units used to compute sort values. Default is meters (m).
  optional DistanceUnit unit = 6;

  // [optional]
  optional GeoValidationMethod validation_method = 7;

  // [optional]
  map<string, GeoLocationArray> location = 8;
}

message ScoreSort {

  // Specifies the sort order (asc or dsc) for the score.
  optional SortOrder order = 1;
}

message GeoLocationArray {

  // The geo points to use for distance calculation.
  repeated GeoLocation geo_location_array = 1;
}

message ScriptSort {

  // [required] The script to execute for custom sorting.
  Script script = 1;

  // [optional] Specifies the sort order (asc or dsc) for the score.
  optional SortOrder order = 2;

  // [optional] Specifies script sort type.
  optional ScriptSortType type = 3;

  // [optional] Specifies what array value should be chosen for sorting the document.
  optional SortMode mode = 4;

  // [optional] Supports sorting by fields that are inside one or more nested objects.
  optional NestedSortValue nested = 5;
}

message NestedSortValue {

  // [required] Specifies the path to the field on which to sort.
  string path = 1;

  // [optional] A filter that the inner objects inside the nested path should match with in order for its field values to be taken into account by sorting. Common case is to repeat the query / filter inside the nested filter or query. By default no filter is active.
  optional QueryContainer filter = 2;

  // [optional] The maximum number of children to consider per root document when picking the sort value. Defaults to unlimited.
  optional int32 max_children = 3;

  // [optional] Same as top-level nested but applies to another nested path within the current nested object.
  optional NestedSortValue nested = 4;
}

message FieldAndFormat {

  // [required] Wildcard pattern. The request returns doc values for field names matching this pattern.
  string field = 1;

  // [optional] Format in which the values are returned.
  optional string format = 2;
}

message FieldCollapse {

  // [required] The document field by which you want to group or collapse the search results
  string field = 1;

  // [optional] Expanding each group uses an additional query for each inner_hit request for every collapsed hit in the response.
  repeated InnerHits inner_hits = 2;

  // [optional] Use to control the maximum number of concurrent searches allowed in this phase.
  optional int32 max_concurrent_group_searches = 3;
}

message ExistsQuery {

  // [required] Name of the field you wish to search.
  string field = 1;

  // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
  optional float boost = 2;

  // [optional] Query name for query tagging.
  optional string x_name = 3;
}

message WildcardQuery {

  // [required] Specifies the field against which to run a search query
  string field = 1;

  // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
  optional float boost = 2;

  // [optional] The name of the query for query tagging.
  optional string x_name = 3;

  // [optional] Allows case insensitive matching of the pattern with the indexed field values when set to `true`. Default is `false` which means the case sensitivity of matching depends on the underlying field's mapping.
  optional bool case_insensitive = 4;

  optional MultiTermQueryRewrite rewrite_deprecated = 5 [deprecated = true];

  // [optional] Wildcard pattern for terms you wish to find in the provided field. Required, when wildcard is not set.
  optional string value = 6;

  // [optional] Wildcard pattern for terms you wish to find in the provided field. Required, when value is not set.
  optional string wildcard = 7;

  optional string rewrite = 8;
}

message KnnQuery {

  // [required] Specifies the vector field against which to run a search query
  string field = 1;

  // [optional]
  // Query vector. Must have the same number of dimensions as the vector field you are searching against.
  repeated float vector = 2;

  // [optional]
  // The final number of nearest neighbors to return as top hits.
  optional int32 k = 3;

  // [optional]
  // The minimum similarity score for a neighbor to be considered a hit.
  optional float min_score = 4;

  // [optional]
  // The maximum physical distance in vector space for a neighbor to be considered a hit.
  optional float max_distance = 5;

  // [optional]
  // Filters for the kNN search query. The kNN search will return the top k documents that also match this filter. If filter is not provided, all documents are allowed to match.
  optional QueryContainer filter = 6;

  // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
  optional float boost = 7;

  // [optional] Query name for query tagging.
  optional string x_name = 8;

  // [optional]
  // Method parameters are dependent on the combination of engine and method used to create the index.
  // Available method ef_search see https://opensearch.org/docs/latest/search-plugins/knn/approximate-knn/#ef_search and nprobes "https://opensearch.org/docs/latest/search-plugins/knn/approximate-knn/#nprobes"
  optional ObjectMap method_parameters = 9;

  // [optional]
  // Available in version later than 2.17
  // To explicitly apply rescoring, provide the rescore parameter in a query on a quantized index and specify the oversample_factor "https://opensearch.org/docs/latest/search-plugins/knn/approximate-knn/#rescoring-quantized-results-using-full-precision"
  optional KnnQueryRescore rescore = 10;

  // [optional] When true, retrieves scores for all nested field documents within each parent document. Used with nested queries. For more information, see Vector search with nested fields.
  optional bool expand_nested_docs = 11;
}

message RescoreContext {

  optional float oversample_factor = 1;
}

message KnnQueryRescore {
  oneof knn_query_rescore {
    bool enable = 1;

    RescoreContext context = 2;

  }
}

message MatchQuery {

  // [required] Specifies the field against which to run a search query
  string field = 1;

  // [required] The query string to use for search.
  FieldValue query = 2;

  // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
  optional float boost = 3;

  // [optional] Query name for query tagging.
  optional string x_name = 4;

  // [optional] The analyzer used to tokenize the query string text. Default is the index-time analyzer specified for the default_field. If no analyzer is specified for the default_field, the analyzer is the default analyzer for the index.
  optional string analyzer = 5;

  // [optional] Specifies whether to create a match phrase query automatically for multi-term synonyms. For example, if you specify ba,batting average as synonyms and search for ba, OpenSearch searches for ba OR "batting average" (if this option is true) or ba OR (batting AND average) (if this option is false).
  optional bool auto_generate_synonyms_phrase_query = 6;

  // [optional] The number of character edits (insertions, deletions, substitutions, or transpositions) that it takes to change one word to another when determining whether a term matched a value. For example, the distance between wined and wind is 1. Valid values are non-negative integers or AUTO.
  optional Fuzziness fuzziness = 7;

  // [optional] Determines how OpenSearch rewrites the query. Default is constant_score.
  optional MultiTermQueryRewrite fuzzy_rewrite_deprecated = 8 [deprecated = true];

  // [optional] Setting fuzzy_transpositions to true (default) adds swaps of adjacent characters to the insert, delete, and substitute operations of the fuzziness option. For example, the distance between wind and wnid is 1 if fuzzy_transpositions is true (swap “n” and “i”) and 2 if it is false (delete “n”, insert “n”). If fuzzy_transpositions is false, rewind and wnid have the same distance (2) from wind, despite the more human-centric opinion that wnid is an obvious typo. The default(true) is a good choice for most use cases.
  optional bool fuzzy_transpositions = 9;

  // [optional] Setting lenient to true ignores data type mismatches between the query and the document field. For example, a query string of "8.2" could match a field of type float. Default is false.
  optional bool lenient = 10;

  // [optional] The maximum number of terms to which the query can expand. Fuzzy queries “expand to” a number of matching terms that are within the distance specified in fuzziness. Then OpenSearch tries to match those terms. Default is 50.
  optional int32 max_expansions = 11;

  // [optional] If the query string contains multiple search terms and you use the or operator, the number of terms that need to match for the document to be considered a match. For example, if minimum_should_match is 2, wind often rising does not match The Wind Rises. If minimum_should_match is 1, it matches.
  optional MinimumShouldMatch minimum_should_match = 12;

  // [optional] If the query string contains multiple search terms, whether all terms need to match (AND) or only one term needs to match (OR) for a document to be considered a match. Default is OR.
  optional Operator operator = 13;

  // [optional] The number of leading characters that are not considered in fuzziness. Default is 0.
  optional int32 prefix_length = 14;

  // [optional] In some cases, the analyzer removes all terms from a query string. For example, the stop analyzer removes all terms from the string an but this. In those cases, zero_terms_query specifies whether to match no documents (none) or all documents (all). Valid values are none and all. Default is none.
  optional ZeroTermsQuery zero_terms_query = 15;

  // [optional] Determines how OpenSearch rewrites the query. Default is constant_score.
  optional string fuzzy_rewrite = 16;
}

message BoolQuery {

  // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
  optional float boost = 1;

  // [optional] The name of the query for query tagging.
  optional string x_name = 2;

  // [optional] The clause (query) must appear in matching documents. However, unlike `must`, the score of the query will be ignored.
  repeated QueryContainer filter = 3;

  // [optional]
  optional MinimumShouldMatch minimum_should_match = 4;

  // [optional]The clause (query) must appear in matching documents and will contribute to the score.
  repeated QueryContainer must = 5;

  // [optional] The clause (query) must not appear in the matching documents. Because scoring is ignored, a score of `0` is returned for all documents.
  repeated QueryContainer must_not = 6;

  // [optional] The clause (query) should appear in the matching document.
  repeated QueryContainer should = 7;

  // [optional] Ensures correct behavior when a query contains only `must_not` clauses. By default set to true, OpenSearch adds a match-all clause to ensure results are returned from Lucene, with the `must_not` conditions applied as filters. If set to false, the query may return no results, as Lucene typically requires at least one positive condition.
  optional bool adjust_pure_negative = 8;
}

message MinimumShouldMatch {
  oneof minimum_should_match {
    // if minimum_should_match is integer type. see "https://opensearch.org/docs/latest/query-dsl/minimum-should-match/#valid-values"
    int32 int32 = 1;

    // if minimum_should_match is string type like percentage or combinations. see "https://opensearch.org/docs/latest/query-dsl/minimum-should-match/#valid-values"
    string string = 2;

  }
}

message ConstantScoreQuery {

  // [required] The filter query that a document must match to be returned in the results.
  QueryContainer filter = 1;

  // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
  optional float boost = 2;

  // [optional] Query name for query tagging.
  optional string x_name = 3;
}

message FunctionScoreQuery {

  // [required] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
  optional float boost = 1;

  // [optional] Query name for query tagging.
  optional string x_name = 2;

  // [optional] how the score computed using all functions is combined with the query score.
  optional FunctionBoostMode boost_mode = 3;

  // [optional] One or more functions that compute a new score for each document returned by the query.
  repeated FunctionScoreContainer functions = 4;

  // [optional] Restricts the new score to not exceed the provided limit.
  optional float max_boost = 5;

  // [optional] Excludes documents that do not meet the provided score threshold.
  optional float min_score = 6;

  // [optional]
  optional QueryContainer query = 7;

  // [optional] Specifies how the computed scores are combined
  optional FunctionScoreMode score_mode = 8;
}

message FunctionScoreContainer {

  // [optional]
  optional QueryContainer filter = 1;

  // [optional]  allows you to multiply the score by the provided weight
  optional float weight = 2;
  oneof function_score_container {
    // Exponential decay
    DecayFunction exp = 3;

    // Normal decay
    DecayFunction gauss = 4;

    // Linear decay
    DecayFunction linear = 5;

    // Allows you to use a field from a document to influence the score
    FieldValueFactorScoreFunction field_value_factor = 6;

    // Generates scores that are uniformly distributed from 0 up to but not including 1
    RandomScoreFunction random_score = 7;

    // Allows you to wrap another query and customize the scoring of it optionally with a computation derived from other numeric field values in the doc using a script expression
    ScriptScoreFunction script_score = 8;

  }
}

message DecayFunction {

  // [optional] specify for decay calculation contains multiple values
  optional MultiValueMode multi_value_mode = 1;

  // [required] Decay functions score a document with a function that decays depending on the distance of a numeric field value of the document from a user given origin
  map<string, DecayPlacement> placement = 2;
}

message DecayPlacement {
  oneof decay_placement {
    DateDecayPlacement date_decay_placement = 1;

    GeoDecayPlacement geo_decay_placement = 2;

    NumericDecayPlacement numeric_decay_placement = 3;

  }
}

message DateDecayPlacement {

  // [required] Defines the distance from origin + offset at which the computed score will equal decay parameter
  string scale = 1;

  // [optional] The decay parameter defines how documents are scored at the distance given at scale
  optional double decay = 2;

  // [optional] If an offset is defined, the decay function will only compute the decay function for documents with a distance greater than the defined offset.
  optional string offset = 3;

  // [optional] The decay function will only compute the decay function for documents with a distance greater than the defined
  optional string origin = 4;
}

message GeoDecayPlacement {

  // [required] Defines the distance from origin + offset at which the computed score will equal decay parameter
  string scale = 1;

  // [required] The point of origin used for calculating distance
  GeoLocation origin = 2;

  // [optional] The decay parameter defines how documents are scored at the distance given at scale
  optional double decay = 3;

  // [optional] The decay function will only compute the decay function for documents with a distance greater than the defined
  optional string offset = 4;
}

message NumericDecayPlacement {

  // [required] Defines the distance from origin + offset at which the computed score will equal decay parameter
  double scale = 1;

  // [required] The point of origin used for calculating distance
  double origin = 2;

  // [optional] The decay parameter defines how documents are scored at the distance given at scale
  optional double decay = 3;

  // [optional] The decay function will only compute the decay function for documents with a distance greater than the defined
  optional double offset = 4;
}

message ScriptScoreFunction {

  Script script = 1;
}

message PrefixQuery {

  // [required] Specifies the field against which to run a search query
  string field = 1;

  // [required] The term to search for in the field specified in <field>.
  string value = 2;

  // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
  optional float boost = 3;

  // [optional] Query name for query tagging.
  optional string x_name = 4;

  // [optional] Determines how OpenSearch rewrites the query. Default is constant_score.
  optional MultiTermQueryRewrite rewrite_deprecated = 5 [deprecated = true];

  // [optional] Allows ASCII case insensitive matching of the value with the indexed field values when set to `true`. Default is `false` which means the case sensitivity of matching depends on the underlying field's mapping.
  optional bool case_insensitive = 6;

  // [optional] Determines how OpenSearch rewrites the query. Default is constant_score.
  optional string rewrite = 7;
}

message TermsQueryField {
  oneof terms_query_field {
    FieldValueArray value = 1;

    TermsLookup lookup = 2;

  }
}

message TermsLookup {

  string index = 1;

  // The unique identifier for a resource.
  string id = 2;

  // The path to a field or an array of paths. Some APIs support wildcards in the path, which allows you to select multiple fields.
  string path = 3;

  // The routing value for the document.
  optional string routing = 4;

  optional bool store = 5;
}

message FieldValueArray {

  repeated FieldValue field_value_array = 1;
}

message TermsSetQuery {

  // [required] Specifies the field against which to run a search query
  string field = 1;

  // [required] The array of terms to search for in the field specified in <field>. A document is returned in the results only if the required number of terms matches the document's field values exactly, with the correct spacing and capitalization.
  repeated string terms = 2;

  // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
  optional float boost = 3;

  // [optional] Query name for query tagging.
  optional string x_name = 4;

  // [optional] The name of the numeric field that specifies the number of matching terms required in order to return a document in the results.
  optional string minimum_should_match_field = 5;

  // [optional] A script that returns the number of matching terms required in order to return a document in the results.
  optional Script minimum_should_match_script = 6;
}

message RegexpQuery {

  // [required] Specifies the field against which to run a search query
  string field = 1;

  // [required] Regular expression for terms you wish to find in the provided field.
  string value = 2;

  // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
  optional float boost = 3;

  // [optional] Query name for query tagging
  optional string x_name = 4;

  // [optional] If true, allows case-insensitive matching of the regular expression value with the indexed field values. Default is false (case sensitivity is determined by the field’s mapping).
  optional bool case_insensitive = 5;

  // [optional] Enables optional operators for the regular expression.
  optional string flags = 6;

  // [optional] Lucene converts a regular expression to an automaton with a number of determinized states. This parameter specifies the maximum number of automaton states the query requires. Use this parameter to prevent high resource consumption. To run complex regular expressions, you may need to increase the value of this parameter. Default is 10,000.
  optional int32 max_determinized_states = 7;

  // [optional] Determines how OpenSearch rewrites and scores multi-term queries. Valid values are constant_score, scoring_boolean, constant_score_boolean, top_terms_N, top_terms_boost_N, and top_terms_blended_freqs_N. Default is constant_score.
  optional MultiTermQueryRewrite rewrite_deprecated = 8 [deprecated = true];

  // [optional] Determines how OpenSearch rewrites and scores multi-term queries. Valid values are constant_score, scoring_boolean, constant_score_boolean, top_terms_N, top_terms_boost_N, and top_terms_blended_freqs_N. Default is constant_score.
  optional string rewrite = 9;
}

message TermQuery {

  // [required] Specifies the field against which to run a search query
  string field = 1;

  // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
  optional float boost = 2;

  // [optional] Query name for query tagging.
  optional string x_name = 3;

  // [required]
  // Term you wish to find in the provided <field>. To return a document, the term must exactly match the field value, including whitespace and capitalization.
  FieldValue value = 4;

  // [optional]
  // Allows ASCII case insensitive matching of the value with the indexed field values when set to `true`. When `false`, the case sensitivity of matching depends on the underlying field's mapping.
  optional bool case_insensitive = 5;
}

message RandomScoreFunction {

  // The path to a field or an array of paths. Some APIs support wildcards in the path, which allows you to select multiple fields.
  optional string field = 1;

  optional RandomScoreFunctionSeed seed = 2;
}

message RandomScoreFunctionSeed {
  oneof random_score_function_seed {
    int32 int32 = 1;

    int64 int64 = 2;

    string string = 3;

  }
}

message RangeQuery {
  oneof range_query {
    NumberRangeQuery number_range_query = 1;

    DateRangeQuery date_range_query = 2;

  }
}

message NumberRangeQuery {

  // [required] Specifies the field against which to run a search query
  string field = 1;

  // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
  optional float boost = 2;

  // [optional] Query name for query tagging.
  optional string x_name = 3;

  // [optional] Indicates how the range query matches values for range fields
  optional RangeRelation relation = 4;

  // [optional] Greater than.
  optional double gt = 5;

  // [optional] Greater than or equal to.
  optional double gte = 6;

  // [optional] Less than.
  optional double lt = 7;

  // [optional] Less than or equal to.
  optional double lte = 8;

  // [optional]
  optional NumberRangeQueryAllOfFrom from = 9;

  // [optional]
  optional NumberRangeQueryAllOfTo to = 10;

  // [optional] Include the lower bound
  optional bool include_lower = 11;

  // [optional] Include the upper bound
  optional bool include_upper = 12;
}

message NumberRangeQueryAllOfFrom {
  oneof number_range_query_all_of_from {
    double double = 1;

    string string = 2;

    NullValue null_value = 3;

  }
}

message NumberRangeQueryAllOfTo {
  oneof number_range_query_all_of_to {
    double double = 1;

    string string = 2;

    NullValue null_value = 3;

  }
}

message DateRangeQuery {

  // [required] Specifies the field against which to run a search query
  string field = 1;

  // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
  optional float boost = 2;

  // [optional] Query name for query tagging.
  optional string x_name = 3;

  // [optional] Indicates how the range query matches values for range fields
  optional RangeRelation relation = 4;

  // [optional] Greater than.
  optional string gt = 5;

  // [optional] Greater than or equal to.
  optional string gte = 6;

  // [optional] Less than.
  optional string lt = 7;

  // [optional] Less than or equal to.
  optional string lte = 8;

  // [optional]
  optional DateRangeQueryAllOfFrom from = 9;

  // [optional]
  optional DateRangeQueryAllOfTo to = 10;

  // [optional] The date format pattern.
  optional string format = 11;

  // [optional] The time zone identifier.
  optional string time_zone = 12;

  // [optional] Include the lower bound
  optional bool include_lower = 13;

  // [optional] Include the upper bound
  optional bool include_upper = 14;
}

message DateRangeQueryAllOfFrom {
  oneof date_range_query_all_of_from {
    string string = 1;

    NullValue null_value = 2;

  }
}

message DateRangeQueryAllOfTo {
  oneof date_range_query_all_of_to {
    string string = 1;

    NullValue null_value = 2;

  }
}

message FuzzyQuery {

  // [required] Specifies the field against which to run a search query
  string field = 1;

  // [required] Term you wish to find in the provided <field>.
  FieldValue value = 2;

  // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
  optional float boost = 3;

  // [optional] Query name for query tagging.
  optional string x_name = 4;

  // [optional] The maximum number of terms to which the query can expand. Fuzzy queries "expand to" a number of matching terms that are within the distance specified in fuzziness. Then OpenSearch tries to match those terms. Default is 50.
  optional int32 max_expansions = 5;

  // [optional] The number of leading characters that are not considered in fuzziness. Default is 0.
  optional int32 prefix_length = 6;

  // [optional] Determines how OpenSearch rewrites the query. Default is constant_score.
  optional MultiTermQueryRewrite rewrite_deprecated = 7 [deprecated = true];

  // [optional] Specifies whether to allow transpositions of two adjacent characters (ab to ba) as edits. Default is true.
  optional bool transpositions = 8;

  // [optional] The number of character edits (insert, delete, substitute) needed to change one word to another when determining whether a term matched a value.
  optional Fuzziness fuzziness = 9;

  // [optional] Determines how OpenSearch rewrites the query. Default is constant_score.
  optional string rewrite = 10;
}

message Fuzziness {
  oneof fuzziness {
    // AUTO: Generates an edit distance based on the length of the term. Low and high distance arguments may be optionally provided AUTO:[low],[high]. AUTO should generally be the preferred value for fuzziness.
    string string = 1;

    // 0,1,2: The maximum allowed Levenshtein Edit Distance (or number of edits)
    int32 int32 = 2;

  }
}

message FieldValue {

  optional bool bool = 1;

  optional GeneralNumber general_number = 2;

  optional string string = 3;

  optional NullValue null_value = 4;
}

message IdsQuery {

  // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
  optional float boost = 1;

  // [optional] Query name for query tagging.
  optional string x_name = 2;

  repeated string values = 3;
}

message MatchAllQuery {

  // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
  optional float boost = 1;

  // [optional] Query name for query tagging.
  optional string x_name = 2;
}

message MatchBoolPrefixQuery {

  // [required] Specifies the field against which to run a search query
  string field = 1;

  // [required] Terms you wish to find in the provided field. The last term is used in a prefix query.
  string query = 2;

  // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
  optional float boost = 3;

  // [optional] Query name for query tagging.
  optional string x_name = 4;

  // [optional] The analyzer used to tokenize the query string text. Default is the index-time analyzer specified for the default_field. If no analyzer is specified for the default_field, the analyzer is the default analyzer for the index.
  optional string analyzer = 5;

  // [optional] The number of character edits (insert, delete, substitute) that it takes to change one word to another when determining whether a term matched a value. For example, the distance between wined and wind is 1. The default, AUTO, chooses a value based on the length of each term and is a good choice for most use cases.
  optional Fuzziness fuzziness = 6;

  // [optional] Determines how OpenSearch rewrites the query. Default is constant_score.
  optional MultiTermQueryRewrite fuzzy_rewrite_deprecated = 7 [deprecated = true];

  // [optional] Setting fuzzy_transpositions to true (default) adds swaps of adjacent characters to the insert, delete, and substitute operations of the fuzziness option. For example, the distance between wind and wnid is 1 if fuzzy_transpositions is true (swap “n” and “i”) and 2 if it is false (delete “n”, insert “n”). If fuzzy_transpositions is false, rewind and wnid have the same distance (2) from wind, despite the more human-centric opinion that wnid is an obvious typo. The default(true) is a good choice for most use cases.
  optional bool fuzzy_transpositions = 8;

  // [optional] The maximum number of terms to which the query can expand. Fuzzy queries “expand to” a number of matching terms that are within the distance specified in fuzziness. Then OpenSearch tries to match those terms. Default is 50.
  optional int32 max_expansions = 9;

  // [optional] If the query string contains multiple search terms and you use the or operator, the number of terms that need to match for the document to be considered a match. For example, if minimum_should_match is 2, wind often rising does not match The Wind Rises. If minimum_should_match is 1, it matches.
  optional MinimumShouldMatch minimum_should_match = 10;

  // [optional] If the query string contains multiple search terms, whether all terms need to match (and) or only one term needs to match (or) for a document to be considered a match. Default is or.
  optional Operator operator = 11;

  // [optional] The number of leading characters that are not considered in fuzziness. Default is 0.
  optional int32 prefix_length = 12;

  // [optional] Determines how OpenSearch rewrites the query. Default is constant_score.
  optional string fuzzy_rewrite = 13;
}

message MatchNoneQuery {

  // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
  optional float boost = 1;

  // [optional] Query name for query tagging.
  optional string x_name = 2;
}

message MatchPhrasePrefixQuery {

  // [required] Specifies the field against which to run a search query
  string field = 1;

  // [required] The query string to use for search
  string query = 2;

  // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
  optional float boost = 3;

  // [optional] Query name for query tagging.
  optional string x_name = 4;

  // [optional] The analyzer used to tokenize the query string text. Default is the index-time analyzer specified for the default_field. If no analyzer is specified for the default_field, the analyzer is the default analyzer for the index.
  optional string analyzer = 5;

  // [optional] The maximum number of terms to which the query can expand. Fuzzy queries “expand to” a number of matching terms that are within the distance specified in fuzziness. Then OpenSearch tries to match those terms. Default is 50.
  optional int32 max_expansions = 6;

  // [optional] Controls the degree to which words in a query can be misordered and still be considered a match. From the Lucene documentation: “The number of other words permitted between words in query phrase. For example, to switch the order of two words requires two moves (the first move places the words atop one another), so to permit reorderings of phrases, the slop must be at least two. A value of zero requires an exact match.”
  optional int32 slop = 7;

  // [optional] In some cases, the analyzer removes all terms from a query string. For example, the stop analyzer removes all terms from the string an but this. In those cases, zero_terms_query specifies whether to match no documents (none) or all documents (all). Valid values are none and all. Default is none.
  optional ZeroTermsQuery zero_terms_query = 8;
}

message MatchPhraseQuery {

  // [required] Specifies the field against which to run a search query
  string field = 1;

  // [required] The query string to use for search.
  string query = 2;

  // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
  optional float boost = 3;

  // [optional] The name of the query for query tagging.
  optional string x_name = 4;

  // [optional] The analyzer used to tokenize the query string text. Default is the index-time analyzer specified for the default_field. If no analyzer is specified for the default_field, the analyzer is the default analyzer for the index.
  optional string analyzer = 5;

  // [optional] Controls the degree to which words in a query can be misordered and still be considered a match. From the Lucene documentation: “The number of other words permitted between words in query phrase. For example, to switch the order of two words requires two moves (the first move places the words atop one another), so to permit reorderings of phrases, the slop must be at least two. A value of zero requires an exact match.”
  optional int32 slop = 6;

  // [optional] In some cases, the analyzer removes all terms from a query string. For example, the stop analyzer removes all terms from the string an but this. In those cases, zero_terms_query specifies whether to match no documents (none) or all documents (all). Valid values are none and all. Default is none.
  optional ZeroTermsQuery zero_terms_query = 7;
}

message MultiMatchQuery {

  // [required] The query string to use for search.
  string query = 1;

  // [optional] Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
  optional float boost = 2;

  // [optional] The name of the query for query tagging.
  optional string x_name = 3;

  // [optional] The analyzer used to tokenize the query string text. Default is the index-time analyzer specified for the default_field. If no analyzer is specified for the default_field, the analyzer is the default analyzer for the index. For more information about index.query.default_field, see Dynamic index-level index settings.
  optional string analyzer = 4;

  // [optional] Specifies whether to create a match phrase query automatically for multi-term synonyms. For example, if you specify ba,batting average as synonyms and search for ba, OpenSearch searches for ba OR "batting average" (if this option is true) or ba OR (batting AND average) (if this option is false). Default is true.
  optional bool auto_generate_synonyms_phrase_query = 5;

  // [optional] The list of fields in which to search. If you don’t provide the fields parameter, multi_match query searches the fields specified in the index.query.default_field setting, which defaults to *.
  repeated string fields = 6;

  // [optional] Determines how OpenSearch rewrites the query. Valid values are constant_score, scoring_boolean, constant_score_boolean, top_terms_N, top_terms_boost_N, and top_terms_blended_freqs_N. If the fuzziness parameter is not 0, the query uses a fuzzy_rewrite method of top_terms_blended_freqs_${max_expansions} by default. Default is constant_score.
  optional MultiTermQueryRewrite fuzzy_rewrite_deprecated = 7 [deprecated = true];

  // [optional] The number of character edits (insert, delete, substitute) that it takes to change one word to another when determining whether a term matched a value.
  optional Fuzziness fuzziness = 8;

  // [optional] Setting fuzzy_transpositions to true (default) adds swaps of adjacent characters to the insert, delete, and substitute operations of the fuzziness option. For example, the distance between wind and wnid is 1 if fuzzy_transpositions is true (swap “n” and “i”) and 2 if it is false (delete “n”, insert “n”). If fuzzy_transpositions is false, rewind and wnid have the same distance (2) from wind, despite the more human-centric opinion that wnid is an obvious typo. The default is a good choice for most use cases.
  optional bool fuzzy_transpositions = 9;

  // [optional] Setting lenient to true ignores data type mismatches between the query and the document field. For example, a query string of "8.2" could match a field of type float. Default is false.
  optional bool lenient = 10;

  // [optional] The maximum number of terms to which the query can expand. Fuzzy queries “expand to” a number of matching terms that are within the distance specified in fuzziness. Then OpenSearch tries to match those terms. Default is 50.
  optional int32 max_expansions = 11;

  // [optional] If the query string contains multiple search terms and you use the or operator, the number of terms that need to match for the document to be considered a match. For example, if minimum_should_match is 2, wind often rising does not match The Wind Rises. If minimum_should_match is 1, it matches. For details, see Minimum should match.
  optional MinimumShouldMatch minimum_should_match = 12;

  // [optional] If the query string contains multiple search terms, whether all terms need to match (AND) or only one term needs to match (OR) for a document to be considered a match. Valid values are: 1) OR: The string to be is interpreted as to OR be. 2) AND: The string to be is interpreted as to AND be. Default is OR.
  optional Operator operator = 13;

  // [optional] The number of leading characters that are not considered in fuzziness. Default is 0.
  optional int32 prefix_length = 14;

  // [optional] Controls the degree to which words in a query can be misordered and still be considered a match. From the Lucene documentation: “The number of other words permitted between words in query phrase. For example, to switch the order of two words requires two moves (the first move places the words atop one another), so to permit reorderings of phrases, the slop must be at least two. A value of zero requires an exact match.” Supported for phrase and phrase_prefix query types.
  optional int32 slop = 15;

  // [optional] A factor between 0 and 1.0 that is used to give more weight to documents that match multiple query clauses. For more information, see The tie_breaker parameter`.
  optional float tie_breaker = 16;

  // [optional] The multi-match query type. Valid values are best_fields, most_fields, cross_fields, phrase, phrase_prefix, bool_prefix. Default is best_fields.
  optional TextQueryType type = 17;

  // [optional] In some cases, the analyzer removes all terms from a query string. For example, the stop analyzer removes all terms from the string an but this. In those cases, zero_terms_query specifies whether to match no documents (none) or all documents (all). Valid values are none and all. Default is none.
  optional ZeroTermsQuery zero_terms_query = 18;

  // [optional] Determines how OpenSearch rewrites the query. Valid values are constant_score, scoring_boolean, constant_score_boolean, top_terms_N, top_terms_boost_N, and top_terms_blended_freqs_N. If the fuzziness parameter is not 0, the query uses a fuzzy_rewrite method of top_terms_blended_freqs_${max_expansions} by default. Default is constant_score.
  optional string fuzzy_rewrite = 19;
}

message FieldValueFactorScoreFunction {

  // [required] Path to field or array of paths. Some API's support wildcards in the path to select multiple fields.
  string field = 1;

  // [optional] Optional factor to multiply the field value with.
  optional float factor = 2;

  // [optional] Value used if the document doesn't have that field. The modifier and factor are still applied to it as though it were read from the document.
  optional double missing = 3;

  // [optional]
  optional FieldValueFactorModifier modifier = 4;
}

message DoubleMap {

  // A map of matched query names to their scores (when `include_named_queries_score` is true).
  map<string, double> double_map = 1;
}

message HitMatchedQueries {
  oneof hit_matched_queries {
    StringArray names = 1;

    DoubleMap scores = 2;

  }
}

message BoostingQuery {

  // Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
  optional float boost = 1;

  optional string x_name = 2;

  // Floating point number between 0 and 1.0 used to decrease the relevance scores of documents matching the `negative` query.
  float negative_boost = 3;

  QueryContainer negative = 4;

  QueryContainer positive = 5;
}

message SimpleQueryStringFlags {
  oneof simple_query_string_flags {
    SimpleQueryStringFlag single = 1;

    string multiple = 2;

  }
}

message SimpleQueryStringQuery {

  // Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
  optional float boost = 1;

  optional string x_name = 2;

  // Analyzer used to convert text in the query string into tokens.
  optional string analyzer = 3;

  // If `true`, the query attempts to analyze wildcard terms in the query string.
  optional bool analyze_wildcard = 4;

  // If `true`, the parser creates a `match_phrase` query for each multi-position token.
  optional bool auto_generate_synonyms_phrase_query = 5;

  optional Operator default_operator = 6;

  // Array of fields you wish to search. Accepts wildcard expressions. You also can boost relevance scores for matches to particular fields using a caret (`^`) notation. Defaults to the `index.query.default_field index` setting, which has a default value of `*`.
  repeated string fields = 7;

  optional SimpleQueryStringFlags flags = 8;

  // Maximum number of terms to which the query expands for fuzzy matching.
  optional int32 fuzzy_max_expansions = 9;

  // Number of beginning characters left unchanged for fuzzy matching.
  optional int32 fuzzy_prefix_length = 10;

  // If `true`, edits for fuzzy matching include transpositions of two adjacent characters (for example, `ab` to `ba`).
  optional bool fuzzy_transpositions = 11;

  // If `true`, format-based errors, such as providing a text value for a numeric field, are ignored.
  optional bool lenient = 12;

  optional MinimumShouldMatch minimum_should_match = 13;

  // Query string in the simple query string syntax you wish to parse and use for search.
  string query = 14;

  // Suffix appended to quoted text in the query string.
  optional string quote_field_suffix = 15;
}

message ShardSearchFailure {

  // The shard id where the failure occurred.
  int32 shard = 1;

  // The index name where the failure occurred.
  optional string index = 2;

  // The node id where the failure occurred.
  optional string node = 3;

  ErrorCause reason = 4;
}

message Aggregate {

  optional DoubleTermsAggregate dterms = 1;

  optional LongTermsAggregate lterms = 2;

  optional MaxAggregate max = 3;

  optional MinAggregate min = 4;

  optional StringTermsAggregate sterms = 5;

  optional UnsignedLongTermsAggregate ulterms = 6;

  optional UnmappedTermsAggregate umterms = 7;
}

message AggregationContainer {

  // Custom metadata to associate with the aggregation (optional)
  optional ObjectMap meta = 1;
  oneof aggregation_container {
    MaxAggregation max = 2;

    MinAggregation min = 3;

    TermsAggregation terms = 4;

  }
}

message DoubleTermsAggregate {

  // The custom metadata attached to a resource.
  optional ObjectMap meta = 1;

  repeated DoubleTermsBucket buckets = 2;

  optional int64 doc_count_error_upper_bound = 3;

  optional int64 sum_other_doc_count = 4;
}

message DoubleTermsBucket {

  int64 doc_count = 1;

  map<string, Aggregate> aggregate = 2;

  // Upper bound of the document count error. Only present when `show_term_doc_count_error` is true.
  optional int64 doc_count_error_upper_bound = 3;

  double key = 4;

  optional string key_as_string = 5;
}

message FloatMap {

  map<string, float> float_map = 1;
}

message LongTermsAggregate {

  // The custom metadata attached to a resource.
  optional ObjectMap meta = 1;

  repeated LongTermsBucket buckets = 2;

  optional int64 doc_count_error_upper_bound = 3;

  optional int64 sum_other_doc_count = 4;
}

message LongTermsBucket {

  int64 doc_count = 1;

  map<string, Aggregate> aggregate = 2;

  // Upper bound of the document count error. Only present when `show_term_doc_count_error` is true.
  optional int64 doc_count_error_upper_bound = 3;

  LongTermsBucketKey key = 4;

  optional string key_as_string = 5;
}

message LongTermsBucketKey {
  oneof long_terms_bucket_key {
    int64 signed = 1;

    string unsigned = 2;

  }
}

message MaxAggregate {

  // The custom metadata attached to a resource.
  optional ObjectMap meta = 1;

  SingleMetricAggregateBaseAllOfValue value = 2;

  optional string value_as_string = 3;
}

message MaxAggregation {

  // Custom metadata to associate with the aggregation (optional)
  optional ObjectMap meta = 1;

  optional FieldValue missing = 2;

  // The path to a field or an array of paths. Some APIs support wildcards in the path, which allows you to select multiple fields.
  optional string field = 3;

  optional Script script = 4;

  optional string format = 5;

  optional ValueType value_type = 6;
}

message MinAggregate {

  // The custom metadata attached to a resource.
  optional ObjectMap meta = 1;

  SingleMetricAggregateBaseAllOfValue value = 2;

  optional string value_as_string = 3;
}

message MinAggregation {

  // Custom metadata to associate with the aggregation (optional)
  optional ObjectMap meta = 1;

  optional FieldValue missing = 2;

  // The path to a field or an array of paths. Some APIs support wildcards in the path, which allows you to select multiple fields.
  optional string field = 3;

  optional Script script = 4;

  optional string format = 5;

  optional ValueType value_type = 6;
}

message SingleMetricAggregateBaseAllOfValue {
  oneof single_metric_aggregate_base_all_of_value {
    double double = 1;

    NullValue null_value = 2;

  }
}

message SortOrderSingleMap {

  string field = 1;

  SortOrder sort_order = 2;
}

message StringTermsAggregate {

  // The custom metadata attached to a resource.
  optional ObjectMap meta = 1;

  repeated StringTermsBucket buckets = 2;

  optional int64 doc_count_error_upper_bound = 3;

  optional int64 sum_other_doc_count = 4;
}

message StringTermsBucket {

  int64 doc_count = 1;

  map<string, Aggregate> aggregate = 2;

  // Upper bound of the document count error. Only present when `show_term_doc_count_error` is true.
  optional int64 doc_count_error_upper_bound = 3;

  string key = 4;
}

message TermsAggregation {

  // Custom metadata to associate with the aggregation (optional)
  optional ObjectMap meta = 1;

  // Sub-aggregations for this bucket aggregation
  map<string, AggregationContainer> aggregations = 2;

  optional TermsAggregationCollectMode collect_mode = 3;

  repeated string exclude = 4;

  optional TermsAggregationExecutionHint execution_hint = 5;

  optional TermsInclude include = 6;

  // Only return values that are found in more than `min_doc_count` hits.
  optional int64 min_doc_count = 7;

  optional FieldValue missing = 8;

  // Coerced unmapped fields into the specified type.
  optional ValueType value_type = 9;

  repeated SortOrderSingleMap order = 10;

  // The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.
  optional int32 shard_size = 11;

  // The minimum number of documents in a bucket on each shard for it to be returned.
  optional int64 shard_min_doc_count = 12;

  // Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.
  optional bool show_term_doc_count_error = 13;

  // The number of buckets returned out of the overall terms list.
  optional int32 size = 14;

  optional string format = 15;

  // The path to a field or an array of paths. Some APIs support wildcards in the path, which allows you to select multiple fields.
  optional string field = 16;

  optional Script script = 17;
}

message TermsInclude {
  oneof terms_include {
    StringArray terms = 1;

    TermsPartition partition = 2;

  }
}

message TermsPartition {

  // The number of partitions.
  int32 num_partitions = 1;

  // The partition number for this request.
  int32 partition = 2;
}

message UnmappedTermsAggregate {

  // The custom metadata attached to a resource.
  optional ObjectMap meta = 1;

  repeated ObjectMap buckets = 2;

  optional int64 doc_count_error_upper_bound = 3;

  optional int64 sum_other_doc_count = 4;
}

message UnsignedLongTermsAggregate {

  // The custom metadata attached to a resource.
  optional ObjectMap meta = 1;

  repeated UnsignedLongTermsBucket buckets = 2;

  optional int64 doc_count_error_upper_bound = 3;

  optional int64 sum_other_doc_count = 4;
}

message UnsignedLongTermsBucket {

  int64 doc_count = 1;

  map<string, Aggregate> aggregate = 2;

  // Upper bound of the document count error. Only present when `show_term_doc_count_error` is true.
  optional int64 doc_count_error_upper_bound = 3;

  // The unsigned 64-bit integer bucket key. While JSON represents this as a number, values larger than 2^53--1 may lose precision in JSON serialization. The gRPC protocol buffer definition uses uint64 to preserve full precision. Use `key_as_string` for exact string representation of large values.
  Uint64 key = 4;

  // String representation of the key. Only present when a custom `format` parameter is specified in the aggregation request.
  optional string key_as_string = 5;
}

enum FieldValueFactorModifier {
  FIELD_VALUE_FACTOR_MODIFIER_UNSPECIFIED = 0;
  FIELD_VALUE_FACTOR_MODIFIER_LN = 1;
  FIELD_VALUE_FACTOR_MODIFIER_LN1P = 2;
  FIELD_VALUE_FACTOR_MODIFIER_LN2P = 3;
  FIELD_VALUE_FACTOR_MODIFIER_LOG = 4;
  FIELD_VALUE_FACTOR_MODIFIER_LOG1P = 5;
  FIELD_VALUE_FACTOR_MODIFIER_LOG2P = 6;
  FIELD_VALUE_FACTOR_MODIFIER_NONE = 7;
  FIELD_VALUE_FACTOR_MODIFIER_RECIPROCAL = 8;
  FIELD_VALUE_FACTOR_MODIFIER_SQRT = 9;
  FIELD_VALUE_FACTOR_MODIFIER_SQUARE = 10;
}

enum WaitForActiveShardOptions {
  WAIT_FOR_ACTIVE_SHARD_OPTIONS_UNSPECIFIED = 0;
  WAIT_FOR_ACTIVE_SHARD_OPTIONS_ALL = 1;
  WAIT_FOR_ACTIVE_SHARD_OPTIONS_NULL = 2;
}

enum TotalHitsRelation {
  TOTAL_HITS_RELATION_UNSPECIFIED = 0;
  TOTAL_HITS_RELATION_EQ = 1;
  TOTAL_HITS_RELATION_GTE = 2;
}

enum ScoreMode {
  SCORE_MODE_UNSPECIFIED = 0;
  SCORE_MODE_AVG = 1;
  SCORE_MODE_MAX = 2;
  SCORE_MODE_MIN = 3;
  SCORE_MODE_MULTIPLY = 4;
  SCORE_MODE_TOTAL = 5;
}

enum OpType {
  OP_TYPE_UNSPECIFIED = 0;
  OP_TYPE_CREATE = 1;
  OP_TYPE_INDEX = 2;
}

enum VersionType {
  VERSION_TYPE_UNSPECIFIED = 0;
  VERSION_TYPE_EXTERNAL = 1;
  VERSION_TYPE_EXTERNAL_GTE = 2;
  VERSION_TYPE_INTERNAL = 3;
  VERSION_TYPE_FORCE = 4 [deprecated = true];
}

enum Refresh {
  REFRESH_UNSPECIFIED = 0;
  REFRESH_FALSE = 1;
  REFRESH_TRUE = 2;
  REFRESH_WAIT_FOR = 3;
}

enum BuiltinScriptLanguage {
  BUILTIN_SCRIPT_LANGUAGE_UNSPECIFIED = 0;
  BUILTIN_SCRIPT_LANGUAGE_EXPRESSION = 1;
  BUILTIN_SCRIPT_LANGUAGE_JAVA = 2;
  BUILTIN_SCRIPT_LANGUAGE_MUSTACHE = 3;
  BUILTIN_SCRIPT_LANGUAGE_PAINLESS = 4;
}

enum ExpandWildcard {
  EXPAND_WILDCARD_UNSPECIFIED = 0;
  EXPAND_WILDCARD_ALL = 1;
  EXPAND_WILDCARD_CLOSED = 2;
  EXPAND_WILDCARD_HIDDEN = 3;
  EXPAND_WILDCARD_NONE = 4;
  EXPAND_WILDCARD_OPEN = 5;
}

enum SearchType {
  SEARCH_TYPE_UNSPECIFIED = 0;
  SEARCH_TYPE_DFS_QUERY_THEN_FETCH = 1;
  SEARCH_TYPE_QUERY_THEN_FETCH = 2;
}

enum SuggestMode {
  SUGGEST_MODE_UNSPECIFIED = 0;
  SUGGEST_MODE_ALWAYS = 1;
  SUGGEST_MODE_MISSING = 2;
  SUGGEST_MODE_POPULAR = 3;
}

enum RangeRelation {
  RANGE_RELATION_UNSPECIFIED = 0;
  RANGE_RELATION_CONTAINS = 1;
  RANGE_RELATION_INTERSECTS = 2;
  RANGE_RELATION_WITHIN = 3;
}

enum TextQueryType {
  TEXT_QUERY_TYPE_UNSPECIFIED = 0;
  TEXT_QUERY_TYPE_BEST_FIELDS = 1;
  TEXT_QUERY_TYPE_BOOL_PREFIX = 2;
  TEXT_QUERY_TYPE_CROSS_FIELDS = 3;
  TEXT_QUERY_TYPE_MOST_FIELDS = 4;
  TEXT_QUERY_TYPE_PHRASE = 5;
  TEXT_QUERY_TYPE_PHRASE_PREFIX = 6;
}

enum ZeroTermsQuery {
  ZERO_TERMS_QUERY_UNSPECIFIED = 0;
  ZERO_TERMS_QUERY_ALL = 1;
  ZERO_TERMS_QUERY_NONE = 2;
}

enum TermsQueryValueType {
  TERMS_QUERY_VALUE_TYPE_UNSPECIFIED = 0;
  TERMS_QUERY_VALUE_TYPE_BITMAP = 1;
  TERMS_QUERY_VALUE_TYPE_DEFAULT = 2;
}

enum MultiValueMode {
  MULTI_VALUE_MODE_UNSPECIFIED = 0;
  MULTI_VALUE_MODE_AVG = 1;
  MULTI_VALUE_MODE_MAX = 2;
  MULTI_VALUE_MODE_MIN = 3;
  MULTI_VALUE_MODE_SUM = 4;
}

enum FunctionBoostMode {
  FUNCTION_BOOST_MODE_UNSPECIFIED = 0;
  FUNCTION_BOOST_MODE_AVG = 1;
  FUNCTION_BOOST_MODE_MAX = 2;
  FUNCTION_BOOST_MODE_MIN = 3;
  FUNCTION_BOOST_MODE_MULTIPLY = 4;
  FUNCTION_BOOST_MODE_REPLACE = 5;
  FUNCTION_BOOST_MODE_SUM = 6;
}

enum FunctionScoreMode {
  FUNCTION_SCORE_MODE_UNSPECIFIED = 0;
  FUNCTION_SCORE_MODE_AVG = 1;
  FUNCTION_SCORE_MODE_FIRST = 2;
  FUNCTION_SCORE_MODE_MAX = 3;
  FUNCTION_SCORE_MODE_MIN = 4;
  FUNCTION_SCORE_MODE_MULTIPLY = 5;
  FUNCTION_SCORE_MODE_SUM = 6;
}

enum Operator {
  OPERATOR_UNSPECIFIED = 0;
  OPERATOR_AND = 1;
  OPERATOR_OR = 2;
}

enum MultiTermQueryRewrite {
  MULTI_TERM_QUERY_REWRITE_UNSPECIFIED = 0;
  MULTI_TERM_QUERY_REWRITE_CONSTANT_SCORE = 1;
  MULTI_TERM_QUERY_REWRITE_CONSTANT_SCORE_BOOLEAN = 2;
  MULTI_TERM_QUERY_REWRITE_SCORING_BOOLEAN = 3;
  MULTI_TERM_QUERY_REWRITE_TOP_TERMS_N = 4;
  MULTI_TERM_QUERY_REWRITE_TOP_TERMS_BLENDED_FREQS_N = 5;
  MULTI_TERM_QUERY_REWRITE_TOP_TERMS_BOOST_N = 6;
}

enum GeoValidationMethod {
  GEO_VALIDATION_METHOD_UNSPECIFIED = 0;
  GEO_VALIDATION_METHOD_COERCE = 1;
  GEO_VALIDATION_METHOD_IGNORE_MALFORMED = 2;
  GEO_VALIDATION_METHOD_STRICT = 3;
}

enum ScriptSortType {
  SCRIPT_SORT_TYPE_UNSPECIFIED = 0;
  SCRIPT_SORT_TYPE_NUMBER = 1;
  SCRIPT_SORT_TYPE_STRING = 2;
  SCRIPT_SORT_TYPE_VERSION = 3;
}

enum FieldSortNumericType {
  FIELD_SORT_NUMERIC_TYPE_UNSPECIFIED = 0;
  FIELD_SORT_NUMERIC_TYPE_DATE = 1;
  FIELD_SORT_NUMERIC_TYPE_DATE_NANOS = 2;
  FIELD_SORT_NUMERIC_TYPE_DOUBLE = 3;
  FIELD_SORT_NUMERIC_TYPE_LONG = 4;
}

enum FieldType {
  FIELD_TYPE_UNSPECIFIED = 0;
  FIELD_TYPE_AGGREGATE_METRIC_DOUBLE = 1;
  FIELD_TYPE_ALIAS = 2;
  FIELD_TYPE_BINARY = 3;
  FIELD_TYPE_BOOLEAN = 4;
  FIELD_TYPE_BYTE = 5;
  FIELD_TYPE_COMPLETION = 6;
  FIELD_TYPE_CONSTANT_KEYWORD = 7;
  FIELD_TYPE_DATE = 8;
  FIELD_TYPE_DATE_NANOS = 9;
  FIELD_TYPE_DATE_RANGE = 10;
  FIELD_TYPE_DOUBLE = 11;
  FIELD_TYPE_DOUBLE_RANGE = 12;
  FIELD_TYPE_FLAT_OBJECT = 13;
  FIELD_TYPE_FLOAT = 14;
  FIELD_TYPE_FLOAT_RANGE = 15;
  FIELD_TYPE_GEO_POINT = 16;
  FIELD_TYPE_GEO_SHAPE = 17;
  FIELD_TYPE_HALF_FLOAT = 18;
  FIELD_TYPE_HISTOGRAM = 19;
  FIELD_TYPE_ICU_COLLATION_KEYWORD = 20;
  FIELD_TYPE_INTEGER = 21;
  FIELD_TYPE_INTEGER_RANGE = 22;
  FIELD_TYPE_IP = 23;
  FIELD_TYPE_IP_RANGE = 24;
  FIELD_TYPE_JOIN = 25;
  FIELD_TYPE_KEYWORD = 26;
  FIELD_TYPE_KNN_VECTOR = 27;
  FIELD_TYPE_LONG = 28;
  FIELD_TYPE_LONG_RANGE = 29;
  FIELD_TYPE_MATCH_ONLY_TEXT = 30;
  FIELD_TYPE_MURMUR3 = 31;
  FIELD_TYPE_NESTED = 32;
  FIELD_TYPE_OBJECT = 33;
  FIELD_TYPE_PERCOLATOR = 34;
  FIELD_TYPE_RANK_FEATURE = 35;
  FIELD_TYPE_RANK_FEATURES = 36;
  FIELD_TYPE_SCALED_FLOAT = 37;
  FIELD_TYPE_SEARCH_AS_YOU_TYPE = 38;
  FIELD_TYPE_SHORT = 39;
  FIELD_TYPE_TEXT = 40;
  FIELD_TYPE_TOKEN_COUNT = 41;
  FIELD_TYPE_UNSIGNED_LONG = 42;
  FIELD_TYPE_VERSION = 43;
  FIELD_TYPE_WILDCARD = 44;
  FIELD_TYPE_XY_POINT = 45;
  FIELD_TYPE_XY_SHAPE = 46;
  FIELD_TYPE_SEMANTIC = 47;
}

enum SortOrder {
  SORT_ORDER_UNSPECIFIED = 0;
  SORT_ORDER_ASC = 1;
  SORT_ORDER_DESC = 2;
}

enum SortMode {
  SORT_MODE_UNSPECIFIED = 0;
  SORT_MODE_AVG = 1;
  SORT_MODE_MAX = 2;
  SORT_MODE_MEDIAN = 3;
  SORT_MODE_MIN = 4;
  SORT_MODE_SUM = 5;
}

enum GeoDistanceType {
  GEO_DISTANCE_TYPE_UNSPECIFIED = 0;
  GEO_DISTANCE_TYPE_ARC = 1;
  GEO_DISTANCE_TYPE_PLANE = 2;
}

enum BuiltinHighlighterType {
  BUILTIN_HIGHLIGHTER_TYPE_UNSPECIFIED = 0;
  BUILTIN_HIGHLIGHTER_TYPE_PLAIN = 1;
  BUILTIN_HIGHLIGHTER_TYPE_FVH = 2;
  BUILTIN_HIGHLIGHTER_TYPE_UNIFIED = 3;
}

enum BoundaryScanner {
  BOUNDARY_SCANNER_UNSPECIFIED = 0;
  BOUNDARY_SCANNER_CHARS = 1;
  BOUNDARY_SCANNER_SENTENCE = 2;
  BOUNDARY_SCANNER_WORD = 3;
}

enum HighlighterFragmenter {
  HIGHLIGHTER_FRAGMENTER_UNSPECIFIED = 0;
  HIGHLIGHTER_FRAGMENTER_SIMPLE = 1;
  HIGHLIGHTER_FRAGMENTER_SPAN = 2;
}

enum HighlighterOrder {
  HIGHLIGHTER_ORDER_UNSPECIFIED = 0;
  HIGHLIGHTER_ORDER_SCORE = 1;
}

enum HighlighterTagsSchema {
  HIGHLIGHTER_TAGS_SCHEMA_UNSPECIFIED = 0;
  HIGHLIGHTER_TAGS_SCHEMA_STYLED = 1;
  HIGHLIGHTER_TAGS_SCHEMA_DEFAULT = 2;
}

enum DistanceUnit {
  DISTANCE_UNIT_UNSPECIFIED = 0;
  DISTANCE_UNIT_CM = 1;
  DISTANCE_UNIT_FT = 2;
  DISTANCE_UNIT_IN = 3;
  DISTANCE_UNIT_KM = 4;
  DISTANCE_UNIT_M = 5;
  DISTANCE_UNIT_MI = 6;
  DISTANCE_UNIT_MM = 7;
  DISTANCE_UNIT_NMI = 8;
  DISTANCE_UNIT_YD = 9;
}

enum ChildScoreMode {
  CHILD_SCORE_MODE_UNSPECIFIED = 0;
  CHILD_SCORE_MODE_AVG = 1;
  CHILD_SCORE_MODE_MAX = 2;
  CHILD_SCORE_MODE_MIN = 3;
  CHILD_SCORE_MODE_NONE = 4;
  CHILD_SCORE_MODE_SUM = 5;
}

enum HighlighterEncoder {
  HIGHLIGHTER_ENCODER_UNSPECIFIED = 0;
  HIGHLIGHTER_ENCODER_DEFAULT = 1;
  HIGHLIGHTER_ENCODER_HTML = 2;
}

enum GeoExecution {
  GEO_EXECUTION_UNSPECIFIED = 0;
  GEO_EXECUTION_INDEXED = 1;
  GEO_EXECUTION_MEMORY = 2;
}

enum SimpleQueryStringFlag {
  SIMPLE_QUERY_STRING_FLAG_UNSPECIFIED = 0;
  SIMPLE_QUERY_STRING_FLAG_ALL = 1;
  SIMPLE_QUERY_STRING_FLAG_AND = 2;
  SIMPLE_QUERY_STRING_FLAG_ESCAPE = 3;
  SIMPLE_QUERY_STRING_FLAG_FUZZY = 4;
  SIMPLE_QUERY_STRING_FLAG_NEAR = 5;
  SIMPLE_QUERY_STRING_FLAG_NONE = 6;
  SIMPLE_QUERY_STRING_FLAG_NOT = 7;
  SIMPLE_QUERY_STRING_FLAG_OR = 8;
  SIMPLE_QUERY_STRING_FLAG_PHRASE = 9;
  SIMPLE_QUERY_STRING_FLAG_PRECEDENCE = 10;
  SIMPLE_QUERY_STRING_FLAG_PREFIX = 11;
  SIMPLE_QUERY_STRING_FLAG_SLOP = 12;
  SIMPLE_QUERY_STRING_FLAG_WHITESPACE = 13;
}

enum TermsAggregationCollectMode {
  TERMS_AGGREGATION_COLLECT_MODE_UNSPECIFIED = 0;
  TERMS_AGGREGATION_COLLECT_MODE_BREADTH_FIRST = 1;
  TERMS_AGGREGATION_COLLECT_MODE_DEPTH_FIRST = 2;
}

enum TermsAggregationExecutionHint {
  TERMS_AGGREGATION_EXECUTION_HINT_UNSPECIFIED = 0;
  TERMS_AGGREGATION_EXECUTION_HINT_GLOBAL_ORDINALS = 1;
  TERMS_AGGREGATION_EXECUTION_HINT_GLOBAL_ORDINALS_HASH = 2;
  TERMS_AGGREGATION_EXECUTION_HINT_GLOBAL_ORDINALS_LOW_CARDINALITY = 3;
  TERMS_AGGREGATION_EXECUTION_HINT_MAP = 4;
}

enum ValueType {
  VALUE_TYPE_UNSPECIFIED = 0;
  VALUE_TYPE_BOOLEAN = 1;
  VALUE_TYPE_BYTE = 2;
  VALUE_TYPE_DATE = 3;
  VALUE_TYPE_DOUBLE = 4;
  VALUE_TYPE_FLOAT = 5;
  VALUE_TYPE_INTEGER = 6;
  VALUE_TYPE_IP = 7;
  VALUE_TYPE_LONG = 8;
  VALUE_TYPE_NUMBER = 9;
  VALUE_TYPE_NUMERIC = 10;
  VALUE_TYPE_SHORT = 11;
  VALUE_TYPE_STRING = 12;
  VALUE_TYPE_UNSIGNED_LONG = 13;
}

message ObjectMap {
  map<string, Value> fields = 1;

  message Value {
    oneof value {
      NullValue null_value = 1;
      int32 int32 = 2;
      int64 int64 = 3;
      float float = 4;
      double double = 5;
      string string = 6;
      bool bool = 7;
      ObjectMap object_map = 8;
      ListValue list_value = 9;
    }
  }

  // `ListValue` is a wrapper around a repeated field of values.
  // The JSON representation for `ListValue` is JSON array.
  message ListValue {
    // Repeated field of dynamically typed values.
    repeated Value value = 1;
  }
}

message GeneralNumber {
  oneof value {
    int32 int32_value = 1;
    int64 int64_value = 2;
    float float_value = 3;
    double double_value = 4;
    uint64 uint64_value = 5;
  }
}

enum NullValue {
  NULL_VALUE_UNSPECIFIED = 0;
  NULL_VALUE_NULL = 1;
}
```

  ### Updated documentation
  - **`CHANGELOG.md`**
    - Documented added TermsAggregation, MinAggregation and MaxAggregation and its response Proto object support
    - Listed all 117 excluded aggregation schemas for transparency

  ## Reasoning

  ### Regeneration process
  Following the Protobuf Local Convert Guide:
  1. Updated `spec-filter.yaml` with exclusion list
  2. Ran preprocessing: `npm run preprocessing`
  3. Generated protobufs: `npx @openapitools/openapi-generator-cli generate`
  4. Ran postprocessing: `npm run postprocessing`
Link to OpenSearch PR: https://github.com/opensearch-project/OpenSearch/pull/20676

# Issues Resolved

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
