### PR TITLE
Add PyPI description metadata to Python wheel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -138,6 +138,9 @@ py_wheel(
     distribution = "opensearch-protobufs",
     python_tag = "py3",
     version = VERSION,
+    summary = "Protocol Buffer definitions for OpenSearch gRPC APIs",
+    description_file = "//:README.md",
+    description_content_type = "text/markdown",
     requires = [
         "protobuf>=3.25.8",
         "grpcio>=1.70.0",


### PR DESCRIPTION
### Description
- add a short PyPI summary to the Python wheel metadata
- use `README.md` as the long description for the wheel
- set the description content type to Markdown

### Verification
- built `//:opensearch_protos_wheel`
- confirmed the wheel `METADATA` contains `Summary`, `Description-Content-Type`, and rendered README content