### PR TITLE
Cleanup release 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### Added
-- Add support for double, int and long in BinaryFieldValue ([#460](https://github.com/opensearch-project/opensearch-protobufs/pull/460))
-- Add Create PIT support to protobuf generation ([#466](https://github.com/opensearch-project/opensearch-protobufs/pull/466)).
-- Add Delete PIT support to protobuf generation ([#468](https://github.com/opensearch-project/opensearch-protobufs/pull/468)).
-- Add PIT RPCs to `SearchService` ([#469](https://github.com/opensearch-project/opensearch-protobufs/pull/469)).
 
 ### Changed
 

--- a/release-notes/opensearch-protobufs.release-notes-1.6.0.md
+++ b/release-notes/opensearch-protobufs.release-notes-1.6.0.md
@@ -1,4 +1,4 @@
-## Version 1.6.0 (2026-06-16) Release Notes
+## Version 1.6.0 (2026-06-11) Release Notes
 
 ### Added
 - Add support for double, int and long in BinaryFieldValue ([#460](https://github.com/opensearch-project/opensearch-protobufs/pull/460))

--- a/release-notes/opensearch-protobufs.release-notes-1.6.0.md
+++ b/release-notes/opensearch-protobufs.release-notes-1.6.0.md
@@ -1,0 +1,15 @@
+## Version 1.6.0 (2026-06-16) Release Notes
+
+### Added
+- Add support for double, int and long in BinaryFieldValue ([#460](https://github.com/opensearch-project/opensearch-protobufs/pull/460))
+- Add Create PIT support to protobuf generation ([#466](https://github.com/opensearch-project/opensearch-protobufs/pull/466)).
+- Add Delete PIT support to protobuf generation ([#468](https://github.com/opensearch-project/opensearch-protobufs/pull/468)).
+- Add PIT RPCs to `SearchService` ([#469](https://github.com/opensearch-project/opensearch-protobufs/pull/469)).
+
+### Changed
+
+### Removed
+
+### Fixed
+
+### Security

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=1.6.0
+version=1.7.0


### PR DESCRIPTION
### Description
Clean up changelog and bump `version.properties` after the `1.6.0` release.
