### PR TITLE
Add normalizeAnyOfInAllOf transformation to prevent protobuf generator from flattening allOf+anyOf structures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
  - Fix simplifySingleMapSchema to generate named wrapper schemas. ([#406](https://github.com/opensearch-project/opensearch-protobufs/pull/406))
  - Change vendorExtension protobuf type handling to use protobuf type instead of openApi type ([#409](https://github.com/opensearch-project/opensearch-protobufs/pull/409))
  - Normalize mixed oneOf patterns ([#416](https://github.com/opensearch-project/opensearch-protobufs/pull/416))
- - Add hoistAnyOfFromAllOf transformation to prevent protobuf generator from flattening allOf+anyOf structures
+ - Add hoistAnyOfFromAllOf transformation to prevent protobuf generator from flattening allOf+anyOf structures ([#425](https://github.com/opensearch-project/opensearch-protobufs/pull/425))
 ### Removed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
  - Fix simplifySingleMapSchema to generate named wrapper schemas. ([#406](https://github.com/opensearch-project/opensearch-protobufs/pull/406))
  - Change vendorExtension protobuf type handling to use protobuf type instead of openApi type ([#409](https://github.com/opensearch-project/opensearch-protobufs/pull/409))
  - Normalize mixed oneOf patterns ([#416](https://github.com/opensearch-project/opensearch-protobufs/pull/416))
+ - Add hoistAnyOfFromAllOf transformation to prevent protobuf generator from flattening allOf+anyOf structures
 ### Removed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
  - Fix simplifySingleMapSchema to generate named wrapper schemas. ([#406](https://github.com/opensearch-project/opensearch-protobufs/pull/406))
  - Change vendorExtension protobuf type handling to use protobuf type instead of openApi type ([#409](https://github.com/opensearch-project/opensearch-protobufs/pull/409))
  - Normalize mixed oneOf patterns ([#416](https://github.com/opensearch-project/opensearch-protobufs/pull/416))
- - Add hoistAnyOfFromAllOf transformation to prevent protobuf generator from flattening allOf+anyOf structures ([#425](https://github.com/opensearch-project/opensearch-protobufs/pull/425))
+ - Add normalizeAnyOfInAllOf transformation to prevent protobuf generator from flattening allOf+anyOf structures ([#425](https://github.com/opensearch-project/opensearch-protobufs/pull/425))
 ### Removed
 
 ### Fixed

--- a/tools/proto-convert/src/SchemaModifier.ts
+++ b/tools/proto-convert/src/SchemaModifier.ts
@@ -23,7 +23,7 @@ export class SchemaModifier {
                 this.deduplicateOneOfWithArrayType(schema)
                 this.collapseSingleItemComposite(schema);
                 this.normalizeMixedOneOf(schema)
-                this.hoistAnyOfFromAllOf(schema);
+                this.normalizeAnyOfInAllOf(schema);
             },
             onSchema: (schema, schemaName) => {
                 if (!schema || isReferenceObject(schema)) return;
@@ -34,7 +34,7 @@ export class SchemaModifier {
                 this.handleOneOfConst(schema, schemaName)
                 this.deduplicateOneOfWithArrayType(schema)
                 this.collapseSingleItemComposite(schema);
-                this.hoistAnyOfFromAllOf(schema);
+                this.normalizeAnyOfInAllOf(schema);
                 this.collapseOneOfObjectPropContainsTitleSchema(schema)
                 this.normalizeMixedOneOf(schema)
                 this.convertOneOfToMinMaxProperties(schema)
@@ -149,62 +149,78 @@ export class SchemaModifier {
     }
 
     /**
-     * Hoists anyOf from within allOf to the top level and moves all base items into the anyOf.
+     * When allOf contains an anyOf item whose variants carry `title` fields, replaces
+     * that anyOf item with a single merged properties object so the generator can
+     * flatten the entire allOf naturally.
      *
-     * Transforms:
-     *   allOf: [base1, { anyOf: [{ $ref: 'Variant1' }, { $ref: 'Variant2' }] }]
+     * Only fires when at least one anyOf variant has a title (typed-discriminator pattern).
+     * Base $refs in allOf are left untouched — the generator flattens them automatically.
      *
-     * Into:
-     *   anyOf: [base1, { $ref: 'Variant1' }, { $ref: 'Variant2' }]
+     * Input:
+     *   allOf:
+     *     - $ref: '#/components/schemas/AggregateBase'
+     *     - anyOf:
+     *         - { title: lterms, $ref: '#/components/schemas/LongTermsAggregate' }
+     *         - { title: max,    $ref: '#/components/schemas/MaxAggregate' }
      *
-     * This prevents OpenAPI Generator from flattening named schema variants while preserving
-     * inline property alternatives.
+     * Output:
+     *   allOf:
+     *     - $ref: '#/components/schemas/AggregateBase'    # untouched, generator flattens
+     *     - type: object
+     *       properties:
+     *         lterms: { $ref: '#/components/schemas/LongTermsAggregate' }
+     *         max:    { $ref: '#/components/schemas/MaxAggregate' }
      */
-    hoistAnyOfFromAllOf(schema: OpenAPIV3.SchemaObject): void {
+    normalizeAnyOfInAllOf(schema: OpenAPIV3.SchemaObject): void {
         if (!Array.isArray(schema.allOf) || schema.allOf.length === 0) {
             return;
         }
 
-        // Find if any allOf item contains anyOf
-        let variantItem: OpenAPIV3.SchemaObject | null = null;
-        const baseItems: Array<OpenAPIV3.ReferenceObject | OpenAPIV3.SchemaObject> = [];
+        // Find the anyOf item inside allOf
+        const anyOfIndex = schema.allOf.findIndex(
+            item => item && typeof item === 'object' && !('$ref' in item) && Array.isArray((item as OpenAPIV3.SchemaObject).anyOf)
+        );
 
-        for (const item of schema.allOf) {
-            if (!item || typeof item !== 'object') continue;
+        if (anyOfIndex === -1) {
+            return;
+        }
 
-            const schemaItem = item as OpenAPIV3.SchemaObject;
-            if ('anyOf' in schemaItem && Array.isArray(schemaItem.anyOf)) {
-                variantItem = schemaItem;
+        const anyOfItem = schema.allOf[anyOfIndex] as OpenAPIV3.SchemaObject;
+        const variants = anyOfItem.anyOf as Array<OpenAPIV3.ReferenceObject | OpenAPIV3.SchemaObject>;
+
+        // Only apply when variants carry titles (typed-discriminator pattern)
+        if (!variants.some(v => (v as any).title)) {
+            return;
+        }
+
+        // Merge variants into a single properties object.
+        // Use title as the property name if present; otherwise derive from the $ref type name in snake_case.
+        const properties: Record<string, OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject> = {};
+        for (const variant of variants) {
+            const v = variant as any;
+            let propName: string;
+            if (v.title) {
+                propName = v.title;
+            } else if (v['$ref']) {
+                const refName = (v['$ref'] as string).split('/').pop() ?? '';
+                propName = toSnakeCase(refName);
             } else {
-                baseItems.push(item);
+                continue; // no way to derive a name
             }
+            const propSchema: Record<string, any> = {};
+            for (const key of Object.keys(v)) {
+                if (key !== 'title') propSchema[key] = v[key];
+            }
+            properties[propName] = propSchema;
         }
 
-        // If we found anyOf, hoist it and move all items into it
-        if (variantItem) {
-            const variants = variantItem.anyOf as Array<OpenAPIV3.ReferenceObject | OpenAPIV3.SchemaObject>;
+        // Replace the anyOf item in-place with a flat properties object
+        schema.allOf[anyOfIndex] = {
+            type: 'object',
+            properties,
+        };
 
-            // Check if at least one variant is a $ref
-            const hasRefVariants = variants.some(variant => {
-                if (!variant || typeof variant !== 'object') return false;
-                return '$ref' in variant;
-            });
-
-            // Only apply transformation if variants are $ref (not inline objects)
-            if (!hasRefVariants) {
-                logger.info(`Skipping anyOf hoist: variants are inline objects (preserving property alternatives)`);
-                return;
-            }
-
-            // Combine base items + variant items into a single anyOf array
-            const newAnyOf = [...baseItems, ...variants];
-
-            // Replace the schema with the hoisted structure
-            delete schema.allOf;
-            schema.anyOf = newAnyOf;
-
-            logger.info(`Hoisted anyOf from allOf (moved ${baseItems.length} base items + ${variants.length} variants into anyOf)`);
-        }
+        logger.info(`normalizeAnyOfInAllOf: replaced anyOf (${variants.length} variants) with merged properties object`);
     }
 
     isArraySchemaObject(schema: any): schema is OpenAPIV3.ArraySchemaObject {

--- a/tools/proto-convert/src/SchemaModifier.ts
+++ b/tools/proto-convert/src/SchemaModifier.ts
@@ -23,6 +23,7 @@ export class SchemaModifier {
                 this.deduplicateOneOfWithArrayType(schema)
                 this.collapseSingleItemComposite(schema);
                 this.normalizeMixedOneOf(schema)
+                this.hoistAnyOfFromAllOf(schema);
             },
             onSchema: (schema, schemaName) => {
                 if (!schema || isReferenceObject(schema)) return;
@@ -33,6 +34,7 @@ export class SchemaModifier {
                 this.handleOneOfConst(schema, schemaName)
                 this.deduplicateOneOfWithArrayType(schema)
                 this.collapseSingleItemComposite(schema);
+                this.hoistAnyOfFromAllOf(schema);
                 this.collapseOneOfObjectPropContainsTitleSchema(schema)
                 this.normalizeMixedOneOf(schema)
                 this.convertOneOfToMinMaxProperties(schema)
@@ -143,6 +145,65 @@ export class SchemaModifier {
         } else if (Array.isArray(schema.anyOf) && schema.anyOf.length === 1) {
             Object.assign(schema, schema.anyOf[0]);
             delete schema.anyOf;
+        }
+    }
+
+    /**
+     * Hoists anyOf from within allOf to the top level and moves all base items into the anyOf.
+     *
+     * Transforms:
+     *   allOf: [base1, { anyOf: [{ $ref: 'Variant1' }, { $ref: 'Variant2' }] }]
+     *
+     * Into:
+     *   anyOf: [base1, { $ref: 'Variant1' }, { $ref: 'Variant2' }]
+     *
+     * This prevents OpenAPI Generator from flattening named schema variants while preserving
+     * inline property alternatives.
+     */
+    hoistAnyOfFromAllOf(schema: OpenAPIV3.SchemaObject): void {
+        if (!Array.isArray(schema.allOf) || schema.allOf.length === 0) {
+            return;
+        }
+
+        // Find if any allOf item contains anyOf
+        let variantItem: OpenAPIV3.SchemaObject | null = null;
+        const baseItems: Array<OpenAPIV3.ReferenceObject | OpenAPIV3.SchemaObject> = [];
+
+        for (const item of schema.allOf) {
+            if (!item || typeof item !== 'object') continue;
+
+            const schemaItem = item as OpenAPIV3.SchemaObject;
+            if ('anyOf' in schemaItem && Array.isArray(schemaItem.anyOf)) {
+                variantItem = schemaItem;
+            } else {
+                baseItems.push(item);
+            }
+        }
+
+        // If we found anyOf, hoist it and move all items into it
+        if (variantItem) {
+            const variants = variantItem.anyOf as Array<OpenAPIV3.ReferenceObject | OpenAPIV3.SchemaObject>;
+
+            // Check if at least one variant is a $ref
+            const hasRefVariants = variants.some(variant => {
+                if (!variant || typeof variant !== 'object') return false;
+                return '$ref' in variant;
+            });
+
+            // Only apply transformation if variants are $ref (not inline objects)
+            if (!hasRefVariants) {
+                logger.info(`Skipping anyOf hoist: variants are inline objects (preserving property alternatives)`);
+                return;
+            }
+
+            // Combine base items + variant items into a single anyOf array
+            const newAnyOf = [...baseItems, ...variants];
+
+            // Replace the schema with the hoisted structure
+            delete schema.allOf;
+            schema.anyOf = newAnyOf;
+
+            logger.info(`Hoisted anyOf from allOf (moved ${baseItems.length} base items + ${variants.length} variants into anyOf)`);
         }
     }
 

--- a/tools/proto-convert/test/SchemaModifier.test.ts
+++ b/tools/proto-convert/test/SchemaModifier.test.ts
@@ -1695,4 +1695,109 @@ describe('SchemaModifier', () => {
             expect(secondAllOfItem.maxProperties).toBe(1);
         });
     });
+
+    describe('hoistAnyOfFromAllOf', () => {
+        it('should move $ref variants into anyOf array', () => {
+            const doc = createDocument();
+            doc.components!.schemas = {
+                TestSchema: {
+                    allOf: [
+                        { $ref: '#/components/schemas/BaseSchema' },
+                        {
+                            anyOf: [
+                                { title: 'variant1', $ref: '#/components/schemas/Variant1' },
+                                { title: 'variant2', $ref: '#/components/schemas/Variant2' }
+                            ]
+                        }
+                    ]
+                },
+                BaseSchema: { type: 'object' },
+                Variant1: { type: 'object' },
+                Variant2: { type: 'object' }
+            };
+
+            const modifier = new SchemaModifier(doc) as any;
+            const schema = doc.components!.schemas!.TestSchema as OpenAPIV3.SchemaObject;
+
+            modifier.hoistAnyOfFromAllOf(schema);
+
+            expect(schema.allOf).toBeUndefined();
+            expect(schema.anyOf).toBeDefined();
+            expect(schema.anyOf).toHaveLength(3);
+            expect(schema.anyOf![0]).toEqual({ $ref: '#/components/schemas/BaseSchema' });
+            expect(schema.anyOf![1]).toEqual({ title: 'variant1', $ref: '#/components/schemas/Variant1' });
+            expect(schema.anyOf![2]).toEqual({ title: 'variant2', $ref: '#/components/schemas/Variant2' });
+        });
+
+        it('should NOT hoist anyOf when variants are inline objects (like field/script alternatives)', () => {
+            const doc = createDocument();
+            doc.components!.schemas!.TermsAggregationFields = {
+                allOf: [
+                    {
+                        type: 'object',
+                        properties: {
+                            collect_mode: { type: 'string' },
+                            min_doc_count: { type: 'integer' }
+                        }
+                    },
+                    {
+                        anyOf: [
+                            {
+                                type: 'object',
+                                properties: {
+                                    field: { type: 'string' }
+                                }
+                            },
+                            {
+                                type: 'object',
+                                properties: {
+                                    script: { type: 'string' }
+                                }
+                            }
+                        ]
+                    }
+                ]
+            };
+
+            const modifier = new SchemaModifier(doc) as any;
+            const schema = doc.components!.schemas!.TermsAggregationFields as OpenAPIV3.SchemaObject;
+            const originalSchema = JSON.parse(JSON.stringify(schema));
+
+            modifier.hoistAnyOfFromAllOf(schema);
+
+            // Should NOT modify schema when variants are inline objects
+            expect(schema).toEqual(originalSchema);
+            expect(schema.allOf).toBeDefined();
+            expect(schema.anyOf).toBeUndefined();
+        });
+
+        it('should hoist even when $ref variants have additional properties like title', () => {
+            const doc = createDocument();
+            doc.components!.schemas = {
+                Aggregate: {
+                    allOf: [
+                        { $ref: '#/components/schemas/AggregateBase' },
+                        {
+                            anyOf: [
+                                { title: 'adjacency_matrix', $ref: '#/components/schemas/AdjacencyMatrixAggregate' },
+                                { title: 'avg', $ref: '#/components/schemas/AvgAggregate' }
+                            ]
+                        }
+                    ]
+                },
+                AggregateBase: { type: 'object' },
+                AdjacencyMatrixAggregate: { type: 'object' },
+                AvgAggregate: { type: 'object' }
+            };
+
+            const modifier = new SchemaModifier(doc) as any;
+            const schema = doc.components!.schemas!.Aggregate as OpenAPIV3.SchemaObject;
+
+            modifier.hoistAnyOfFromAllOf(schema);
+
+            expect(schema.allOf).toBeUndefined();
+            expect(schema.anyOf).toBeDefined();
+            expect(schema.anyOf).toHaveLength(3);
+        });
+    });
 });

--- a/tools/proto-convert/test/SchemaModifier.test.ts
+++ b/tools/proto-convert/test/SchemaModifier.test.ts
@@ -1696,8 +1696,8 @@ describe('SchemaModifier', () => {
         });
     });
 
-    describe('hoistAnyOfFromAllOf', () => {
-        it('should move $ref variants into anyOf array', () => {
+    describe('normalizeAnyOfInAllOf', () => {
+        it('should replace anyOf item in allOf with merged properties object', () => {
             const doc = createDocument();
             doc.components!.schemas = {
                 TestSchema: {
@@ -1705,99 +1705,103 @@ describe('SchemaModifier', () => {
                         { $ref: '#/components/schemas/BaseSchema' },
                         {
                             anyOf: [
-                                { title: 'variant1', $ref: '#/components/schemas/Variant1' },
-                                { title: 'variant2', $ref: '#/components/schemas/Variant2' }
+                                { title: 'lterms', $ref: '#/components/schemas/Variant1' },
+                                { title: 'max',    $ref: '#/components/schemas/Variant2' }
                             ]
                         }
                     ]
-                },
-                BaseSchema: { type: 'object' },
+                } as any,
+                BaseSchema: { type: 'object', properties: { meta: { type: 'string' } } },
                 Variant1: { type: 'object' },
                 Variant2: { type: 'object' }
             };
 
             const modifier = new SchemaModifier(doc) as any;
-            const schema = doc.components!.schemas!.TestSchema as OpenAPIV3.SchemaObject;
+            const schema = doc.components!.schemas!.TestSchema as any;
+            modifier.normalizeAnyOfInAllOf(schema);
 
-            modifier.hoistAnyOfFromAllOf(schema);
-
-            expect(schema.allOf).toBeUndefined();
-            expect(schema.anyOf).toBeDefined();
-            expect(schema.anyOf).toHaveLength(3);
-            expect(schema.anyOf![0]).toEqual({ $ref: '#/components/schemas/BaseSchema' });
-            expect(schema.anyOf![1]).toEqual({ title: 'variant1', $ref: '#/components/schemas/Variant1' });
-            expect(schema.anyOf![2]).toEqual({ title: 'variant2', $ref: '#/components/schemas/Variant2' });
-        });
-
-        it('should NOT hoist anyOf when variants are inline objects (like field/script alternatives)', () => {
-            const doc = createDocument();
-            doc.components!.schemas!.TermsAggregationFields = {
-                allOf: [
-                    {
-                        type: 'object',
-                        properties: {
-                            collect_mode: { type: 'string' },
-                            min_doc_count: { type: 'integer' }
-                        }
-                    },
-                    {
-                        anyOf: [
-                            {
-                                type: 'object',
-                                properties: {
-                                    field: { type: 'string' }
-                                }
-                            },
-                            {
-                                type: 'object',
-                                properties: {
-                                    script: { type: 'string' }
-                                }
-                            }
-                        ]
-                    }
-                ]
-            };
-
-            const modifier = new SchemaModifier(doc) as any;
-            const schema = doc.components!.schemas!.TermsAggregationFields as OpenAPIV3.SchemaObject;
-            const originalSchema = JSON.parse(JSON.stringify(schema));
-
-            modifier.hoistAnyOfFromAllOf(schema);
-
-            // Should NOT modify schema when variants are inline objects
-            expect(schema).toEqual(originalSchema);
+            // allOf is preserved with base ref untouched
             expect(schema.allOf).toBeDefined();
-            expect(schema.anyOf).toBeUndefined();
+            expect(schema.allOf).toHaveLength(2);
+            expect(schema.allOf[0]).toEqual({ $ref: '#/components/schemas/BaseSchema' });
+            // anyOf item replaced with merged properties object
+            expect(schema.allOf[1].anyOf).toBeUndefined();
+            expect(schema.allOf[1].type).toBe('object');
+            expect(schema.allOf[1].properties.lterms).toEqual({ $ref: '#/components/schemas/Variant1' });
+            expect(schema.allOf[1].properties.max).toEqual({ $ref: '#/components/schemas/Variant2' });
         });
 
-        it('should hoist even when $ref variants have additional properties like title', () => {
+        it('should use type name snake_case for untitled variants mixed with titled ones', () => {
             const doc = createDocument();
             doc.components!.schemas = {
-                Aggregate: {
+                TestSchema: {
                     allOf: [
-                        { $ref: '#/components/schemas/AggregateBase' },
+                        { $ref: '#/components/schemas/BaseSchema' },
                         {
                             anyOf: [
-                                { title: 'adjacency_matrix', $ref: '#/components/schemas/AdjacencyMatrixAggregate' },
-                                { title: 'avg', $ref: '#/components/schemas/AvgAggregate' }
+                                { title: 'lterms', $ref: '#/components/schemas/LongTermsAggregate' },
+                                { $ref: '#/components/schemas/MaxAggregate' }  // no title
                             ]
                         }
                     ]
-                },
-                AggregateBase: { type: 'object' },
-                AdjacencyMatrixAggregate: { type: 'object' },
-                AvgAggregate: { type: 'object' }
+                } as any,
+                BaseSchema: { type: 'object' },
+                LongTermsAggregate: { type: 'object' },
+                MaxAggregate: { type: 'object' }
             };
 
             const modifier = new SchemaModifier(doc) as any;
-            const schema = doc.components!.schemas!.Aggregate as OpenAPIV3.SchemaObject;
+            const schema = doc.components!.schemas!.TestSchema as any;
+            modifier.normalizeAnyOfInAllOf(schema);
 
-            modifier.hoistAnyOfFromAllOf(schema);
+            expect(schema.allOf[1].type).toBe('object');
+            // titled variant uses its title
+            expect(schema.allOf[1].properties.lterms).toEqual({ $ref: '#/components/schemas/LongTermsAggregate' });
+            // untitled variant falls back to snake_case of the type name
+            expect(schema.allOf[1].properties.max_aggregate).toEqual({ $ref: '#/components/schemas/MaxAggregate' });
+        });
+
+        it('should not modify when variants have no titles', () => {
+            const doc = createDocument();
+            const original = {
+                allOf: [
+                    { $ref: '#/components/schemas/Base' },
+                    { anyOf: [{ $ref: '#/components/schemas/V1' }, { $ref: '#/components/schemas/V2' }] }
+                ]
+            };
+            doc.components!.schemas!.TestSchema = JSON.parse(JSON.stringify(original)) as any;
+
+            const modifier = new SchemaModifier(doc) as any;
+            const schema = doc.components!.schemas!.TestSchema as any;
+            modifier.normalizeAnyOfInAllOf(schema);
+
+            expect(schema).toEqual(original);
+        });
+
+        it('should not modify when allOf has no anyOf item', () => {
+            const doc = createDocument();
+            doc.components!.schemas!.TestSchema = {
+                allOf: [{ $ref: '#/components/schemas/Base' }, { $ref: '#/components/schemas/Base2' }]
+            } as any;
+
+            const modifier = new SchemaModifier(doc) as any;
+            const schema = doc.components!.schemas!.TestSchema as any;
+            const original = JSON.parse(JSON.stringify(schema));
+            modifier.normalizeAnyOfInAllOf(schema);
+
+            expect(schema).toEqual(original);
+        });
+
+        it('should not modify schema without allOf', () => {
+            const doc = createDocument();
+            doc.components!.schemas!.TestSchema = { type: 'object', properties: { x: { type: 'string' } } };
+
+            const modifier = new SchemaModifier(doc) as any;
+            const schema = doc.components!.schemas!.TestSchema as any;
+            modifier.normalizeAnyOfInAllOf(schema);
 
             expect(schema.allOf).toBeUndefined();
-            expect(schema.anyOf).toBeDefined();
-            expect(schema.anyOf).toHaveLength(3);
+            expect(schema.type).toBe('object');
         });
     });
 });


### PR DESCRIPTION
### Description
Add normalizeAnyOfInAllOf transformation to preserve variant structure in
generated protobuf by replacing anyOf typed-discriminator items inside allOf with a merged properties object

### Test
```
message Aggregate {

  optional ObjectMap meta = 1;

  optional DoubleTermsAggregate dterms = 2;

  optional LongTermsAggregate lterms = 3;

  optional MaxAggregate max = 4;

  optional MinAggregate min = 5;

  optional StringTermsAggregate sterms = 6;

  optional UnsignedLongTermsAggregate ulterms = 7;

  optional UnmappedTermsAggregate umterms = 8;
}
```
### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
