### PR TITLE
Preprocessing normalize mixed oneOf patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Changed
  - Fix simplifySingleMapSchema to generate named wrapper schemas. ([#406](https://github.com/opensearch-project/opensearch-protobufs/pull/406))
  - Change vendorExtension protobuf type handling to use protobuf type instead of openApi type ([#409](https://github.com/opensearch-project/opensearch-protobufs/pull/409))
-
+ - Normalize mixed oneOf patterns ([#411](https://github.com/opensearch-project/opensearch-protobufs/pull/411))
 ### Removed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Changed
  - Fix simplifySingleMapSchema to generate named wrapper schemas. ([#406](https://github.com/opensearch-project/opensearch-protobufs/pull/406))
  - Change vendorExtension protobuf type handling to use protobuf type instead of openApi type ([#409](https://github.com/opensearch-project/opensearch-protobufs/pull/409))
- - Normalize mixed oneOf patterns ([#411](https://github.com/opensearch-project/opensearch-protobufs/pull/411))
+ - Normalize mixed oneOf patterns ([#416](https://github.com/opensearch-project/opensearch-protobufs/pull/416))
 ### Removed
 
 ### Fixed

--- a/tools/proto-convert/src/SchemaModifier.ts
+++ b/tools/proto-convert/src/SchemaModifier.ts
@@ -22,6 +22,7 @@ export class SchemaModifier {
                 this.convertNullTypeToNullValue(schema)
                 this.deduplicateOneOfWithArrayType(schema)
                 this.collapseSingleItemComposite(schema);
+                this.normalizeMixedOneOf(schema)
             },
             onSchema: (schema, schemaName) => {
                 if (!schema || isReferenceObject(schema)) return;
@@ -33,6 +34,7 @@ export class SchemaModifier {
                 this.deduplicateOneOfWithArrayType(schema)
                 this.collapseSingleItemComposite(schema);
                 this.collapseOneOfObjectPropContainsTitleSchema(schema)
+                this.normalizeMixedOneOf(schema)
                 this.convertOneOfToMinMaxProperties(schema)
             },
         });
@@ -513,6 +515,81 @@ export class SchemaModifier {
         }
 
         logger.info(`Converted additionalProperties to named property '${propertyName}' with type: object`);
+    }
+
+    /**
+     * Normalizes mixed oneOf patterns where some items have properties and others are direct $refs.
+     * Converts direct $ref items into property-based format to match the inline property items.
+     *
+     *
+     * Example:
+     *   Input:
+     *   {
+     *     type: object,
+     *     oneOf: [
+     *       { properties: { max: { $ref: '#/components/schemas/MaxAggregation' } }, required: ['max'] },
+     *       { $ref: '#/components/schemas/TermsAggregation' }
+     *     ]
+     *   }
+     *
+     *   Output:
+     *   {
+     *     type: object,
+     *     oneOf: [
+     *       { properties: { max: { $ref: '#/components/schemas/MaxAggregation' } }, required: ['max'] },
+     *       { properties: { terms_aggregation: { $ref: '#/components/schemas/TermsAggregation' } }, required: ['terms_aggregation'] }
+     *     ]
+     *   }
+     **/
+    normalizeMixedOneOf(schema: OpenAPIV3.SchemaObject): void {
+        // Check if this schema has oneOf with mixed types (properties + $ref)
+        if (!Array.isArray(schema.oneOf) || schema.oneOf.length === 0) {
+            return;
+        }
+
+        let hasPropertiesType = false;
+        let hasRefType = false;
+
+        for (const item of schema.oneOf) {
+            if (!item || typeof item !== 'object') continue;
+
+            if ('$ref' in item) {
+                hasRefType = true;
+            } else if ('properties' in item) {
+                hasPropertiesType = true;
+            }
+        }
+
+        // Only process if we have both types
+        if (!hasPropertiesType || !hasRefType) {
+            return;
+        }
+
+        // Normalize $ref items to properties format
+        for (let i = 0; i < schema.oneOf.length; i++) {
+            const item = schema.oneOf[i];
+            if (!item || typeof item !== 'object') continue;
+
+            if ('$ref' in item) {
+                const ref = item.$ref;
+                // Extract schema name from $ref
+                const schemaName = ref.split('/').pop();
+                if (!schemaName) continue;
+
+                // Convert to snake_case for property name
+                const propertyName = toSnakeCase(schemaName);
+
+                // Replace $ref item with properties format
+                schema.oneOf[i] = {
+                    properties: {
+                        [propertyName]: { $ref: ref }
+                    },
+                    required: [propertyName]
+                };
+
+                logger.info(`Normalized oneOf $ref to properties: ${ref} -> ${propertyName}`);
+            }
+        }
     }
 
     /**

--- a/tools/proto-convert/test/SchemaModifier.test.ts
+++ b/tools/proto-convert/test/SchemaModifier.test.ts
@@ -59,7 +59,7 @@ describe('SchemaModifier', () => {
             doc.components!.schemas!.BoolQuery = {
                 type: 'object',
                 properties: {
-                    must: { 
+                    must: {
                         type: 'array',
                         items: { type: 'string' }
                     }
@@ -262,7 +262,7 @@ describe('SchemaModifier', () => {
             };
 
             const modifier = new SchemaModifier(doc);
-            
+
             // Should not throw error on $ref
             expect(() => modifier.modify()).not.toThrow();
         });
@@ -1032,7 +1032,7 @@ describe('SchemaModifier', () => {
             doc.components!.schemas!.BoolQuery = {
                 type: 'object',
                 properties: {
-                    must: { 
+                    must: {
                         type: 'array',
                         items: { type: 'string' }
                     }
@@ -1057,7 +1057,7 @@ describe('SchemaModifier', () => {
             // Should use old inline behavior - becomes a $ref directly (no SingleMap wrapper)
             expect(schema.$ref).toBe('#/components/schemas/BoolQuery');
             expect(doc.components!.schemas!.BoolQuerySingleMap).toBeUndefined();
-            
+
             // Properties should be deleted
             expect(schema.type).toBeUndefined();
             expect(schema.additionalProperties).toBeUndefined();
@@ -1274,7 +1274,7 @@ describe('SchemaModifier', () => {
 
             const optionA = doc.components!.schemas!.OptionA as any;
             const optionB = doc.components!.schemas!.OptionB as any;
-            
+
             // Both options should have the field property added
             expect(optionA.properties).toHaveProperty('field');
             expect(optionB.properties).toHaveProperty('field');
@@ -1305,7 +1305,7 @@ describe('SchemaModifier', () => {
 
             const optionC = doc.components!.schemas!.OptionC as any;
             const optionD = doc.components!.schemas!.OptionD as any;
-            
+
             // Both options should have the field property added
             expect(optionC.properties).toHaveProperty('field');
             expect(optionD.properties).toHaveProperty('field');
@@ -1320,14 +1320,14 @@ describe('SchemaModifier', () => {
 
             const modifier = new SchemaModifier(doc);
             const visit = new Set();
-            
+
             const schema = { $ref: '#/components/schemas/TestSchema' };
             const resolvedSchema = doc.components!.schemas!.TestSchema;
-            
+
             visit.add(resolvedSchema);
-            
+
             const result = modifier.reconstructAdditionalPropertySchema(schema, visit);
-            
+
             // Should return original schema without modification
             expect(result).toBe(schema);
             expect((resolvedSchema as any).properties).not.toHaveProperty('field');
@@ -1359,11 +1359,11 @@ describe('SchemaModifier', () => {
             const visit = new Set();
 
             const schema = { $ref: '#/components/schemas/ConflictSchema' };
-            
+
             const errorSpy = jest.spyOn(console, 'error').mockImplementation();
-            
+
             modifier.reconstructAdditionalPropertySchema(schema, visit);
-            
+
             expect(errorSpy).toHaveBeenCalled();
             errorSpy.mockRestore();
         });
@@ -1450,6 +1450,249 @@ describe('SchemaModifier', () => {
 
             const result = modifier.isArraySchemaObject(schema);
             expect(result).toBe(false);
+        });
+    });
+
+    describe('normalizeMixedOneOf', () => {
+        it('should normalize mixed oneOf with properties and $ref items', () => {
+            const doc: OpenAPIV3.Document = {
+                openapi: '3.1.0',
+                info: { title: 'Test', version: '1.0.0' },
+                paths: {},
+                components: {
+                    schemas: {
+                        TestSchema: {
+                            type: 'object',
+                            oneOf: [
+                                {
+                                    properties: {
+                                        max: { $ref: '#/components/schemas/MaxAggregation' }
+                                    },
+                                    required: ['max']
+                                },
+                                {
+                                    $ref: '#/components/schemas/TermsAggregation'
+                                }
+                            ]
+                        }
+                    }
+                }
+            };
+
+            const modifier = new SchemaModifier(doc);
+            const schema = doc.components!.schemas!.TestSchema as OpenAPIV3.SchemaObject;
+
+            modifier.normalizeMixedOneOf(schema);
+
+            // The $ref item should be converted to properties format
+            expect(schema.oneOf).toHaveLength(2);
+
+            // First item should remain unchanged (already has properties)
+            expect((schema.oneOf![0] as any).properties).toEqual({
+                max: { $ref: '#/components/schemas/MaxAggregation' }
+            });
+            expect((schema.oneOf![0] as any).required).toEqual(['max']);
+
+            // Second item should now have properties format with snake_case property name
+            expect((schema.oneOf![1] as any).properties).toEqual({
+                terms_aggregation: { $ref: '#/components/schemas/TermsAggregation' }
+            });
+            expect((schema.oneOf![1] as any).required).toEqual(['terms_aggregation']);
+            expect((schema.oneOf![1] as any).$ref).toBeUndefined();
+        });
+
+        it('should handle multiple $ref items in oneOf', () => {
+            const doc: OpenAPIV3.Document = {
+                openapi: '3.1.0',
+                info: { title: 'Test', version: '1.0.0' },
+                paths: {},
+                components: {
+                    schemas: {
+                        TestSchema: {
+                            type: 'object',
+                            oneOf: [
+                                {
+                                    properties: {
+                                        max: { type: 'string' }
+                                    },
+                                    required: ['max']
+                                },
+                                {
+                                    $ref: '#/components/schemas/FirstAgg'
+                                },
+                                {
+                                    $ref: '#/components/schemas/SecondAgg'
+                                }
+                            ]
+                        }
+                    }
+                }
+            };
+
+            const modifier = new SchemaModifier(doc);
+            const schema = doc.components!.schemas!.TestSchema as OpenAPIV3.SchemaObject;
+
+            modifier.normalizeMixedOneOf(schema);
+
+            expect(schema.oneOf).toHaveLength(3);
+
+            // Second item should be normalized
+            expect((schema.oneOf![1] as any).properties).toEqual({
+                first_agg: { $ref: '#/components/schemas/FirstAgg' }
+            });
+
+            // Third item should be normalized
+            expect((schema.oneOf![2] as any).properties).toEqual({
+                second_agg: { $ref: '#/components/schemas/SecondAgg' }
+            });
+        });
+
+        it('should not modify oneOf with only properties items', () => {
+            const doc: OpenAPIV3.Document = {
+                openapi: '3.1.0',
+                info: { title: 'Test', version: '1.0.0' },
+                paths: {},
+                components: {
+                    schemas: {
+                        TestSchema: {
+                            type: 'object',
+                            oneOf: [
+                                {
+                                    properties: {
+                                        field1: { type: 'string' }
+                                    },
+                                    required: ['field1']
+                                },
+                                {
+                                    properties: {
+                                        field2: { type: 'number' }
+                                    },
+                                    required: ['field2']
+                                }
+                            ]
+                        }
+                    }
+                }
+            };
+
+            const modifier = new SchemaModifier(doc);
+            const schema = doc.components!.schemas!.TestSchema as OpenAPIV3.SchemaObject;
+            const originalOneOf = JSON.parse(JSON.stringify(schema.oneOf));
+
+            modifier.normalizeMixedOneOf(schema);
+
+            // Should remain unchanged
+            expect(schema.oneOf).toEqual(originalOneOf);
+        });
+
+        it('should not modify oneOf with only $ref items', () => {
+            const doc: OpenAPIV3.Document = {
+                openapi: '3.1.0',
+                info: { title: 'Test', version: '1.0.0' },
+                paths: {},
+                components: {
+                    schemas: {
+                        TestSchema: {
+                            type: 'object',
+                            oneOf: [
+                                {
+                                    $ref: '#/components/schemas/Schema1'
+                                },
+                                {
+                                    $ref: '#/components/schemas/Schema2'
+                                }
+                            ]
+                        }
+                    }
+                }
+            };
+
+            const modifier = new SchemaModifier(doc);
+            const schema = doc.components!.schemas!.TestSchema as OpenAPIV3.SchemaObject;
+            const originalOneOf = JSON.parse(JSON.stringify(schema.oneOf));
+
+            modifier.normalizeMixedOneOf(schema);
+
+            // Should remain unchanged
+            expect(schema.oneOf).toEqual(originalOneOf);
+        });
+
+        it('should handle oneOf within allOf (full integration)', () => {
+            const doc: OpenAPIV3.Document = {
+                openapi: '3.0.0',
+                info: { title: 'Test', version: '1.0.0' },
+                paths: {
+                    '/test': {
+                        get: {
+                            responses: {
+                                '200': {
+                                    description: 'OK',
+                                    content: {
+                                        'application/json': {
+                                            schema: {
+                                                $ref: '#/components/schemas/AggregationContainer'
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                components: {
+                    schemas: {
+                        AggregationContainer: {
+                            allOf: [
+                                {
+                                    $ref: '#/components/schemas/Aggregation'
+                                },
+                                {
+                                    type: 'object',
+                                    oneOf: [
+                                        {
+                                            properties: {
+                                                max: { $ref: '#/components/schemas/MaxAggregation' }
+                                            },
+                                            required: ['max']
+                                        },
+                                        {
+                                            $ref: '#/components/schemas/TermsAggregation'
+                                        }
+                                    ]
+                                }
+                            ] as any
+                        },
+                        Aggregation: {
+                            type: 'object',
+                            properties: {
+                                meta: { type: 'object' }
+                            }
+                        },
+                        MaxAggregation: {
+                            type: 'object'
+                        },
+                        TermsAggregation: {
+                            type: 'object'
+                        }
+                    }
+                }
+            };
+
+            const modifier = new SchemaModifier(doc);
+            const result = modifier.modify();
+
+            const aggContainer = result.components!.schemas!.AggregationContainer as OpenAPIV3.SchemaObject;
+            const secondAllOfItem = (aggContainer.allOf![1] as OpenAPIV3.SchemaObject);
+
+            // After full pipeline: normalizeMixedOneOf runs first, then convertOneOfToMinMaxProperties
+            // The oneOf should be normalized first (mixed -> all properties)
+            // Then converted to minProperties/maxProperties pattern
+            expect(secondAllOfItem.oneOf).toBeUndefined();
+            expect(secondAllOfItem.properties).toBeDefined();
+            expect(secondAllOfItem.properties!.max).toBeDefined();
+            expect(secondAllOfItem.properties!.terms_aggregation).toBeDefined();
+            expect(secondAllOfItem.minProperties).toBe(1);
+            expect(secondAllOfItem.maxProperties).toBe(1);
         });
     });
 });


### PR DESCRIPTION
### Description
Adds transformation logic to handle OpenAPI schemas with mixed oneOf patterns (containing both inline properties and direct $ref items). This ensures consistent schema structure for protobuf generation.

### Problem
Some OpenAPI schemas, like AggregationContainer, contain oneOf arrays with inconsistent item formats:

Some items use inline properties format: { properties: { max: { $ref: ... } }, required: ['max'] }
Other items use direct $ref: { $ref: '#/components/schemas/TermsAggregation' }
This mixed format prevents the existing convertOneOfToMinMaxProperties transformation from working correctly, resulting in inconsistent protobuf message generation.

Implemented normalizeMixedOneOf() method in SchemaModifier that:
### Solution
Detects oneOf arrays containing both format types
Converts direct $ref items into the properties format

### Test

```
message AggregationContainer {

  // Custom metadata to associate with the aggregation (optional)
  optional ObjectMap meta = 1;
  oneof aggregation_container {
    MaxAggregation max = 2;

    MinAggregation min = 3;

    TermsAggregation terms_aggregation = 4;

  }
}

message TermsAggregation {

  // Sub-aggregations for this bucket aggregation
  map<string, AggregationContainer> aggregations = 1;

  TermsAggregationFields terms = 2;
}

message MaxAggregation {

  optional FieldValue missing = 1;

  // The path to a field or an array of paths. Some APIs support wildcards in the path, which allows you to select multiple fields.
  optional string field = 2;

  optional Script script = 3;

  optional string format = 4;

  optional ValueType value_type = 5;
}
```


