### PR TITLE
Add protobuf definitions for min/max aggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### Added
+ - Add min aggregation and max aggregation support to search protobufs.
 
 ### Changed
  - Fix simplifySingleMapSchema to generate named wrapper schemas. ([#406](https://github.com/opensearch-project/opensearch-protobufs/pull/406))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### Added
- - Add min aggregation and max aggregation support to search protobufs.
+ - Add min aggregation and max aggregation support to search protobufs. ([#410](https://github.com/opensearch-project/opensearch-protobufs/pull/410))
 
 ### Changed
  - Fix simplifySingleMapSchema to generate named wrapper schemas. ([#406](https://github.com/opensearch-project/opensearch-protobufs/pull/406))

--- a/tools/proto-convert/src/config/spec-filter.yaml
+++ b/tools/proto-convert/src/config/spec-filter.yaml
@@ -6,8 +6,6 @@ x-operation-groups:
 # Schemas to exclude from proto generation
 # These schemas and their nested dependencies will not be included
 excluded_schemas:
-  - AggregationContainer
-  - Aggregate
   - Suggester
   - Suggest
   - DisMaxQuery
@@ -39,3 +37,129 @@ excluded_schemas:
   - TypeQuery
   - WrapperQuery
   - XyShapeQuery
+
+  # AggregationContainer - exclude all except MinAggregation and MaxAggregation
+  - AdjacencyMatrixAggregation
+  - AutoDateHistogramAggregation
+  - AverageAggregation
+  - AverageBucketAggregation
+  - BoxplotAggregation
+  - BucketScriptAggregation
+  - BucketSelectorAggregation
+  - BucketSortAggregation
+  - CardinalityAggregation
+  - ChildrenAggregation
+  - CompositeAggregation
+  - CumulativeCardinalityAggregation
+  - CumulativeSumAggregation
+  - DateHistogramAggregation
+  - DateRangeAggregation
+  - DerivativeAggregation
+  - DiversifiedSamplerAggregation
+  - ExtendedStatsAggregation
+  - ExtendedStatsBucketAggregation
+  - FiltersAggregation
+  - GeoBoundsAggregation
+  - GeoCentroidAggregation
+  - GeoDistanceAggregation
+  - GeoHashGridAggregation
+  - GeoTileGridAggregation
+  - GlobalAggregation
+  - HistogramAggregation
+  - IpRangeAggregation
+  - MatrixStatsAggregation
+  - MaxBucketAggregation
+  - MedianAbsoluteDeviationAggregation
+  - MinBucketAggregation
+  - MissingAggregation
+  - MovingAverageAggregation
+  - MovingFunctionAggregation
+  - MovingPercentilesAggregation
+  - MultiTermsAggregation
+  - NestedAggregation
+  - NormalizeAggregation
+  - ParentAggregation
+  - PercentileRanksAggregation
+  - PercentilesAggregation
+  - PercentilesBucketAggregation
+  - RangeAggregation
+  - RareTermsAggregation
+  - RateAggregation
+  - ReverseNestedAggregation
+  - SamplerAggregation
+  - ScriptedMetricAggregation
+  - SerialDifferencingAggregation
+  - SignificantTermsAggregation
+  - SignificantTextAggregation
+  - StatsAggregation
+  - StatsBucketAggregation
+  - SumAggregation
+  - SumBucketAggregation
+  - TermsAggregation
+  - TopHitsAggregation
+  - TTestAggregation
+  - ValueCountAggregation
+  - VariableWidthHistogramAggregation
+  - WeightedAverageAggregation
+
+  # Aggregate - exclude all except MinAggregate and MaxAggregate
+  - AdjacencyMatrixAggregate
+  - AutoDateHistogramAggregate
+  - AvgAggregate
+  - BoxPlotAggregate
+  - BucketMetricValueAggregate
+  - CardinalityAggregate
+  - ChildrenAggregate
+  - CompositeAggregate
+  - CumulativeCardinalityAggregate
+  - DateHistogramAggregate
+  - DateRangeAggregate
+  - DerivativeAggregate
+  - DoubleTermsAggregate
+  - ExtendedStatsAggregate
+  - ExtendedStatsBucketAggregate
+  - FilterAggregate
+  - FiltersAggregate
+  - GeoBoundsAggregate
+  - GeoCentroidAggregate
+  - GeoDistanceAggregate
+  - GeoHashGridAggregate
+  - GeoTileGridAggregate
+  - GlobalAggregate
+  - HdrPercentileRanksAggregate
+  - HdrPercentilesAggregate
+  - HistogramAggregate
+  - IpRangeAggregate
+  - LongTermsAggregate
+  - LongRareTermsAggregate
+  - MatrixStatsAggregate
+  - MedianAbsoluteDeviationAggregate
+  - MissingAggregate
+  - MultiTermsAggregate
+  - NestedAggregate
+  - ParentAggregate
+  - PercentilesBucketAggregate
+  - RangeAggregate
+  - RateAggregate
+  - ReverseNestedAggregate
+  - SamplerAggregate
+  - ScriptedMetricAggregate
+  - SignificantLongTermsAggregate
+  - SignificantStringTermsAggregate
+  - SimpleValueAggregate
+  - StatsAggregate
+  - StatsBucketAggregate
+  - StringTermsAggregate
+  - StringRareTermsAggregate
+  - SumAggregate
+  - TDigestPercentileRanksAggregate
+  - TDigestPercentilesAggregate
+  - TopHitsAggregate
+  - TTestAggregate
+  - UnmappedRareTermsAggregate
+  - UnmappedSignificantTermsAggregate
+  - UnmappedTermsAggregate
+  - UnsignedLongTermsAggregate
+  - ValueCountAggregate
+  - VariableWidthHistogramAggregate
+  - WeightedAvgAggregate


### PR DESCRIPTION
### Description
- Modified `common.proto`
- Support Min and Max aggregation in Proto/gRPC server
- gRPC server PR: https://github.com/opensearch-project/OpenSearch/pull/20794

```
 % git diff
diff --git a/protos/schemas/common.proto b/protos/schemas/common.proto
index 0746d3a..67c5112 100755
--- a/protos/schemas/common.proto
+++ b/protos/schemas/common.proto
@@ -134,7 +134,7 @@ message SearchRequestBody {
   optional TrackHits track_total_hits = 7;
 
   // [optional] Values used to boost the score of specified indexes. Specify in the format of <index> : <boost-multiplier>
-  map<string, float> indices_boost = 8;
+  map<string, float> indices_boost = 8 [deprecated = true];
 
   // [optional] The fields that OpenSearch should return using their docvalue forms. Specify a format to return results in a certain format, such as date and time.
   repeated FieldAndFormat docvalue_fields = 9;
@@ -210,6 +210,12 @@ message SearchRequestBody {
 
   // [optional]
   map<string, DerivedField> derived = 35;
+
+  // Defines the aggregations that are run as part of the search request.
+  map<string, AggregationContainer> aggregations = 36;
+
+  // [optional] Values used to boost the score of specified indexes. Specify in the format of <index> : <boost-multiplier>
+  repeated FloatMap indices_boost_2 = 37;
 }
 
 message DerivedField {
@@ -286,6 +292,8 @@ message SearchResponse {
 
   // [optional] If the query was terminated early, the terminated_early flag will be set to true in the response
   optional bool terminated_early = 13;
+
+  map<string, Aggregate> aggregations = 14;
 }
 
 message ProcessorExecutionDetail {
@@ -2908,6 +2916,70 @@ message ShardSearchFailure {
   ErrorCause reason = 4;
 }
 
+message Aggregate {
+
+  // The custom metadata attached to a resource.
+  optional ObjectMap meta = 1;
+
+  SingleMetricAggregateBaseValue value = 2;
+
+  optional string value_as_string = 3;
+}
+
+message AggregationContainer {
+
+  // Custom metadata to associate with the aggregation (optional)
+  optional ObjectMap meta = 1;
+  oneof aggregation_container {
+    MaxAggregation max = 2;
+
+    MinAggregation min = 3;
+
+  }
+}
+
+message FloatMap {
+
+  map<string, float> float_map = 1;
+}
+
+message MaxAggregation {
+
+  optional FieldValue missing = 1;
+
+  // The path to a field or an array of paths. Some APIs support wildcards in the path, which allows you to select multiple fields.
+  optional string field = 2;
+
+  optional Script script = 3;
+
+  optional string format = 4;
+
+  optional ValueType value_type = 5;
+}
+
+message MinAggregation {
+
+  optional FieldValue missing = 1;
+
+  // The path to a field or an array of paths. Some APIs support wildcards in the path, which allows you to select multiple fields.
+  optional string field = 2;
+
+  optional Script script = 3;
+
+  optional string format = 4;
+
+  optional ValueType value_type = 5;
+}
+
+message SingleMetricAggregateBaseValue {
+  oneof single_metric_aggregate_base_value {
+    double double = 1;
+
+    NullValue null_value = 2;
+
+  }
+}
+
 enum FieldValueFactorModifier {
   FIELD_VALUE_FACTOR_MODIFIER_UNSPECIFIED = 0;
   FIELD_VALUE_FACTOR_MODIFIER_LN = 1;
@@ -3243,6 +3315,23 @@ enum SimpleQueryStringFlag {
   SIMPLE_QUERY_STRING_FLAG_WHITESPACE = 13;
 }
 
+enum ValueType {
+  VALUE_TYPE_UNSPECIFIED = 0;
+  VALUE_TYPE_BOOLEAN = 1;
+  VALUE_TYPE_BYTE = 2;
+  VALUE_TYPE_DATE = 3;
+  VALUE_TYPE_DOUBLE = 4;
+  VALUE_TYPE_FLOAT = 5;
+  VALUE_TYPE_INTEGER = 6;
+  VALUE_TYPE_IP = 7;
+  VALUE_TYPE_LONG = 8;
+  VALUE_TYPE_NUMBER = 9;
+  VALUE_TYPE_NUMERIC = 10;
+  VALUE_TYPE_SHORT = 11;
+  VALUE_TYPE_STRING = 12;
+  VALUE_TYPE_UNSIGNED_LONG = 13;
+}
+
 message ObjectMap {
   map<string, Value> fields = 1;
 
(END)
```

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
