### PR TITLE
Add terms bucket aggregation support to search protobufs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 ### Added
  - Add min aggregation and max aggregation support to search protobufs. ([#410](https://github.com/opensearch-project/opensearch-protobufs/pull/410))
+ - Add terms bucket aggregation support to search protobufs. ([#424](https://github.com/opensearch-project/opensearch-protobufs/pull/424))
 
 ### Changed
  - Fix simplifySingleMapSchema to generate named wrapper schemas. ([#406](https://github.com/opensearch-project/opensearch-protobufs/pull/406))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### Added
+ - Add min aggregation and max aggregation support to search protobufs. ([#410](https://github.com/opensearch-project/opensearch-protobufs/pull/410))
 
 ### Changed
  - Fix simplifySingleMapSchema to generate named wrapper schemas. ([#406](https://github.com/opensearch-project/opensearch-protobufs/pull/406))

--- a/protos/schemas/common.proto
+++ b/protos/schemas/common.proto
@@ -213,6 +213,9 @@ message SearchRequestBody {
 
   // [optional] Values used to boost the score of specified indexes. Specify in the format of <index> : <boost-multiplier>
   repeated FloatMap indices_boost_2 = 36;
+
+  // Defines the aggregations that are run as part of the search request.
+  map<string, AggregationContainer> aggregations = 37;
 }
 
 message DerivedField {
@@ -289,6 +292,8 @@ message SearchResponse {
 
   // [optional] If the query was terminated early, the terminated_early flag will be set to true in the response
   optional bool terminated_early = 13;
+
+  map<string, Aggregate> aggregations = 14;
 }
 
 message ProcessorExecutionDetail {
@@ -2916,6 +2921,146 @@ message FloatMap {
   map<string, float> float_map = 1;
 }
 
+message Aggregate {
+
+  // The custom metadata attached to a resource.
+  optional ObjectMap meta = 1;
+
+  repeated ObjectMap buckets = 2;
+
+  optional int64 doc_count_error_upper_bound = 3;
+
+  optional int64 sum_other_doc_count = 4;
+
+  SingleMetricAggregateBaseValue value = 5;
+
+  optional string value_as_string = 6;
+}
+
+message AggregationContainer {
+
+  // Custom metadata to associate with the aggregation (optional)
+  optional ObjectMap meta = 1;
+  oneof aggregation_container {
+    MaxAggregation max = 2;
+
+    MinAggregation min = 3;
+
+    TermsAggregation terms_aggregation = 4;
+
+  }
+}
+
+message MaxAggregation {
+
+  optional FieldValue missing = 1;
+
+  // The path to a field or an array of paths. Some APIs support wildcards in the path, which allows you to select multiple fields.
+  optional string field = 2;
+
+  optional Script script = 3;
+
+  optional string format = 4;
+
+  optional ValueType value_type = 5;
+}
+
+message MinAggregation {
+
+  optional FieldValue missing = 1;
+
+  // The path to a field or an array of paths. Some APIs support wildcards in the path, which allows you to select multiple fields.
+  optional string field = 2;
+
+  optional Script script = 3;
+
+  optional string format = 4;
+
+  optional ValueType value_type = 5;
+}
+
+message SingleMetricAggregateBaseValue {
+  oneof single_metric_aggregate_base_value {
+    double double = 1;
+
+    NullValue null_value = 2;
+
+  }
+}
+
+message SortOrderSingleMap {
+
+  string field = 1;
+
+  SortOrder sort_order = 2;
+}
+
+message TermsAggregation {
+
+  // Sub-aggregations for this bucket aggregation
+  map<string, AggregationContainer> aggregations = 1;
+
+  TermsAggregationFields terms = 2;
+}
+
+message TermsAggregationFields {
+
+  optional TermsAggregationCollectMode collect_mode = 1;
+
+  repeated string exclude = 2;
+
+  optional TermsAggregationExecutionHint execution_hint = 3;
+
+  optional TermsInclude include = 4;
+
+  // Only return values that are found in more than `min_doc_count` hits.
+  optional int64 min_doc_count = 5;
+
+  optional FieldValue missing = 6;
+
+  // Coerced unmapped fields into the specified type.
+  optional ValueType value_type = 7;
+
+  repeated SortOrderSingleMap order = 8;
+
+  // The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.
+  optional int32 shard_size = 9;
+
+  // The minimum number of documents in a bucket on each shard for it to be returned.
+  optional int64 shard_min_doc_count = 10;
+
+  // Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.
+  optional bool show_term_doc_count_error = 11;
+
+  // The number of buckets returned out of the overall terms list.
+  optional int32 size = 12;
+
+  optional string format = 13;
+
+  // The path to a field or an array of paths. Some APIs support wildcards in the path, which allows you to select multiple fields.
+  optional string field = 14;
+
+  optional Script script = 15;
+}
+
+message TermsInclude {
+  oneof terms_include {
+    StringArray terms = 1;
+
+    TermsPartition partition = 2;
+
+  }
+}
+
+message TermsPartition {
+
+  // The number of partitions.
+  int32 num_partitions = 1;
+
+  // The partition number for this request.
+  int32 partition = 2;
+}
+
 enum FieldValueFactorModifier {
   FIELD_VALUE_FACTOR_MODIFIER_UNSPECIFIED = 0;
   FIELD_VALUE_FACTOR_MODIFIER_LN = 1;
@@ -3249,6 +3394,37 @@ enum SimpleQueryStringFlag {
   SIMPLE_QUERY_STRING_FLAG_PREFIX = 11;
   SIMPLE_QUERY_STRING_FLAG_SLOP = 12;
   SIMPLE_QUERY_STRING_FLAG_WHITESPACE = 13;
+}
+
+enum TermsAggregationCollectMode {
+  TERMS_AGGREGATION_COLLECT_MODE_UNSPECIFIED = 0;
+  TERMS_AGGREGATION_COLLECT_MODE_BREADTH_FIRST = 1;
+  TERMS_AGGREGATION_COLLECT_MODE_DEPTH_FIRST = 2;
+}
+
+enum TermsAggregationExecutionHint {
+  TERMS_AGGREGATION_EXECUTION_HINT_UNSPECIFIED = 0;
+  TERMS_AGGREGATION_EXECUTION_HINT_GLOBAL_ORDINALS = 1;
+  TERMS_AGGREGATION_EXECUTION_HINT_GLOBAL_ORDINALS_HASH = 2;
+  TERMS_AGGREGATION_EXECUTION_HINT_GLOBAL_ORDINALS_LOW_CARDINALITY = 3;
+  TERMS_AGGREGATION_EXECUTION_HINT_MAP = 4;
+}
+
+enum ValueType {
+  VALUE_TYPE_UNSPECIFIED = 0;
+  VALUE_TYPE_BOOLEAN = 1;
+  VALUE_TYPE_BYTE = 2;
+  VALUE_TYPE_DATE = 3;
+  VALUE_TYPE_DOUBLE = 4;
+  VALUE_TYPE_FLOAT = 5;
+  VALUE_TYPE_INTEGER = 6;
+  VALUE_TYPE_IP = 7;
+  VALUE_TYPE_LONG = 8;
+  VALUE_TYPE_NUMBER = 9;
+  VALUE_TYPE_NUMERIC = 10;
+  VALUE_TYPE_SHORT = 11;
+  VALUE_TYPE_STRING = 12;
+  VALUE_TYPE_UNSIGNED_LONG = 13;
 }
 
 message ObjectMap {

--- a/tools/proto-convert/src/config/spec-filter.yaml
+++ b/tools/proto-convert/src/config/spec-filter.yaml
@@ -8,6 +8,7 @@ x-operation-groups:
 excluded_schemas:
   - Suggester
   - Suggest
+  - AgenticQuery
   - DisMaxQuery
   - QueryStringQuery
   - IntervalsQuery
@@ -95,7 +96,6 @@ excluded_schemas:
   - StatsBucketAggregation
   - SumAggregation
   - SumBucketAggregation
-  - TermsAggregation
   - TopHitsAggregation
   - TTestAggregation
   - ValueCountAggregation
@@ -115,7 +115,6 @@ excluded_schemas:
   - DateHistogramAggregate
   - DateRangeAggregate
   - DerivativeAggregate
-  - DoubleTermsAggregate
   - ExtendedStatsAggregate
   - ExtendedStatsBucketAggregate
   - FilterAggregate
@@ -130,7 +129,6 @@ excluded_schemas:
   - HdrPercentilesAggregate
   - HistogramAggregate
   - IpRangeAggregate
-  - LongTermsAggregate
   - LongRareTermsAggregate
   - MatrixStatsAggregate
   - MedianAbsoluteDeviationAggregate
@@ -149,7 +147,6 @@ excluded_schemas:
   - SimpleValueAggregate
   - StatsAggregate
   - StatsBucketAggregate
-  - StringTermsAggregate
   - StringRareTermsAggregate
   - SumAggregate
   - TDigestPercentileRanksAggregate
@@ -158,8 +155,6 @@ excluded_schemas:
   - TTestAggregate
   - UnmappedRareTermsAggregate
   - UnmappedSignificantTermsAggregate
-  - UnmappedTermsAggregate
-  - UnsignedLongTermsAggregate
   - ValueCountAggregate
   - VariableWidthHistogramAggregate
   - WeightedAvgAggregate

--- a/tools/proto-convert/src/config/spec-filter.yaml
+++ b/tools/proto-convert/src/config/spec-filter.yaml
@@ -6,8 +6,6 @@ x-operation-groups:
 # Schemas to exclude from proto generation
 # These schemas and their nested dependencies will not be included
 excluded_schemas:
-  - AggregationContainer
-  - Aggregate
   - Suggester
   - Suggest
   - DisMaxQuery
@@ -39,3 +37,129 @@ excluded_schemas:
   - TypeQuery
   - WrapperQuery
   - XyShapeQuery
+
+  # AggregationContainer - exclude all except TermsAggregation
+  - AdjacencyMatrixAggregation
+  - AutoDateHistogramAggregation
+  - AverageAggregation
+  - AverageBucketAggregation
+  - BoxplotAggregation
+  - BucketScriptAggregation
+  - BucketSelectorAggregation
+  - BucketSortAggregation
+  - CardinalityAggregation
+  - ChildrenAggregation
+  - CompositeAggregation
+  - CumulativeCardinalityAggregation
+  - CumulativeSumAggregation
+  - DateHistogramAggregation
+  - DateRangeAggregation
+  - DerivativeAggregation
+  - DiversifiedSamplerAggregation
+  - ExtendedStatsAggregation
+  - ExtendedStatsBucketAggregation
+  - FiltersAggregation
+  - GeoBoundsAggregation
+  - GeoCentroidAggregation
+  - GeoDistanceAggregation
+  - GeoHashGridAggregation
+  - GeoTileGridAggregation
+  - GlobalAggregation
+  - HistogramAggregation
+  - IpRangeAggregation
+  - MatrixStatsAggregation
+  - MaxBucketAggregation
+  - MedianAbsoluteDeviationAggregation
+  - MinBucketAggregation
+  - MissingAggregation
+  - MovingAverageAggregation
+  - MovingFunctionAggregation
+  - MovingPercentilesAggregation
+  - MultiTermsAggregation
+  - NestedAggregation
+  - NormalizeAggregation
+  - ParentAggregation
+  - PercentileRanksAggregation
+  - PercentilesAggregation
+  - PercentilesBucketAggregation
+  - RangeAggregation
+  - RareTermsAggregation
+  - RateAggregation
+  - ReverseNestedAggregation
+  - SamplerAggregation
+  - ScriptedMetricAggregation
+  - SerialDifferencingAggregation
+  - SignificantTermsAggregation
+  - SignificantTextAggregation
+  - StatsAggregation
+  - StatsBucketAggregation
+  - SumAggregation
+  - SumBucketAggregation
+  - TermsAggregation
+  - TopHitsAggregation
+  - TTestAggregation
+  - ValueCountAggregation
+  - VariableWidthHistogramAggregation
+  - WeightedAverageAggregation
+
+  # Aggregate - exclude all except TermsAggregate variants (DoubleTerms, LongTerms, StringTerms, UnmappedTerms)
+  - AdjacencyMatrixAggregate
+  - AutoDateHistogramAggregate
+  - AvgAggregate
+  - BoxPlotAggregate
+  - BucketMetricValueAggregate
+  - CardinalityAggregate
+  - ChildrenAggregate
+  - CompositeAggregate
+  - CumulativeCardinalityAggregate
+  - DateHistogramAggregate
+  - DateRangeAggregate
+  - DerivativeAggregate
+  - DoubleTermsAggregate
+  - ExtendedStatsAggregate
+  - ExtendedStatsBucketAggregate
+  - FilterAggregate
+  - FiltersAggregate
+  - GeoBoundsAggregate
+  - GeoCentroidAggregate
+  - GeoDistanceAggregate
+  - GeoHashGridAggregate
+  - GeoTileGridAggregate
+  - GlobalAggregate
+  - HdrPercentileRanksAggregate
+  - HdrPercentilesAggregate
+  - HistogramAggregate
+  - IpRangeAggregate
+  - LongTermsAggregate
+  - LongRareTermsAggregate
+  - MatrixStatsAggregate
+  - MedianAbsoluteDeviationAggregate
+  - MissingAggregate
+  - MultiTermsAggregate
+  - NestedAggregate
+  - ParentAggregate
+  - PercentilesBucketAggregate
+  - RangeAggregate
+  - RateAggregate
+  - ReverseNestedAggregate
+  - SamplerAggregate
+  - ScriptedMetricAggregate
+  - SignificantLongTermsAggregate
+  - SignificantStringTermsAggregate
+  - SimpleValueAggregate
+  - StatsAggregate
+  - StatsBucketAggregate
+  - StringTermsAggregate
+  - StringRareTermsAggregate
+  - SumAggregate
+  - TDigestPercentileRanksAggregate
+  - TDigestPercentilesAggregate
+  - TopHitsAggregate
+  - TTestAggregate
+  - UnmappedRareTermsAggregate
+  - UnmappedSignificantTermsAggregate
+  - UnmappedTermsAggregate
+  - UnsignedLongTermsAggregate
+  - ValueCountAggregate
+  - VariableWidthHistogramAggregate
+  - WeightedAvgAggregate


### PR DESCRIPTION
### Description
Based on #410 , enables TermsAggregation by excluding all other unsupported formats.

Generated protos are included in the diff.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
