### PR TITLE
Add support of BinaryFieldValues for non _source primitive array indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
  - Change vendorExtension protobuf type handling to use protobuf type instead of openApi type ([#409](https://github.com/opensearch-project/opensearch-protobufs/pull/409))
  - Normalize mixed oneOf patterns ([#416](https://github.com/opensearch-project/opensearch-protobufs/pull/416))
  - Add normalizeAnyOfInAllOf transformation to prevent protobuf generator from flattening allOf+anyOf structures ([#425](https://github.com/opensearch-project/opensearch-protobufs/pull/425))
+ - Add support of BinaryFieldValue for non _source primitive array indexing ([#434](https://github.com/opensearch-project/opensearch-protobufs/pull/434))
 ### Removed
 
 ### Fixed

--- a/protos/schemas/common.proto
+++ b/protos/schemas/common.proto
@@ -890,6 +890,18 @@ message BulkRequestBody {
 
   // [optional]
   optional bytes object = 3;
+
+  // EXPERIMENTAL field
+  // [optional] Map of fully-qualified field path -> typed value.
+  // This field is intended for large field values, such as large vectors, that
+  // should be provided separately from `_source`.
+  // Supported operations: index, create and update
+  // Compatibility:
+  // - May be provided together with `object`and update_action.
+  // - `object` and `update_action` continue to represent `_source`.
+  // - `extra_field_values` provides additional out-of-band field values and does
+  //   not replace `_source`.
+  map<string, BinaryFieldValue> extra_field_values = 4 [(tooling_skip) = true];
 }
 
 message OperationContainer {
@@ -2828,6 +2840,51 @@ message HitMatchedQueries {
 
   }
 }
+
+message BinaryFieldValue {
+  oneof binary_field_value {
+
+    // [optional] Raw bytes payload for a field-specific binary representation.
+    BytesValue bytes_value = 1;
+
+    // [optional] Float array payload for fields that support vector-like input.
+    FloatArrayValue float_array_value = 2;
+
+  }
+}
+
+message BytesValue {
+
+  // [required] Raw bytes for the field value.
+  bytes bytes = 1;
+}
+
+message FloatArrayValue {
+  oneof encoding {
+
+    // [optional] Fast path: 4 * dimension bytes, little-endian binary float array.
+    FloatBinaryLE binary_le = 1;
+
+    // [optional] Simple path: packed array
+    FloatList values = 2;
+  }
+}
+
+message FloatBinaryLE {
+
+  // [required] Raw float data encoded as little-endian IEEE-754 float32 values.
+  bytes bytes_le = 1;
+
+  // [required] Number of float elements in the payload.
+  int32 dimension = 2;
+}
+
+message FloatList {
+
+  // [required] Float values for the field.
+  repeated float values = 1;
+}
+
 
 message BoostingQuery {
 


### PR DESCRIPTION
closing [387](https://github.com/opensearch-project/opensearch-protobufs/pull/387)


This is part of a broader contribution to add support of non _source primitive array indexing

For now, only float arrays are supported, as well as BytesValue.

Two options are offered:

- packed array.
- binary LE (little-endian) which is much faster (see benchmarks results in the related issues).

### Issues Resolved
https://github.com/opensearch-project/opensearch-api-specification/pull/1035
https://github.com/opensearch-project/OpenSearch/issues/19638


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
