### PR TITLE
Add @tooling_skip annotation to preserve manually-maintained protobuf fields

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -61,6 +61,7 @@ genrule(
         "//protos/services:document_service.proto",
         "//protos/services:search_service.proto",
         "@com_google_protobuf//:well_known_type_protos",
+        "@com_google_protobuf//:descriptor_proto_srcs",
     ],
     outs = [
         "python_pyi/schemas/common_pb2.pyi",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### Added
-- Add tooling_skip field option to preserve manually-maintained protobuf fields ([#378](https://github.com/opensearch-project/opensearch-protobufs/pull/378))
+- Add tooling_skip field option to preserve manually-maintained protobuf fields ([#417](https://github.com/opensearch-project/opensearch-protobufs/pull/417))
 
 ### Changed
  - Fix simplifySingleMapSchema to generate named wrapper schemas. ([#406](https://github.com/opensearch-project/opensearch-protobufs/pull/406))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### Added
+- Add tooling_skip field option to preserve manually-maintained protobuf fields ([#378](https://github.com/opensearch-project/opensearch-protobufs/pull/378))
 
 ### Changed
  - Fix simplifySingleMapSchema to generate named wrapper schemas. ([#406](https://github.com/opensearch-project/opensearch-protobufs/pull/406))

--- a/protos/schemas/common.proto
+++ b/protos/schemas/common.proto
@@ -8,6 +8,13 @@ option go_package = "github.com/opensearch-project/opensearch-protobufs/go/opens
 option java_multiple_files = true;
 option java_outer_classname = "CommonProto";
 option java_package = "org.opensearch.protobufs";
+import "google/protobuf/descriptor.proto";
+
+// Custom field option for tooling
+extend google.protobuf.FieldOptions {
+  // Mark a field to be skipped by tooling. These fields are manually maintained and won't be marked as deprecated.
+  optional bool tooling_skip = 50001;
+}
 
 // The Search API operation to perform a search across all indices in the cluster or index search
 message SearchRequest {

--- a/tools/proto-convert/src/config/protobuf-schema-template/field_options.mustache
+++ b/tools/proto-convert/src/config/protobuf-schema-template/field_options.mustache
@@ -1,0 +1,8 @@
+
+import "google/protobuf/descriptor.proto";
+
+// Custom field option for tooling
+extend google.protobuf.FieldOptions {
+  // Mark a field to be skipped by tooling. These fields are manually maintained and won't be marked as deprecated.
+  optional bool tooling_skip = 50001;
+}

--- a/tools/proto-convert/src/postprocessing/CompatibilityMerger.ts
+++ b/tools/proto-convert/src/postprocessing/CompatibilityMerger.ts
@@ -13,6 +13,7 @@ import {
 import { CompatibilityReporter, formatField } from './CompatibilityReporter';
 
 const DEPRECATED: Annotation = { name: 'deprecated', value: 'true' };
+const TOOLING_SKIP: Annotation = { name: '(tooling_skip)', value: 'true' };
 
 /**
  * Extract base name
@@ -39,6 +40,16 @@ type HasAnnotations = { annotations?: Annotation[] };
 function isDeprecated(item: HasAnnotations): boolean {
     return item.annotations?.some(a =>
         a.name === DEPRECATED.name && a.value === DEPRECATED.value
+    ) ?? false;
+}
+
+/**
+ * Check if an item has tooling_skip option set to true.
+ * Fields with this option are manually maintained and won't be deprecated.
+ */
+function hasToolingSkip(item: HasAnnotations): boolean {
+    return item.annotations?.some(a =>
+        a.name === TOOLING_SKIP.name && a.value === TOOLING_SKIP.value
     ) ?? false;
 }
 
@@ -114,6 +125,9 @@ function mergeField(
             }
         }
     } else {
+        if (hasToolingSkip(sourceField)) {
+            return sourceField;
+        }
         reporter?.addFieldChange({
             messageName: msgName,
             changeType: 'DEPRECATED',
@@ -244,7 +258,7 @@ export function mergeMessage(
                     continue;
                 }
 
-                // Try 3: No match - deprecate
+                // Try 3: No match - deprecate or skip
                 mergedOneofFields.push(mergeField(sourceField, upcomingOneofByName, sourceMsg.name, reporter));
             }
 

--- a/tools/proto-convert/src/postprocessing/writer.ts
+++ b/tools/proto-convert/src/postprocessing/writer.ts
@@ -9,9 +9,10 @@ import { ProtoMessage, ProtoEnum } from './types';
 
 const TEMPLATE = readFileSync(join(__dirname, 'templates', 'proto.mustache'), 'utf8');
 
-const TEMPLATE_DIR = join(__dirname, '../config/protobuf-schema-template');
-const PROTO_HEADER = readFileSync(join(TEMPLATE_DIR, 'partial_header.mustache'), 'utf-8');
-const CUSTOM_MESSAGES = readFileSync(join(TEMPLATE_DIR, 'custom_message.mustache'), 'utf-8');
+const CONFIG_TEMPLATE_DIR = join(__dirname, '../config/protobuf-schema-template');
+const PROTO_HEADER = readFileSync(join(CONFIG_TEMPLATE_DIR, 'partial_header.mustache'), 'utf-8');
+const FIELD_OPTIONS = readFileSync(join(CONFIG_TEMPLATE_DIR, 'field_options.mustache'), 'utf-8');
+const CUSTOM_MESSAGES = readFileSync(join(CONFIG_TEMPLATE_DIR, 'custom_message.mustache'), 'utf-8');
 
 // Custom messages/enums defined in template - always handled separately
 export const CUSTOM_MESSAGE_NAMES = new Set(['ObjectMap', 'GeneralNumber']);
@@ -96,6 +97,9 @@ export function writeProtoFile(
 
     // Use fixed header from template
     outputParts.push(PROTO_HEADER.trim());
+    
+    // Add field options (import descriptor + extend)
+    outputParts.push(FIELD_OPTIONS.trim());
 
     // Generate messages (excluding custom ones - they're added from template)
     for (const msg of messages) {

--- a/tools/proto-convert/test/postprocessing/CompatibilityMerger.test.ts
+++ b/tools/proto-convert/test/postprocessing/CompatibilityMerger.test.ts
@@ -275,6 +275,125 @@ describe('mergeMessage', () => {
             );
             expect(deprecatedOptions).toHaveLength(1);
         });
+
+        it('should keep fields with tooling_skip option without deprecating', () => {
+            const source: ProtoMessage = {
+                name: 'TestMessage',
+                fields: [{
+                    name: 'skip_field',
+                    type: 'string',
+                    number: 1,
+                    annotations: [{ name: '(tooling_skip)', value: 'true' }]
+                }, {
+                    name: 'normal_field',
+                    type: 'string',
+                    number: 2
+                }]
+            };
+            const upcoming: ProtoMessage = {
+                name: 'TestMessage',
+                fields: [{
+                    name: 'normal_field',
+                    type: 'string',
+                    number: 2
+                }]
+            };
+
+            const result = mergeMessage(source, upcoming);
+
+            // skip_field should remain without deprecated annotation added
+            expect(result.fields).toHaveLength(2);
+            const skipField = result.fields.find(f => f.name === 'skip_field');
+            expect(skipField).toBeDefined();
+            // Should only have tooling_skip, not deprecated
+            expect(skipField!.annotations).not.toContainEqual({ name: 'deprecated', value: 'true' });
+        });
+
+        it('should not report tooling_skip fields as deprecated', () => {
+            const source: ProtoMessage = {
+                name: 'TestMessage',
+                fields: [{
+                    name: 'skip_field',
+                    type: 'string',
+                    number: 1,
+                    annotations: [{ name: '(tooling_skip)', value: 'true' }]
+                }]
+            };
+            const upcoming: ProtoMessage = {
+                name: 'TestMessage',
+                fields: []
+            };
+
+            const reporter = new CompatibilityReporter();
+            mergeMessage(source, upcoming, reporter);
+
+            const markdown = reporter.toMarkdown();
+            // Should not report deprecation for tooling_skip fields
+            expect(markdown).toContain('No changes detected');
+        });
+
+        it('should keep tooling_skip field if it exists in upcoming', () => {
+            const source: ProtoMessage = {
+                name: 'TestMessage',
+                fields: [{
+                    name: 'field_name',
+                    type: 'string',
+                    number: 1,
+                    annotations: [{ name: '(tooling_skip)', value: 'true' }]
+                }]
+            };
+            const upcoming: ProtoMessage = {
+                name: 'TestMessage',
+                fields: [{
+                    name: 'field_name',
+                    type: 'string',
+                    number: 1
+                }]
+            };
+
+            const result = mergeMessage(source, upcoming);
+
+            expect(result.fields).toHaveLength(1);
+            expect(result.fields[0].name).toBe('field_name');
+        });
+
+        it('should assign new field number after max including tooling_skip field', () => {
+            const source: ProtoMessage = {
+                name: 'TestMessage',
+                fields: [{
+                    name: 'existing_field',
+                    type: 'string',
+                    number: 1
+                }, {
+                    name: 'skip_field',
+                    type: 'string',
+                    number: 5,  // This is the max field number
+                    annotations: [{ name: '(tooling_skip)', value: 'true' }]
+                }]
+            };
+            const upcoming: ProtoMessage = {
+                name: 'TestMessage',
+                fields: [{
+                    name: 'existing_field',
+                    type: 'string',
+                    number: 1
+                }, {
+                    name: 'new_field',
+                    type: 'int32',
+                    number: 99  // This will be reassigned
+                }]
+            };
+
+            const result = mergeMessage(source, upcoming);
+
+            // skip_field is kept, new_field is added
+            expect(result.fields).toHaveLength(3);
+            expect(result.fields.find(f => f.name === 'skip_field')).toBeDefined();
+
+            const newField = result.fields.find(f => f.name === 'new_field');
+            expect(newField).toBeDefined();
+            expect(newField!.number).toBe(6);
+        });
     });
 
     describe('new fields', () => {
@@ -884,6 +1003,7 @@ describe('mergeEnum', () => {
             const markdown = reporter.toMarkdown();
             expect(markdown).toContain('No changes detected');
         });
+
     });
 
     describe('new values', () => {


### PR DESCRIPTION
### Description
Adds support for the [(tooling_skip) = true] option in protobuf files to mark fields that are manually maintained for gRPC and should not be marked as deprecated after postprocessing.

### Test
1. unit test.

2.  Local test :
a) Add a [(tooling_skip) = true] option to protos/schemas/common.proto:
Map of fully-qualified field path -> typed value.
map<string, BinaryFieldValue> field_values = 4 [(tooling_skip) = true];
b) Run postprocessing processing:
c) Verified field_values remains in the output without [deprecated = true]

3. https://github.com/opensearch-project/opensearch-protobufs/actions/runs/23170638560/job/67321469760?pr=417
auto-convert wf run successfully.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
