### PR TITLE
Add ml_service to BUILD config

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -12,6 +12,7 @@ java_library(
         "//protos/schemas:common_java_proto",
         "//protos/services:document_service_java_proto",
         "//protos/services:search_service_java_proto",
+        "//protos/services:ml_service_java_proto",
     ],
 )
 
@@ -29,6 +30,7 @@ python_grpc_library(
     protos = [
         "//protos/services:document_service_proto",
         "//protos/services:search_service_proto",
+        "//protos/services:ml_service_proto",
     ],
     deps = [
         ":python_schemas"
@@ -42,6 +44,7 @@ go_library(
         "//protos/schemas:common_go_proto",
         "//protos/services:document_service_go_proto",
         "//protos/services:search_service_go_proto",
+        "//protos/services:ml_service_go_proto",
     ],
 )
 
@@ -60,6 +63,7 @@ genrule(
         "//protos/schemas:common.proto",
         "//protos/services:document_service.proto",
         "//protos/services:search_service.proto",
+        "//protos/services:ml_service.proto",
         "@com_google_protobuf//:well_known_type_protos",
         "@com_google_protobuf//:descriptor_proto_srcs",
     ],
@@ -67,6 +71,7 @@ genrule(
         "python_pyi/schemas/common_pb2.pyi",
         "python_pyi/services/document_service_pb2.pyi",
         "python_pyi/services/search_service_pb2.pyi",
+        "python_pyi/services/ml_service_pb2.pyi",
     ],
     cmd = """
         # Use protoc with --pyi_out to generate debug symbols
@@ -76,7 +81,8 @@ genrule(
             --pyi_out=$(RULEDIR) \
             protos/schemas/common.proto \
             protos/services/document_service.proto \
-            protos/services/search_service.proto
+            protos/services/search_service.proto \
+            protos/services/ml_service.proto
 
         mkdir -p $(RULEDIR)/python_pyi/
         mv $(RULEDIR)/protos/schemas $(RULEDIR)/python_pyi
@@ -102,6 +108,9 @@ genrule(
         "opensearch/protobufs/services/search_service_pb2.py",
         "opensearch/protobufs/services/search_service_pb2.pyi",
         "opensearch/protobufs/services/search_service_pb2_grpc.py",
+        "opensearch/protobufs/services/ml_service_pb2.py",
+        "opensearch/protobufs/services/ml_service_pb2.pyi",
+        "opensearch/protobufs/services/ml_service_pb2_grpc.py",
         "opensearch/__init__.py",
         "opensearch/protobufs/__init__.py",
         "opensearch/protobufs/schemas/__init__.py",

--- a/protos/services/BUILD.bazel
+++ b/protos/services/BUILD.bazel
@@ -17,9 +17,21 @@ proto_library(
     deps = ["//protos/schemas:common_proto"],
 )
 
+proto_library(
+    name = "ml_service_proto",
+    srcs = ["ml_service.proto"],
+    deps = ["//protos/schemas:common_proto"],
+)
+
 java_grpc_library(
     name = "document_service_java_proto",
     protos = [":document_service_proto"],
+    deps = ["//protos/schemas:common_java_proto"],
+)
+
+java_grpc_library(
+    name = "ml_service_java_proto",
+    protos = [":ml_service_proto"],
     deps = ["//protos/schemas:common_java_proto"],
 )
 
@@ -38,5 +50,11 @@ go_grpc_library(
 go_grpc_library(
     name = "search_service_go_proto",
     protos = [":search_service_proto"],
+    deps = ["//protos/schemas:common_go_proto"],
+)
+
+go_grpc_library(
+    name = "ml_service_go_proto",
+    protos = [":ml_service_proto"],
     deps = ["//protos/schemas:common_go_proto"],
 )


### PR DESCRIPTION
### Description
**Issue:** `MLServiceGrpc` class is missing from the published protobufs jar because the BUILD configuration was not updated to compile `ml_service.proto`, causing ml-commons compilation to fail when it tries to import the non-existent class.

**Root Cause:** Build configuration incomplete - proto file existed but wasn't included in build targets

**Solution:** Added ML service to all relevant BUILD targets (Java, Python, Go) so `MLServiceGrpc` gets compiled and included in the published jar

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
