### PR TITLE
Add ML stream endpoint to protobuf definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### Added
+- Add `ml.predict_model_stream` and `ml.execute_agent_stream` to protobuf definitons. ([#414](https://github.com/opensearch-project/opensearch-protobufs/pull/414))
 
 ### Changed
 

--- a/tools/proto-convert/src/config/spec-filter.yaml
+++ b/tools/proto-convert/src/config/spec-filter.yaml
@@ -2,6 +2,8 @@
 x-operation-groups:
   - bulk
   - search
+  - ml.predict_model_stream
+  - ml.execute_agent_stream
 
 # Schemas to exclude from proto generation
 # These schemas and their nested dependencies will not be included


### PR DESCRIPTION
### Description
Following this [steps](https://github.com/opensearch-project/opensearch-protobufs/blob/main/DEVELOPER_GUIDE.md#adding-new-apis) to add new API endpoint:
- Add `ml.predict_model_stream` and `ml.execute_agent_stream` to protobuf definitons

Server-side implementation: https://github.com/opensearch-project/ml-commons/pull/4790

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
