### PR TITLE
Updated deduplicateOneOfWithArrayType to preserve oneOf variants when have different title attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
  - Change vendorExtension protobuf type handling to use protobuf type instead of openApi type ([#409](https://github.com/opensearch-project/opensearch-protobufs/pull/409))
  - Normalize mixed oneOf patterns ([#416](https://github.com/opensearch-project/opensearch-protobufs/pull/416))
  - Add normalizeAnyOfInAllOf transformation to prevent protobuf generator from flattening allOf+anyOf structures ([#425](https://github.com/opensearch-project/opensearch-protobufs/pull/425))
+ - Updated deduplicateOneOfWithArrayType to preserve oneOf variants when they have different title attributes
 ### Removed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
  - Change vendorExtension protobuf type handling to use protobuf type instead of openApi type ([#409](https://github.com/opensearch-project/opensearch-protobufs/pull/409))
  - Normalize mixed oneOf patterns ([#416](https://github.com/opensearch-project/opensearch-protobufs/pull/416))
  - Add normalizeAnyOfInAllOf transformation to prevent protobuf generator from flattening allOf+anyOf structures ([#425](https://github.com/opensearch-project/opensearch-protobufs/pull/425))
- - Updated deduplicateOneOfWithArrayType to preserve oneOf variants when they have different title attributes
+ - Updated deduplicateOneOfWithArrayType to preserve oneOf variants when they have different title attributes ([#436](https://github.com/opensearch-project/opensearch-protobufs/pull/436))
 ### Removed
 
 ### Fixed

--- a/tools/proto-convert/src/SchemaModifier.ts
+++ b/tools/proto-convert/src/SchemaModifier.ts
@@ -105,24 +105,41 @@ export class SchemaModifier {
     // Simplify schemas with `oneOf` by aggregating items.
     // If there are only two `oneOf` items and one matches an array schema, remove oneOf type and set type to array.
     // If there are more than two `oneOf` items and one matches an array schema, remove that item from `oneOf`.
+    // IMPORTANT: Skips deduplication if BOTH single and array items have titles AND they're different.
+    // This preserves semantically different variants (e.g., 'regexp' vs 'terms', 'single' vs 'array').
     deduplicateOneOfWithArrayType(schema: OpenAPIV3.SchemaObject): void{
         if (!('$ref' in schema) && Array.isArray(schema.oneOf)) {
             const oneOfs = schema.oneOf;
 
-            const arraySet = new Set<string>();
+            const arrayMap = new Map<string, any>(); // signature -> array item
             var deleteIndx = -1;
 
+            // Collect all array items
             for (const oneOf of oneOfs) {
                 if (this.isArraySchemaObject(oneOf)) {
                     const { type, $ref, additionalProperties} = oneOf.items as any;
                     const oneOfStr = JSON.stringify({ type, $ref, additionalProperties});
-                    arraySet.add(oneOfStr)
+                    arrayMap.set(oneOfStr, oneOf);
                 }
             }
+
+            // Find matching single items and check titles before removing
             for (const oneOf of oneOfs) {
                 const { type, $ref, additionalProperties} = oneOf as any;
                 const oneOfStr = JSON.stringify({ type, $ref, additionalProperties});
-                if (arraySet.has(oneOfStr)) {
+
+                if (arrayMap.has(oneOfStr)) {
+                    const arrayItem = arrayMap.get(oneOfStr);
+                    const singleTitle = (oneOf as any).title;
+                    const arrayTitle = arrayItem.title;
+
+                    // Only skip if BOTH have titles AND they're different
+                    if (singleTitle && arrayTitle && singleTitle !== arrayTitle) {
+                        logger.info(`Skipping deduplicateOneOfWithArrayType: different titles '${singleTitle}' vs '${arrayTitle}'`);
+                        continue;
+                    }
+
+                    // Same title or at least one has no title -> proceed with deduplication
                     deleteIndx = oneOfs.findIndex(item => isEqual(item, oneOf));
                     oneOfs.splice(deleteIndx, 1);
                 }

--- a/tools/proto-convert/src/SchemaModifier.ts
+++ b/tools/proto-convert/src/SchemaModifier.ts
@@ -111,7 +111,7 @@ export class SchemaModifier {
         if (!('$ref' in schema) && Array.isArray(schema.oneOf)) {
             const oneOfs = schema.oneOf;
 
-            const arrayMap = new Map<string, any>(); // signature -> array item
+            const arrayMap = new Map<string, any>();
             var deleteIndx = -1;
 
             // Collect all array items

--- a/tools/proto-convert/test/SchemaModifier.test.ts
+++ b/tools/proto-convert/test/SchemaModifier.test.ts
@@ -416,6 +416,119 @@ describe('SchemaModifier', () => {
             expect(schema.oneOf).toContainEqual({ type: 'boolean' });
             expect(schema.oneOf).toContainEqual({ type: 'array', items: { type: 'string' } });
         });
+
+        it('should NOT remove single item when it has different title from array item', () => {
+            const doc = createDocument();
+            const modifier = new SchemaModifier(doc);
+
+            const schema: any = {
+                oneOf: [
+                    { title: 'regexp', type: 'string' },
+                    { title: 'terms', type: 'array', items: { type: 'string' } }
+                ]
+            };
+
+            modifier.deduplicateOneOfWithArrayType(schema);
+
+            // Both items should be preserved because titles differ
+            expect(schema.oneOf).toHaveLength(2);
+            expect(schema.oneOf[0]).toEqual({ title: 'regexp', type: 'string' });
+            expect(schema.oneOf[1]).toEqual({ title: 'terms', type: 'array', items: { type: 'string' } });
+        });
+
+        it('should NOT remove single item when titles differ (BucketsPath pattern)', () => {
+            const doc = createDocument();
+            const modifier = new SchemaModifier(doc);
+
+            const schema: any = {
+                oneOf: [
+                    { title: 'single', type: 'string' },
+                    { title: 'array', type: 'array', items: { type: 'string' } },
+                    { title: 'dict', type: 'object', additionalProperties: { type: 'string' } }
+                ]
+            };
+
+            modifier.deduplicateOneOfWithArrayType(schema);
+
+            // All items should be preserved because single and array have different titles
+            expect(schema.oneOf).toHaveLength(3);
+            expect(schema.oneOf).toContainEqual({ title: 'single', type: 'string' });
+            expect(schema.oneOf).toContainEqual({ title: 'array', type: 'array', items: { type: 'string' } });
+            expect(schema.oneOf).toContainEqual({ title: 'dict', type: 'object', additionalProperties: { type: 'string' } });
+        });
+
+        it('should remove single item when both have the same title', () => {
+            const doc = createDocument();
+            const modifier = new SchemaModifier(doc);
+
+            const schema: any = {
+                oneOf: [
+                    { title: 'value', type: 'string' },
+                    { title: 'value', type: 'array', items: { type: 'string' } }
+                ]
+            };
+
+            modifier.deduplicateOneOfWithArrayType(schema);
+
+            // Single item should be removed since titles match
+            expect(schema.oneOf).toHaveLength(1);
+            expect(schema.oneOf[0]).toEqual({ title: 'value', type: 'array', items: { type: 'string' } });
+        });
+
+        it('should remove single item when only single item has title', () => {
+            const doc = createDocument();
+            const modifier = new SchemaModifier(doc);
+
+            const schema: any = {
+                oneOf: [
+                    { title: 'value', type: 'string' },
+                    { type: 'array', items: { type: 'string' } }
+                ]
+            };
+
+            modifier.deduplicateOneOfWithArrayType(schema);
+
+            // Single item should be removed (no conflict since array has no title)
+            expect(schema.oneOf).toHaveLength(1);
+            expect(schema.oneOf[0]).toEqual({ type: 'array', items: { type: 'string' } });
+        });
+
+        it('should remove single item when only array item has title', () => {
+            const doc = createDocument();
+            const modifier = new SchemaModifier(doc);
+
+            const schema: any = {
+                oneOf: [
+                    { type: 'string' },
+                    { title: 'array', type: 'array', items: { type: 'string' } }
+                ]
+            };
+
+            modifier.deduplicateOneOfWithArrayType(schema);
+
+            // Single item should be removed (no conflict since single has no title)
+            expect(schema.oneOf).toHaveLength(1);
+            expect(schema.oneOf[0]).toEqual({ title: 'array', type: 'array', items: { type: 'string' } });
+        });
+
+        it('should NOT remove when different titles with $ref types', () => {
+            const doc = createDocument();
+            const modifier = new SchemaModifier(doc);
+
+            const schema: any = {
+                oneOf: [
+                    { title: 'inline', $ref: '#/components/schemas/InlineScript' },
+                    { title: 'stored', type: 'array', items: { $ref: '#/components/schemas/InlineScript' } }
+                ]
+            };
+
+            modifier.deduplicateOneOfWithArrayType(schema);
+
+            // Both should be preserved because titles differ
+            expect(schema.oneOf).toHaveLength(2);
+            expect(schema.oneOf[0]).toEqual({ title: 'inline', $ref: '#/components/schemas/InlineScript' });
+            expect(schema.oneOf[1]).toEqual({ title: 'stored', type: 'array', items: { $ref: '#/components/schemas/InlineScript' } });
+        });
     });
 
     describe('collapseSingleItemComposite', () => {


### PR DESCRIPTION
### Description
Updated deduplicateOneOfWithArrayType to preserve oneOf variants when have different title attributes.

### Problem
Previously, deduplicateOneOfWithArrayType would remove single items when a matching array type existed, even if they had different title attributes. This incorrectly collapsed semantically distinct variants into a single option.

### Test
1. No breaking change introduced.
https://github.com/opensearch-project/opensearch-protobufs/actions/runs/24427085588/artifacts/6439658182
2. Local test: 
```
message TermsExclude {
  oneof terms_exclude {
    string regexp = 1;

    StringArray terms = 2;

  }
}

message TermsInclude {
  oneof terms_include {
    string regexp = 1;

    StringArray terms = 2;

    TermsPartition partition = 3;

  }
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
