### PR TITLE
Add PIT RPCs to SearchService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add support for double, int and long in BinaryFieldValue ([#460](https://github.com/opensearch-project/opensearch-protobufs/pull/460))
 - Add Create PIT support to protobuf generation ([#466](https://github.com/opensearch-project/opensearch-protobufs/pull/466)).
 - Add Delete PIT support to protobuf generation ([#468](https://github.com/opensearch-project/opensearch-protobufs/pull/468)).
-- Add PIT RPCs to `SearchService`.
+- Add PIT RPCs to `SearchService` ([#469](https://github.com/opensearch-project/opensearch-protobufs/pull/469)).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add support for double, int and long in BinaryFieldValue ([#460](https://github.com/opensearch-project/opensearch-protobufs/pull/460))
 - Add Create PIT support to protobuf generation ([#466](https://github.com/opensearch-project/opensearch-protobufs/pull/466)).
 - Add Delete PIT support to protobuf generation ([#468](https://github.com/opensearch-project/opensearch-protobufs/pull/468)).
+- Add PIT RPCs to `SearchService`.
 
 ### Changed
 

--- a/protos/services/search_service.proto
+++ b/protos/services/search_service.proto
@@ -22,6 +22,10 @@ import "protos/schemas/common.proto";
 service SearchService {
   rpc Search(SearchRequest) returns (SearchResponse) {}
 
+  rpc CreatePit(CreatePitRequest) returns (CreatePITResponse) {}
+
+  rpc DeletePit(DeletePitRequest) returns (DeletePITResponse) {}
+
   // Server side grpc stream endpoint
   rpc ServerStreamSearch(SearchRequest) returns (stream SearchResponse) {}
 }


### PR DESCRIPTION
### Description
- add `CreatePit` and `DeletePit` RPCs to `SearchService`