### PR TITLE
Add GitHub environment to release workflow and bump jenkins lib version

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,4 +1,4 @@
-name: Release drafter
+name: Release Workflow
 
 # Push events to every tag not containing "/"
 #
@@ -13,51 +13,46 @@ on:
       - "*"
 
 jobs:
-  draft-a-release:
-    name: Draft a release
+  release:
+    environment: release-approval
     runs-on: ubuntu-latest
     permissions: write-all
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - id: get_data
-        run: |
-          echo "approvers=$(cat .github/CODEOWNERS | grep @ | tr -d '*\n ' | sed 's/@/,/g' | sed 's/,//1')" >> $GITHUB_OUTPUT
-          echo "version=$(cat version.properties)" >> $GITHUB_OUTPUT
-      - uses: trstringer/manual-approval@v1
-        with:
-          secret: ${{ github.TOKEN }}
-          approvers: ${{ steps.get_data.outputs.approvers }}
-          minimum-approvals: 2
-          issue-title: 'Release OpenSearch Protobufs ${{ steps.get_data.outputs.version }}'
-          issue-body: "Please approve or deny the release of OpenSearch Protobufs **TAG**: ${{ github.ref_name }}  **COMMIT**: ${{ github.sha }} **VERSION** : ${{ steps.get_data.outputs.version }} "
-          exclude-workflow-initiator-as-approver: true
+      - name: Checkout
+        uses: actions/checkout@v6
+
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           java-version: 21
           distribution: 'temurin'
           cache: gradle
+
       - name: Set up Python 3
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
+
       - name: Build with Gradle
         run: |
           ./tools/java/package_proto_jar.sh -c true -s false
           ./gradlew --no-daemon -Dbuild.snapshot=false publishCreatePublicationToLocalRepoRepository
           tar -C build -cvf "opensearch-protobufs-java.tar.gz" repository
+
       - name: Create protobuf zip
         run: ./tools/package_proto_zip.sh
+
       - name: Build python with bazel
         run: |
           mkdir -p dist
           bazel build //:opensearch_protos_wheel
           mv bazel-bin/opensearch_protobufs-*-py3-none-any.whl dist/
+
       - name: Publish python artifacts to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-      - name: Draft a release
-        uses: softprops/action-gh-release@v1
+
+      - name: Release on Github
+        uses: softprops/action-gh-release@v2
         with:
           draft: true
           generate_release_notes: true

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,7 +18,7 @@ git rebase upstream/main
 git tag <version>
 git push upstream <version>
 ```
-2. Wait for Github Actions to run and open the newly created issue. Two maintainers should comment `approve` in the issue.
+2. Wait for Github Actions to run. The workflow requires approval from reviewers configured in the `release-approval` GitHub environment before it proceeds.
 3. Wait for Jenkins to be triggered, pull the artifacts built by Actions, push to sonatype release channel on remote. Wait for an hour or so for Sonatype to copy it into Maven Central.
 4. Bump [version.properties](./version.properties), update [release-notes](./release-notes/), and clean up entries from [CHANGELOG.md](./CHANGELOG.md) via a PR.
 

--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -1,4 +1,4 @@
-lib = library(identifier: 'jenkins@10.2.2', retriever: modernSCM([
+lib = library(identifier: 'jenkins@12.0.0', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))


### PR DESCRIPTION
### Description
Add GitHub environment to release workflow and bump jenkins lib version to accommodate newly created secrets on onepassword

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
